### PR TITLE
添加移动端点击自动关闭侧边栏

### DIFF
--- a/web/src/components/MemoList.tsx
+++ b/web/src/components/MemoList.tsx
@@ -6,6 +6,7 @@ import { TAG_REG, LINK_REG } from "../labs/marked/parser";
 import * as utils from "../helpers/utils";
 import { checkShouldShowMemoWithFilters } from "../helpers/filter";
 import toastHelper from "./Toast";
+import closeSidebar from "../hooks/closeSidebar";
 import Memo from "./Memo";
 import "../less/memo-list.less";
 
@@ -92,7 +93,7 @@ const MemoList = () => {
   }, [query]);
 
   return (
-    <div className="memo-list-container" ref={wrapperElement}>
+    <div className="memo-list-container" ref={wrapperElement} onClick={() => closeSidebar()}>
       {sortedMemos.map((memo) => (
         <Memo key={`${memo.id}-${memo.createdTs}-${memo.updatedTs}`} memo={memo} />
       ))}

--- a/web/src/components/MemoList.tsx
+++ b/web/src/components/MemoList.tsx
@@ -93,7 +93,7 @@ const MemoList = () => {
   }, [query]);
 
   return (
-    <div className="memo-list-container" ref={wrapperElement} onClick={() => closeSidebar()}>
+    <div className="memo-list-container" ref={wrapperElement} onClick={closeSidebar}>
       {sortedMemos.map((memo) => (
         <Memo key={`${memo.id}-${memo.createdTs}-${memo.updatedTs}`} memo={memo} />
       ))}

--- a/web/src/components/MemoList.tsx
+++ b/web/src/components/MemoList.tsx
@@ -6,7 +6,7 @@ import { TAG_REG, LINK_REG } from "../labs/marked/parser";
 import * as utils from "../helpers/utils";
 import { checkShouldShowMemoWithFilters } from "../helpers/filter";
 import toastHelper from "./Toast";
-import closeSidebar from "../hooks/closeSidebar";
+import {closeSidebar} from "../helpers/utils";
 import Memo from "./Memo";
 import "../less/memo-list.less";
 

--- a/web/src/components/MemoList.tsx
+++ b/web/src/components/MemoList.tsx
@@ -6,7 +6,7 @@ import { TAG_REG, LINK_REG } from "../labs/marked/parser";
 import * as utils from "../helpers/utils";
 import { checkShouldShowMemoWithFilters } from "../helpers/filter";
 import toastHelper from "./Toast";
-import {closeSidebar} from "../helpers/utils";
+import { closeSidebar } from "../helpers/utils";
 import Memo from "./Memo";
 import "../less/memo-list.less";
 

--- a/web/src/components/ShortcutList.tsx
+++ b/web/src/components/ShortcutList.tsx
@@ -5,7 +5,7 @@ import { useAppSelector } from "../store";
 import * as utils from "../helpers/utils";
 import useToggle from "../hooks/useToggle";
 import useLoading from "../hooks/useLoading";
-import {closeSidebar} from "../helpers/utils";
+import { closeSidebar } from "../helpers/utils";
 import Icon from "./Icon";
 import toastHelper from "./Toast";
 import showCreateShortcutDialog from "./CreateShortcutDialog";

--- a/web/src/components/ShortcutList.tsx
+++ b/web/src/components/ShortcutList.tsx
@@ -5,6 +5,7 @@ import { useAppSelector } from "../store";
 import * as utils from "../helpers/utils";
 import useToggle from "../hooks/useToggle";
 import useLoading from "../hooks/useLoading";
+import closeSidebar from "../hooks/closeSidebar";
 import Icon from "./Icon";
 import toastHelper from "./Toast";
 import showCreateShortcutDialog from "./CreateShortcutDialog";
@@ -63,6 +64,7 @@ const ShortcutContainer: React.FC<ShortcutContainerProps> = (props: ShortcutCont
   const [showConfirmDeleteBtn, toggleConfirmDeleteBtn] = useToggle(false);
 
   const handleShortcutClick = () => {
+    closeSidebar();
     if (isActive) {
       locationService.setMemoShortcut(undefined);
     } else {

--- a/web/src/components/ShortcutList.tsx
+++ b/web/src/components/ShortcutList.tsx
@@ -5,7 +5,7 @@ import { useAppSelector } from "../store";
 import * as utils from "../helpers/utils";
 import useToggle from "../hooks/useToggle";
 import useLoading from "../hooks/useLoading";
-import closeSidebar from "../hooks/closeSidebar";
+import {closeSidebar} from "../helpers/utils";
 import Icon from "./Icon";
 import toastHelper from "./Toast";
 import showCreateShortcutDialog from "./CreateShortcutDialog";

--- a/web/src/components/TagList.tsx
+++ b/web/src/components/TagList.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useAppSelector } from "../store";
 import { locationService, memoService, userService } from "../services";
 import useToggle from "../hooks/useToggle";
+import closeSidebar from "../hooks/closeSidebar"
 import Icon from "./Icon";
 import "../less/tag-list.less";
 
@@ -69,7 +70,7 @@ const TagList = () => {
   }, [tagsText]);
 
   return (
-    <div className="tags-wrapper">
+    <div className="tags-wrapper" onClick={() => closeSidebar()}>
       <p className="title-text">{t("common.tags")}</p>
       <div className="tags-container">
         {tags.map((t, idx) => (

--- a/web/src/components/TagList.tsx
+++ b/web/src/components/TagList.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useAppSelector } from "../store";
 import { locationService, memoService, userService } from "../services";
 import useToggle from "../hooks/useToggle";
-import {closeSidebar} from "../helpers/utils";
+import { closeSidebar } from "../helpers/utils";
 import Icon from "./Icon";
 import "../less/tag-list.less";
 

--- a/web/src/components/TagList.tsx
+++ b/web/src/components/TagList.tsx
@@ -70,7 +70,7 @@ const TagList = () => {
   }, [tagsText]);
 
   return (
-    <div className="tags-wrapper" onClick={() => closeSidebar()}>
+    <div className="tags-wrapper" onClick={closeSidebar}>
       <p className="title-text">{t("common.tags")}</p>
       <div className="tags-container">
         {tags.map((t, idx) => (

--- a/web/src/components/TagList.tsx
+++ b/web/src/components/TagList.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useAppSelector } from "../store";
 import { locationService, memoService, userService } from "../services";
 import useToggle from "../hooks/useToggle";
-import closeSidebar from "../hooks/closeSidebar"
+import closeSidebar from "../hooks/closeSidebar";
 import Icon from "./Icon";
 import "../less/tag-list.less";
 

--- a/web/src/components/TagList.tsx
+++ b/web/src/components/TagList.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useAppSelector } from "../store";
 import { locationService, memoService, userService } from "../services";
 import useToggle from "../hooks/useToggle";
-import closeSidebar from "../hooks/closeSidebar";
+import {closeSidebar} from "../helpers/utils";
 import Icon from "./Icon";
 import "../less/tag-list.less";
 

--- a/web/src/helpers/utils.ts
+++ b/web/src/helpers/utils.ts
@@ -134,3 +134,8 @@ export const parseHTMLToRawText = (htmlStr: string): string => {
   const text = tempEl.innerText;
   return text;
 };
+
+export function closeSidebar() {
+  const sidebarEl = document.body.querySelector(".sidebar-wrapper") as HTMLDivElement;
+  sidebarEl.style.display = "none";
+};

--- a/web/src/helpers/utils.ts
+++ b/web/src/helpers/utils.ts
@@ -138,4 +138,4 @@ export const parseHTMLToRawText = (htmlStr: string): string => {
 export function closeSidebar() {
   const sidebarEl = document.body.querySelector(".sidebar-wrapper") as HTMLDivElement;
   sidebarEl.style.display = "none";
-};
+}

--- a/web/src/hooks/closeSidebar.ts
+++ b/web/src/hooks/closeSidebar.ts
@@ -1,6 +1,0 @@
-const closeSidebar = () => {
-  const sidebarEl = document.body.querySelector(".sidebar-wrapper") as HTMLDivElement;
-  sidebarEl.style.display = "none";
-};
-
-export default closeSidebar;

--- a/web/src/hooks/closeSidebar.ts
+++ b/web/src/hooks/closeSidebar.ts
@@ -1,6 +1,6 @@
 const closeSidebar = () => {
-    const sidebarEl = document.body.querySelector(".sidebar-wrapper") as HTMLDivElement;
-    sidebarEl.style.display = "none";
+  const sidebarEl = document.body.querySelector(".sidebar-wrapper") as HTMLDivElement;
+  sidebarEl.style.display = "none";
 };
 
 export default closeSidebar;

--- a/web/src/hooks/closeSidebar.ts
+++ b/web/src/hooks/closeSidebar.ts
@@ -1,0 +1,6 @@
+const closeSidebar = () => {
+    const sidebarEl = document.body.querySelector(".sidebar-wrapper") as HTMLDivElement;
+    sidebarEl.style.display = "none";
+};
+
+export default closeSidebar;


### PR DESCRIPTION
非常感谢大佬们写出这样牛逼的程序👍！我在移动端的使用过程中，发现当标签过多的时候，选择需要的标签后，需要上滑找到侧边栏的关闭按钮点击才能关闭掉侧边栏，查看选择标签的内容。有一些不太方便。

修改：点击快捷方式、标签、和列表区域时，会关闭掉侧边栏。
![msedge_TKYBzQB71w](https://user-images.githubusercontent.com/70848869/194710341-d9045a4b-d553-4ecf-bb78-73ecdf520a57.gif)
