### PR TITLE
chore: pin button color

### DIFF
--- a/web/src/components/Memo.tsx
+++ b/web/src/components/Memo.tsx
@@ -203,7 +203,7 @@ const Memo: React.FC<Props> = (props: Props) => {
               <div className="more-action-btns-container">
                 <div className="btns-container">
                   <div className="btn" onClick={handleTogglePinMemoBtnClick}>
-                    <Icon.Flag className={`icon-img ${memo.pinned ? "" : "opacity-20"}`} />
+                    <Icon.Flag className={`icon-img ${memo.pinned ? "text-green-600" : ""}`} />
                     <span className="tip-text">{memo.pinned ? t("common.unpin") : t("common.pin")}</span>
                   </div>
                   <div className="btn" onClick={handleEditMemoClick}>


### PR DESCRIPTION
||pinned|unpinned|
|---|---|---|
|new|<img width="151" alt="image" src="https://user-images.githubusercontent.com/17293034/199307446-4f70d8e3-2539-44d8-967e-a8a912c2e691.png">|<img width="158" alt="image" src="https://user-images.githubusercontent.com/17293034/199307517-e5fe9a22-80ef-4a52-81d3-aa9645ef190e.png">|
|old|<img width="153" alt="image" src="https://user-images.githubusercontent.com/17293034/199308063-b3466e5a-b21c-4671-a8ba-a1b650514aec.png">|<img width="148" alt="image" src="https://user-images.githubusercontent.com/17293034/199308115-b160d1cc-3c49-4a64-a6e5-788cab37a7d2.png">|

The old unpinned Memo's pin button looks like a disabled button. Maybe we can change the color a bit.