### PR TITLE
feat: inline code within link

### DIFF
--- a/web/src/labs/marked/index.ts
+++ b/web/src/labs/marked/index.ts
@@ -26,7 +26,7 @@ export const marked = (markdownStr: string, blockParsers = blockElementParserLis
   let matchedInlineParser = undefined;
   let matchedIndex = -1;
 
-  for (const parser of inlineElementParserList) {
+  for (const parser of inlineParsers) {
     if (parser.name === "plain text" && matchedInlineParser !== undefined) {
       continue;
     }

--- a/web/src/labs/marked/marked.test.ts
+++ b/web/src/labs/marked/marked.test.ts
@@ -73,6 +73,18 @@ console.log("hello world!")
       expect(unescape(marked(t.markdown))).toBe(t.want);
     }
   });
+  test("parse inline code within inline element", () => {
+    const tests = [
+      {
+        markdown: `Link: [\`baidu\`](https://baidu.com)`,
+        want: `<p>Link: <a class='link' target='_blank' rel='noreferrer' href='https://baidu.com'><code>baidu</code></a></p>`,
+      },
+    ];
+
+    for (const t of tests) {
+      expect(unescape(marked(t.markdown))).toBe(t.want);
+    }
+  });
   test("parse plain link", () => {
     const tests = [
       {

--- a/web/src/labs/marked/parser/Link.ts
+++ b/web/src/labs/marked/parser/Link.ts
@@ -1,4 +1,8 @@
 import { escape } from "lodash-es";
+import Emphasis from "./Emphasis";
+import Bold from "./Bold";
+import { marked } from "..";
+import InlineCode from "./InlineCode";
 
 export const LINK_REG = /\[(.*?)\]\((.+?)\)/;
 
@@ -7,8 +11,8 @@ const renderer = (rawStr: string): string => {
   if (!matchResult) {
     return rawStr;
   }
-
-  return `<a class='link' target='_blank' rel='noreferrer' href='${escape(matchResult[2])}'>${escape(matchResult[1])}</a>`;
+  const parsedContent = marked(matchResult[1], [], [InlineCode, Emphasis, Bold]);
+  return `<a class='link' target='_blank' rel='noreferrer' href='${escape(matchResult[2])}'>${parsedContent}</a>`;
 };
 
 export default {

--- a/web/src/less/memo-content.less
+++ b/web/src/less/memo-content.less
@@ -31,9 +31,9 @@
     }
 
     .link {
-      @apply text-blue-600 cursor-pointer underline break-all hover:opacity-80;
+      @apply text-blue-600 cursor-pointer underline break-all hover:opacity-80 decoration-1;
       code {
-        @apply underline;
+        @apply underline decoration-1;
       }
     }
 

--- a/web/src/less/memo-content.less
+++ b/web/src/less/memo-content.less
@@ -32,6 +32,9 @@
 
     .link {
       @apply text-blue-600 cursor-pointer underline break-all hover:opacity-80;
+      code {
+        @apply underline;
+      }
     }
 
     .ol-block,


### PR DESCRIPTION
close #317 

link with code:
<img width="247" alt="image" src="https://user-images.githubusercontent.com/17293034/196955361-59077b6b-da2c-455a-a728-c5c4d1f76374.png">
pure link:
<img width="130" alt="image" src="https://user-images.githubusercontent.com/17293034/196955459-b9364cbc-bf8c-4bd7-b511-4898a220a9b5.png">

---

use `decoration-1` with tailwind (`text-decoration-thickness: 1px`)
without `decoration-1`:
<img width="187" alt="image" src="https://user-images.githubusercontent.com/17293034/196955737-348c18bd-0a06-4c74-b240-9550ed95cf7f.png">
