### PR TITLE
fix: resource-container overflow

### DIFF
--- a/web/src/less/memo-editor.less
+++ b/web/src/less/memo-editor.less
@@ -111,7 +111,7 @@
     @apply w-full flex flex-row justify-start flex-wrap;
 
     > .resource-container {
-      @apply mt-1 mr-1 flex flex-row justify-start items-center flex-nowrap bg-gray-100 px-2 py-1 rounded cursor-pointer hover:bg-gray-200;
+      @apply max-w-full mt-1 mr-1 flex flex-row justify-start items-center flex-nowrap bg-gray-100 px-2 py-1 rounded cursor-pointer hover:bg-gray-200;
 
       > .icon-img {
         @apply w-4 h-auto mr-1 text-gray-500;


### PR DESCRIPTION
## Version

0.8.0

## Steps to reproduce

Upload a file with a long name

## Device

iphone SE

## What is expected?

I can remove this file

## What is actually happening?

![file-name-overflow](https://user-images.githubusercontent.com/40316220/205208820-fb3b1274-ae2e-4159-98e0-a5868ede517d.png)

## Solution

```css
.resource-container {
  max-width: 100%;
}
```
