### PR TITLE
fix: abnormal link regex

### DIFF
--- a/web/src/labs/marked/parser/Link.ts
+++ b/web/src/labs/marked/parser/Link.ts
@@ -5,7 +5,7 @@ import { marked } from "..";
 import InlineCode from "./InlineCode";
 import BoldEmphasis from "./BoldEmphasis";
 
-export const LINK_REG = /\[(.*?)\]\((.+?)\)/;
+export const LINK_REG = /\[(.*?)\]\((.+?)\)+/;
 
 const renderer = (rawStr: string): string => {
   const matchResult = rawStr.match(LINK_REG);


### PR DESCRIPTION
```markdown
[Predicate (mathematical logic)](https://en.wikipedia.org/wiki/Predicate_(mathematical_logic))
```
+ Now: [Predicate (mathematical logic)](https://en.wikipedia.org/wiki/Predicate_(mathematical_logic)))
+ Should: [Predicate (mathematical logic)](https://en.wikipedia.org/wiki/Predicate_(mathematical_logic))