### PR TITLE
chore: update German translation

### DIFF
--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -174,9 +174,9 @@
     }
   },
   "amount-text": {
-    "memo": "MEMO",
-    "tag": "TAG",
-    "day": "TAG"
+    "memo": "MEMOS",
+    "tag": "TAGS",
+    "day": "TAGE"
   },
   "message": {
     "no-memos": "Keine Memos 🌃",


### PR DESCRIPTION
Switched to plural to make the difference between TAG(S) and TAG(E) clearer... Refers to #545