### PR TITLE
fix: get markdown image from backend

### DIFF
--- a/web/src/components/Memo.tsx
+++ b/web/src/components/Memo.tsx
@@ -153,7 +153,6 @@ const Memo: React.FC<Props> = (props: Props) => {
                   .slice(1, -1) ?? ""
               }`
           ) ?? [];
-        console.log(currImgUrl, imageUrls);
         showPreviewImageDialog(
           imageUrls,
           imageUrls.findIndex((item) => item === currImgUrl)

--- a/web/src/components/Memo.tsx
+++ b/web/src/components/Memo.tsx
@@ -146,11 +146,14 @@ const Memo: React.FC<Props> = (props: Props) => {
         const imageUrls =
           memo.content.match(/!\[.*?\]\((.*?)\)/g)?.map(
             (item) =>
-              item
-                .match(/\((.*?)\)/g)
-                ?.slice(-1)[0]
-                .slice(1, -1) ?? ""
+              `/o/get/image?url=${
+                item
+                  .match(/\((.*?)\)/g)
+                  ?.slice(-1)[0]
+                  .slice(1, -1) ?? ""
+              }`
           ) ?? [];
+        console.log(currImgUrl, imageUrls);
         showPreviewImageDialog(
           imageUrls,
           imageUrls.findIndex((item) => item === currImgUrl)


### PR DESCRIPTION
src of the img tag is  `/o/get/image?url=http://localhost:3000/o/r/1/image.png`
but 
src in the markdown content is `['http://localhost:3000/o/r/1/image.png']`
 
So `findIndex` function cannot find the correct index.