### PR TITLE
修复移动端侧边栏弹出时闪烁问题

### DIFF
--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -26,7 +26,7 @@ const Sidebar = () => {
 
   return (
     <>
-      <div className="mask" onClick={() => toggleSiderbar(false)}></div>
+      <div className="mask hide" onClick={() => toggleSiderbar(false)}></div>
       <aside className="sidebar-wrapper">
         <UserBanner />
         <UsageHeatMap />
@@ -62,10 +62,10 @@ export const toggleSiderbar = (show?: boolean) => {
 
   if (show) {
     sidebarEl.classList.add("show");
-    maskEl.classList.add("show");
+    maskEl.classList.replace("hide", "show");
   } else {
     sidebarEl.classList.remove("show");
-    maskEl.classList.remove("show");
+    maskEl.classList.replace("show", "hide");
   }
 };
 

--- a/web/src/less/home.less
+++ b/web/src/less/home.less
@@ -15,7 +15,7 @@
       @apply relative flex-grow max-w-2xl w-full min-h-full flex flex-col justify-start items-start px-4 sm:pr-6;
 
       > .memos-editor-wrapper {
-        @apply sticky top-0 w-full h-full flex flex-col justify-start items-start z-10;
+        @apply sticky top-0 w-full h-full flex flex-col justify-start items-start z-1;
         background-color: #f6f5f4;
       }
 

--- a/web/src/less/siderbar.less
+++ b/web/src/less/siderbar.less
@@ -25,6 +25,29 @@
   @apply fixed top-0 right-0 w-screen h-screen bg-transparent transition-all duration-300 z-0 sm:hidden;
 
   &.show {
-    @apply z-20 bg-black opacity-60;
+    @apply z-20 bg-black opacity-70;
+    animation: show 0.37s linear;
+    @keyframes show {
+      0%{
+        opacity: 0;
+      }
+      100% {
+        opacity: 0.7;
+      }
+    }
+  }
+
+  &.hide {
+    animation: hide 0.37s ease;
+    @keyframes hide {
+      0%{
+        opacity: 0.7;
+        z-index: 20;
+      }
+      100% {
+        opacity: 0;
+        z-index: 0;
+      }
+    }
   }
 }


### PR DESCRIPTION
尝试修复移动端侧边栏弹出时遮罩层闪烁问题。

思路：用 animation 动画控制 mask 在透明的时候去切换 z-index。

思路很蠢，当作抛砖引玉，希望能够有大佬指点一下，谢谢。