### PR TITLE
fix: shoutcut tag filter handle mutiple tags

### DIFF
--- a/web/src/helpers/filter.ts
+++ b/web/src/helpers/filter.ts
@@ -156,7 +156,7 @@ export const checkShouldShowMemo = (memo: Memo, filter: Filter) => {
   if (type === "TAG") {
     let contained = true;
     const tagsSet = new Set<string>();
-    for (const t of Array.from(memo.content.match(TAG_REG) ?? [])) {
+    for (const t of Array.from(memo.content.match(new RegExp(TAG_REG, "g")) ?? [])) {
       const tag = t.replace(TAG_REG, "$1").trim();
       const items = tag.split("/");
       let temp = "";

--- a/web/src/labs/marked/parser/Tag.ts
+++ b/web/src/labs/marked/parser/Tag.ts
@@ -1,15 +1,14 @@
 import { escape } from "lodash-es";
 
-export const TAG_REG = /#([^\s#]+?) /g;
+export const TAG_REG = /#([^\s#]+?) /;
 
 const renderer = (rawStr: string): string => {
   const matchResult = rawStr.match(TAG_REG);
   if (!matchResult) {
     return rawStr;
   }
-  const tag = matchResult[0].replace(TAG_REG, "$1").trim();
 
-  return `<span class='tag-span'>#${escape(tag)}</span> `;
+  return `<span class='tag-span'>#${escape(matchResult[1])}</span> `;
 };
 
 export default {

--- a/web/src/labs/marked/parser/Tag.ts
+++ b/web/src/labs/marked/parser/Tag.ts
@@ -1,14 +1,15 @@
 import { escape } from "lodash-es";
 
-export const TAG_REG = /#([^\s#]+?) /;
+export const TAG_REG = /#([^\s#]+?) /g;
 
 const renderer = (rawStr: string): string => {
   const matchResult = rawStr.match(TAG_REG);
   if (!matchResult) {
     return rawStr;
   }
+  const tag = matchResult[0].replace(TAG_REG, "$1").trim();
 
-  return `<span class='tag-span'>#${escape(matchResult[1])}</span> `;
+  return `<span class='tag-span'>#${escape(tag)}</span> `;
 };
 
 export default {


### PR DESCRIPTION
when apply a shortcut using tag filter, only the first tag in content can be found.

For example..
![截屏2022-11-27 下午8 57 35](https://user-images.githubusercontent.com/16509323/204136475-f1d4ae66-fef0-4480-b493-ee36a8e48539.png)
![截屏2022-11-27 下午8 58 06](https://user-images.githubusercontent.com/16509323/204136487-7773f053-e77b-47ea-a39f-b794aee19861.png)

result is 
![截屏2022-11-27 下午8 58 19](https://user-images.githubusercontent.com/16509323/204136501-e524561c-79cb-4ce1-a2e3-aed24a37c57f.png)

it should be 
![截屏2022-11-27 下午9 04 06](https://user-images.githubusercontent.com/16509323/204136715-7a8b16a7-9c76-46fc-8e20-9950fee87e34.png)

