### PR TITLE
fix: clear shortcut filter when delete this shortcut

### DIFF
--- a/web/src/components/ShortcutList.tsx
+++ b/web/src/components/ShortcutList.tsx
@@ -76,7 +76,7 @@ const ShortcutContainer: React.FC<ShortcutContainerProps> = (props: ShortcutCont
     if (showConfirmDeleteBtn) {
       try {
         await shortcutService.deleteShortcutById(shortcut.id);
-        if(locationService.getState().query?.shortcutId === shortcut.id){
+        if (locationService.getState().query?.shortcutId === shortcut.id) {
           // need clear shortcut filter
           locationService.setMemoShortcut(undefined);
         }

--- a/web/src/components/ShortcutList.tsx
+++ b/web/src/components/ShortcutList.tsx
@@ -76,6 +76,10 @@ const ShortcutContainer: React.FC<ShortcutContainerProps> = (props: ShortcutCont
     if (showConfirmDeleteBtn) {
       try {
         await shortcutService.deleteShortcutById(shortcut.id);
+        if(locationService.getState().query?.shortcutId === shortcut.id){
+          // need clear shortcut filter
+          locationService.setMemoShortcut(undefined);
+        }
       } catch (error: any) {
         console.error(error);
         toastHelper.error(error.response.data.message);


### PR DESCRIPTION
when delete a shortcut which is apply for the filter, the filter remain but filter item disappear, and the list still remain filtered

![截屏2022-11-27 下午11 44 34](https://user-images.githubusercontent.com/16509323/204146256-e0b7faac-c99c-43e4-9fb2-1535a9dd20da.png)
