### PR TITLE
chore: change memo card's bg color

### DIFF
--- a/web/src/less/memo-card-dialog.less
+++ b/web/src/less/memo-card-dialog.less
@@ -41,7 +41,7 @@
 
       > .layer-container,
       > .background-layer-container {
-        @apply bg-amber-100;
+        @apply bg-white;
         position: absolute;
         bottom: -3px;
         left: 3px;
@@ -53,7 +53,7 @@
       }
 
       > .layer-container {
-        @apply bg-amber-100;
+        @apply bg-white;
         z-index: 0;
         border: 1px solid lightgray;
         width: 100%;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31177490/201895075-e1d7304e-eba0-4910-8749-d00e648c656e.png)

![image](https://user-images.githubusercontent.com/31177490/201895100-d6755af3-9054-434c-9fe4-f0bad0440d85.png)

I think white is more suitable for the current style.