### PR TITLE
fix: make tooltip text no-selecting

### DIFF
--- a/web/src/less/memo.less
+++ b/web/src/less/memo.less
@@ -62,6 +62,7 @@
 
             > .btn {
               @apply relative w-6 h-6 p-1 text-gray-600 cursor-pointer;
+              user-select: none;
 
               &:hover > .tip-text {
                 @apply block;

--- a/web/src/less/memo.less
+++ b/web/src/less/memo.less
@@ -61,8 +61,7 @@
             @apply w-full flex flex-row justify-around items-center border-b border-gray-100 p-1 mb-1;
 
             > .btn {
-              @apply relative w-6 h-6 p-1 text-gray-600 cursor-pointer;
-              user-select: none;
+              @apply relative w-6 h-6 p-1 text-gray-600 cursor-pointer select-none;
 
               &:hover > .tip-text {
                 @apply block;


### PR DESCRIPTION
With a double click on edit/pin button, you can get selection on tooltip text. It doesn't look good.

https://user-images.githubusercontent.com/118022040/203890748-5901c054-6f83-4834-94c7-17ee84e4d404.mov

