### PR TITLE
feat: add `visibility` field to resource

### DIFF
--- a/api/resource.go
+++ b/api/resource.go
@@ -9,10 +9,11 @@ type Resource struct {
 	UpdatedTs int64 `json:"updatedTs"`
 
 	// Domain specific fields
-	Filename string `json:"filename"`
-	Blob     []byte `json:"-"`
-	Type     string `json:"type"`
-	Size     int64  `json:"size"`
+	Filename   string     `json:"filename"`
+	Blob       []byte     `json:"-"`
+	Type       string     `json:"type"`
+	Size       int64      `json:"size"`
+	Visibility Visibility `json:"visibility"`
 
 	// Related fields
 	LinkedMemoAmount int `json:"linkedMemoAmount"`
@@ -23,10 +24,11 @@ type ResourceCreate struct {
 	CreatorID int
 
 	// Domain specific fields
-	Filename string `json:"filename"`
-	Blob     []byte `json:"blob"`
-	Type     string `json:"type"`
-	Size     int64  `json:"size"`
+	Filename   string     `json:"filename"`
+	Blob       []byte     `json:"blob"`
+	Type       string     `json:"type"`
+	Size       int64      `json:"size"`
+	Visibility Visibility `json:"visibility"`
 }
 
 type ResourceFind struct {
@@ -36,8 +38,9 @@ type ResourceFind struct {
 	CreatorID *int `json:"creatorId"`
 
 	// Domain specific fields
-	Filename *string `json:"filename"`
-	MemoID   *int
+	Filename   *string `json:"filename"`
+	MemoID     *int
+	Visibility *Visibility `json:"visibility"`
 }
 
 type ResourcePatch struct {
@@ -47,7 +50,8 @@ type ResourcePatch struct {
 	UpdatedTs *int64
 
 	// Domain specific fields
-	Filename *string `json:"filename"`
+	Filename   *string     `json:"filename"`
+	Visibility *Visibility `json:"visibility"`
 }
 
 type ResourceDelete struct {

--- a/store/db/migration/dev/LATEST__SCHEMA.sql
+++ b/store/db/migration/dev/LATEST__SCHEMA.sql
@@ -75,7 +75,8 @@ CREATE TABLE resource (
   blob BLOB DEFAULT NULL,
   external_link TEXT NOT NULL DEFAULT '',
   type TEXT NOT NULL DEFAULT '',
-  size INTEGER NOT NULL DEFAULT 0
+  size INTEGER NOT NULL DEFAULT 0,
+  visibility TEXT NOT NULL CHECK (visibility IN ('PUBLIC', 'PROTECTED', 'PRIVATE')) DEFAULT 'PRIVATE'
 );
 
 -- memo_resource

--- a/store/db/migration/prod/0.9/00__resource_visibility.sql
+++ b/store/db/migration/prod/0.9/00__resource_visibility.sql
@@ -1,0 +1,2 @@
+-- Add visibility field to resource
+ALTER TABLE resource ADD COLUMN visibility TEXT NOT NULL CHECK (visibility IN ('PUBLIC', 'PROTECTED' 'PRIVATE')) DEFAULT 'PRIVATE';


### PR DESCRIPTION
We now fetch resources (such as images) via the route `/o/r/:resourceId/:filename`. So everyone can get the image through the link.

This PR introduces a new field `visibility` in the `resource` model. It has the same meaning as the `visibility` field in `memo` model.