### PR TITLE
feat: add swedish/svenska translation

### DIFF
--- a/api/user_setting.go
+++ b/api/user_setting.go
@@ -34,7 +34,7 @@ func (key UserSettingKey) String() string {
 }
 
 var (
-	UserSettingLocaleValue                 = []string{"en", "zh", "vi", "fr"}
+	UserSettingLocaleValue                 = []string{"en", "zh", "vi", "fr", "sv"}
 	UserSettingAppearanceValue             = []string{"light", "dark"}
 	UserSettingMemoVisibilityValue         = []Visibility{Private, Protected, Public}
 	UserSettingMemoDisplayTsOptionKeyValue = []string{"created_ts", "updated_ts"}

--- a/web/src/components/Settings/PreferencesSection.tsx
+++ b/web/src/components/Settings/PreferencesSection.tsx
@@ -24,6 +24,10 @@ const localeSelectorItems = [
     text: "French",
     value: "fr",
   },
+  {
+    text: "Svenska",
+    value: "sv",
+  },
 ];
 
 const PreferencesSection = () => {

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -4,6 +4,7 @@ import enLocale from "./locales/en.json";
 import zhLocale from "./locales/zh.json";
 import viLocale from "./locales/vi.json";
 import frLocale from "./locales/fr.json";
+import svLocale from "./locales/sv.json";
 
 i18n.use(initReactI18next).init({
   resources: {
@@ -18,6 +19,9 @@ i18n.use(initReactI18next).init({
     },
     fr: {
       translation: frLocale,
+    },
+    sv: {
+      translation: svLocale,
     },
   },
   lng: "en",

--- a/web/src/locales/sv.json
+++ b/web/src/locales/sv.json
@@ -1,0 +1,213 @@
+{
+  "common": {
+    "about": "Om",
+    "email": "E-post",
+    "password": "Lösenord",
+    "repeat-password-short": "Upprepa",
+    "repeat-password": "Uprepa lösenordet",
+    "new-password": "Nytt lösenord",
+    "repeat-new-password": "Upprepa det nya lösenordet",
+    "username": "Användarnamn",
+    "nickname": "Smeknamn",
+    "save": "Spara",
+    "close": "Stäng",
+    "cancel": "Avbryt",
+    "create": "Skapa",
+    "change": "Ändra",
+    "confirm": "Bekräfta",
+    "reset": "Återställ",
+    "language": "Språk",
+    "version": "Version",
+    "pin": "Fäst",
+    "unpin": "Ta bort fäst",
+    "edit": "Redigera",
+    "restore": "Återställ",
+    "delete": "Radera",
+    "null": "Null",
+    "share": "Dela",
+    "archive": "Arkivera",
+    "basic": "Grundläggande",
+    "admin": "Admin",
+    "explore": "Utforska",
+    "sign-in": "Logga in",
+    "sign-up": "Bli medlem",
+    "sign-out": "Logga ut",
+    "back-to-home": "Tillbaka hem",
+    "type": "Typ",
+    "shortcuts": "Genvägar",
+    "title": "Titel",
+    "filter": "Filter",
+    "tags": "Taggar",
+    "yourself": "Själv",
+    "archived-at": "Arkiverad på",
+    "changed": "Ändrad",
+    "update-on": "Uppdatering på",
+    "fold": "Vik ihop",
+    "expand": "Expandera",
+    "image": "Bild",
+    "link": "Länk"
+  },
+  "slogan": "En öppen källkod, self-hosted antecknings hubb med kunskapshantering och socialisering",
+  "auth": {
+    "signup-as-host": "Registera dig som värd",
+    "host-tip": "Du registerar dig som webbplatsvärd.",
+    "not-host-tip": "Om du inte har ett konto, kontakta webbplatsens värd."
+  },
+  "sidebar": {
+    "daily-review": "Daglig återblick",
+    "resources": "Resurser",
+    "setting": "Inställningar",
+    "archived": "Arkiverade"
+  },
+  "daily-review": {
+    "oops-nothing": "Oj, det finns inget här."
+  },
+  "resources": {
+    "description": "Visa dina statiska resurser i anteckningarn. t.ex bilder.",
+    "no-resources": "Inga resurser.",
+    "fetching-data": "hämtar data...",
+    "upload": "Ladda upp",
+    "preview": "Förhandsvisa",
+    "copy-link": "Kopiera länk",
+    "delete-resource": "Ta bort resurs",
+    "warning-text": "Är du säker på att du vill ta bort den här resursen? DENNA ÅTGÄRD ÄR OÅTERSTÄLLBAR❗",
+    "linked-amount": "Länkat antecknings belopp",
+    "rename": "Döp om",
+    "clear-unused-resources": "Rensa outnytjade resurser",
+    "warning-text-unused": "Är du säker på att du vill ta bort dessa oanvända resurser? DENNA ÅTGÄRD ÄR OÅTERSTÄLLBAR❗",
+    "no-unused-resources": "Inga oanvända resurser"
+  },
+  "archived": {
+    "archived-memos": "Arkiverade anteckningar",
+    "no-archived-memos": "Inga arkiverade anteckningar.",
+    "fetching-data": "hämtar data..."
+  },
+  "editor": {
+    "editing": "Redigerar...",
+    "cancel-edit": "Avbryt redigering",
+    "save": "Spara",
+    "placeholder": "Några tankar...",
+    "only-image-supported": "Endast bildfiler stöds.",
+    "cant-empty": "Innehållet får inte vara tomt",
+    "local": "Lokal",
+    "resources": "Resurser"
+  },
+  "memo": {
+    "view-detail": "Visa detaljer",
+    "copy": "Kopiera",
+    "visibility": {
+      "private": "Endast synlig för dig",
+      "protected": "Synlig för medlemmar",
+      "public": "Synlig för alla"
+    }
+  },
+  "memo-list": {
+    "fetching-data": "hämtar data...",
+    "fetch-more": "Klicka här för att hämta mer"
+  },
+  "shortcut-list": {
+    "shortcut-title": "Genvägs titel",
+    "create-shortcut": "Skapa genväg",
+    "edit-shortcut": "Ändra genväg",
+    "eligible-memo": "kvalificerad anteckning",
+    "fill-previous": "Vänligen fyll i tidigare filtervärde",
+    "title-required": "Titel krävs",
+    "value-required": "Filtervärde krävs"
+  },
+  "filter": {
+    "new-filter": "Nytt filter",
+    "operator": {
+      "contains": "Innehåller",
+      "not-contains": "Innehåller inte",
+      "is": "Är",
+      "is-not": "Är inte",
+      "before": "Innan",
+      "after": "Efter"
+    },
+    "value": {
+      "not-tagged": "Inga taggar",
+      "linked": "Har länkar"
+    },
+    "text-placeholder": "Börjar med ^ för att använda regex"
+  },
+  "tag-list": {
+    "tip-text": "Ange `#tag ` för att skapa"
+  },
+  "search": {
+    "quickly-filter": "Filtrera snabbt"
+  },
+  "setting": {
+    "my-account": "Mitt konto",
+    "preference": "Preferens",
+    "member": "Medlem",
+    "member-list": "Medlemslista",
+    "system": "System",
+    "account-section": {
+      "title": "Kontoinformation",
+      "update-information": "Uppdatera informationen",
+      "change-password": "Ändra lösenord"
+    },
+    "preference-section": {
+      "default-memo-visibility": "Standard synlighet för anteckningar",
+      "enable-folding-memo": "Aktivera vikbara anteckningar",
+      "editor-font-style": "Redigerare teckensnitt",
+      "mobile-editor-style": "Mobilredigerade stil",
+      "default-memo-sort-option": "Anteckning visningstid",
+      "created_ts": "Skapade tid",
+      "updated_ts": "Upodaterad tid"
+    },
+    "member-section": {
+      "create-a-member": "Skapa en medlem"
+    },
+    "system-section": {
+      "database-file-size": "Databas filstorlek",
+      "allow-user-signup": "Tillåt användarregistrering",
+      "additional-style": "Ytterligare stil",
+      "additional-script": "Ytterligare skript",
+      "additional-style-placeholder": "Ytterligare CSS kod",
+      "additional-script-placeholder": "Ytterligare JavaScript kod"
+    },
+    "apperance-option": {
+      "light": "Alltid ljus",
+      "dark": "Alltid mörk",
+      "system": "Följ systeminställningarna"
+    }
+  },
+  "amount-text": {
+    "memo": "ANTECKNING",
+    "tag": "TAGG",
+    "day": "DAG"
+  },
+  "message": {
+    "no-memos": "inga anteckningar 🌃",
+    "memos-ready": "alla anteckningar är redo 🎉",
+    "restored-successfully": "Återställdes framgångsrikt",
+    "memo-updated-datetime": "Anteckning skapad datum och tid ändrad",
+    "invalid-created-datetime": "Ogiltig skapad datumtid.",
+    "change-memo-created-time": "Ändra anteckning skapade tid",
+    "memo-not-found": "Anteckning hittades inte.",
+    "fill-all": "Var god fyll i alla fält.",
+    "password-not-match": "Lösenorden matchar inte.",
+    "new-password-not-match": "Nya lösenord matchar inte.",
+    "image-load-failed": "Bildladdning misslyckades",
+    "fill-form": "Vänligen fyll i detta formulär",
+    "login-failed": "Inloggningen misslyckades",
+    "signup-failed": "Registrering misslyckades",
+    "user-not-found": "Användaren hittades inte",
+    "password-changed": "Lösenord ändrat",
+    "private-only": "Denna anteckning är privat.",
+    "copied": "Kopierad",
+    "succeed-copy-content": "Innehållet kopierat till urklipp.",
+    "succeed-copy-link": "Länk kopioerat till urklipp.",
+    "change-resource-filename": "Ändra resursfilnamn",
+    "resource-filename-updated": "Resursfilnamn ändrat.",
+    "invalid-resource-filename": "Ogiltligt filnamn.",
+    "click-to-save-the-image": "Klicka för att spara bilden",
+    "generating-the-screenshot": "Genererar skärmdumpen...",
+    "count-selected-resources": "Totalt valt",
+    "too-short": "För kort",
+    "too-long": "För långt",
+    "not-allow-space": "Tillåt inte mellanslag",
+    "not-allow-chinese": "Tillåt inte kinesiska"
+  }
+}

--- a/web/src/pages/Auth.tsx
+++ b/web/src/pages/Auth.tsx
@@ -176,6 +176,7 @@ const Auth = () => {
             <Option value="zh">中文</Option>
             <Option value="vi">Tiếng Việt</Option>
             <Option value="fr">French</Option>
+            <Option value="sv">Svenska</Option>
           </Select>
           <AppearanceSelect />
         </div>

--- a/web/src/types/i18n.d.ts
+++ b/web/src/types/i18n.d.ts
@@ -1,1 +1,1 @@
-type Locale = "en" | "zh" | "vi" | "fr";
+type Locale = "en" | "zh" | "vi" | "fr" | "sv";


### PR DESCRIPTION
This adds `swedish / svenska` translation for all current translatable strings.
