### PR TITLE
feat: add 'theme' to translation

### DIFF
--- a/web/src/components/Settings/PreferencesSection.tsx
+++ b/web/src/components/Settings/PreferencesSection.tsx
@@ -99,7 +99,7 @@ const PreferencesSection = () => {
         </Select>
       </div>
       <div className="form-label selector">
-        <span className="normal-text">Theme</span>
+        <span className="normal-text">{t("setting.preference-section.theme")}</span>
         <AppearanceSelect />
       </div>
       <p className="title-text">{t("setting.preference")}</p>

--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -149,6 +149,7 @@
       "change-password": "Passwort ändern"
     },
     "preference-section": {
+      "theme": "Thema",
       "default-memo-visibility": "Standard Sichtbarkeit von Memos",
       "enable-folding-memo": "Aktiviere Falten von Memos",
       "editor-font-style": "Editor Textstil",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -149,6 +149,7 @@
       "change-password": "Change password"
     },
     "preference-section": {
+      "theme": "Theme",
       "default-memo-visibility": "Default memo visibility",
       "enable-folding-memo": "Enable folding memo",
       "editor-font-style": "Editor font style",

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -149,6 +149,7 @@
             "change-password": "Cambiar Contraseña"
         },
         "preference-section": {
+            "theme": "Tema",
             "default-memo-visibility": "Visibilidad predeterminada de las notas",
             "enable-folding-memo": "Habilitar nota plegable",
             "editor-font-style": "Estilo de fuente del editor",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -149,6 +149,7 @@
       "change-password": "Modifier le mot de passe"
     },
     "preference-section": {
+      "theme": "Thème",
       "default-memo-visibility": "Visibilité du mémo par défaut",
       "enable-folding-memo": "Activer le mémo pliable",
       "editor-font-style": "Style de police de l'éditeur",

--- a/web/src/locales/nl.json
+++ b/web/src/locales/nl.json
@@ -143,6 +143,7 @@
       "change-password": "Wachtwoord wijzigen"
     },
     "preference-section": {
+      "theme": "Thema",
       "default-memo-visibility": "Standaard memo zichtbaarheid",
       "enable-folding-memo": "Vouwende memo aanzetten",
       "editor-font-style": "Editor lettertype",

--- a/web/src/locales/sv.json
+++ b/web/src/locales/sv.json
@@ -149,6 +149,7 @@
       "change-password": "Ändra lösenord"
     },
     "preference-section": {
+      "theme": "Tema",
       "default-memo-visibility": "Standard synlighet för anteckningar",
       "enable-folding-memo": "Aktivera vikbara anteckningar",
       "editor-font-style": "Redigerare teckensnitt",

--- a/web/src/locales/vi.json
+++ b/web/src/locales/vi.json
@@ -148,6 +148,7 @@
       "change-password": "Đổi mật khẩu"
     },
     "preference-section": {
+      "theme": "Chủ đề",
       "default-memo-visibility": "Chế độ memo mặc định",
       "enable-folding-memo": "Enable folding memo",
       "editor-font-style": "Thay đổi font cho trình soạn thảo",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -149,6 +149,7 @@
       "change-password": "修改密码"
     },
     "preference-section": {
+      "theme": "主题",
       "default-memo-visibility": "默认 Memo 可见性",
       "enable-folding-memo": "开启折叠 Memo",
       "editor-font-style": "编辑器字体样式",


### PR DESCRIPTION
I've changed the word 'Theme' in the 'Preferences' settings section to also be translated. Also added translation for all languages currently in main.

(yes, i know my branch name is 'dutch-locale'. it's the same as before, i'm lazy)