### PR TITLE
fix: search bar dropdown disappearing

### DIFF
--- a/web/src/less/memos-header.less
+++ b/web/src/less/memos-header.less
@@ -1,6 +1,6 @@
 .section-header-container,
 .memos-header-container {
-  @apply sticky top-4 flex flex-row justify-between items-center w-full h-10 flex-nowrap mt-4 mb-2 shrink-0 z-1;
+  @apply sticky top-4 flex flex-row justify-between items-center w-full h-10 flex-nowrap mt-4 mb-2 shrink-0 z-10;
 
   > .title-container {
     @apply flex flex-row justify-start items-center mr-2 shrink-0 overflow-hidden;


### PR DESCRIPTION
Dropdown was disappearing when the mouse was still on it.
Common tools bar has the same z-level, so it overlaps the dropdown.

https://user-images.githubusercontent.com/118022040/204094779-827e679b-4c3d-47a3-96c8-411a531bbccc.mov

