### PR TITLE
implement plurals for stats

### DIFF
--- a/web/src/components/UserBanner.tsx
+++ b/web/src/components/UserBanner.tsx
@@ -116,15 +116,15 @@ const UserBanner = () => {
       <div className="amount-text-container">
         <div className="status-text memos-text">
           <span className="amount-text">{memoAmount}</span>
-          <span className="type-text">{t("amount-text.memo")}</span>
+          <span className="type-text">{memoAmount == 1 ? t("amount-text.memo") : t("amount-text.memo-plural")}</span>
         </div>
         <div className="status-text tags-text">
           <span className="amount-text">{tags.length}</span>
-          <span className="type-text">{t("amount-text.tag")}</span>
+          <span className="type-text">{tags.length == 1 ? t("amount-text.tag") : t("amount-text.tag-plural")}</span>
         </div>
         <div className="status-text duration-text">
           <span className="amount-text">{createdDays}</span>
-          <span className="type-text">{t("amount-text.day")}</span>
+          <span className="type-text">{createdDays == 1 ? t("amount-text.day") : t("amount-text.day-plural")}</span>
         </div>
       </div>
     </>

--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -176,9 +176,12 @@
     }
   },
   "amount-text": {
-    "memo": "MEMOS",
-    "tag": "TAGS",
-    "day": "TAGE"
+    "memo": "MEMO",
+    "memo-plural": "MEMOS",
+    "tag": "TAG",
+    "tag-plural": "TAGS",
+    "day": "TAG",
+    "day-plural": "TAGE"
   },
   "message": {
     "no-memos": "Keine Memos 🌃",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -177,8 +177,11 @@
   },
   "amount-text": {
     "memo": "MEMO",
+    "memo-plural": "MEMOS",
     "tag": "TAG",
-    "day": "DAY"
+    "tag-plural": "TAGS",
+    "day": "DAY",
+    "day-plural": "DAYS"
   },
   "message": {
     "no-memos": "no memos 🌃",

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -177,8 +177,11 @@
     },
     "amount-text": {
         "memo": "NOTA",
+        "memo-plural": "NOTAS",
         "tag": "ETIQUETA",
-        "day": "DÍA"
+        "tag-plural": "ETIQUETAS",
+        "day": "DÍA",
+        "day-plural": "DÍAS"
     },
     "message": {
         "no-memos": "no hay notas 🌃",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -172,8 +172,11 @@
   },
   "amount-text": {
     "memo": "MEMO",
+    "memo-plural": "MEMOS",
     "tag": "ÉTIQUETTE",
-    "day": "JOUR"
+    "tag-plural": "ÉTIQUETTES",
+    "day": "JOUR",
+    "day-plural": "JOURS"
   },
   "message": {
     "no-memos": "pas de mémos 🌃",

--- a/web/src/locales/nl.json
+++ b/web/src/locales/nl.json
@@ -171,8 +171,11 @@
   },
   "amount-text": {
     "memo": "MEMO",
+    "memo-plural": "MEMOS",
     "tag": "LABEL",
-    "day": "DAG"
+    "tag-plural": "LABELS",
+    "day": "DAG",
+    "day-plural": "DAGEN"
   },
   "message": {
     "no-memos": "geen memos 🌃",

--- a/web/src/locales/sv.json
+++ b/web/src/locales/sv.json
@@ -177,8 +177,11 @@
   },
   "amount-text": {
     "memo": "ANTECKNING",
+    "memo-plural": "ANTECKNINGAR",
     "tag": "TAGG",
-    "day": "DAG"
+    "tag-plural": "TAGGAR",
+    "day": "DAG",
+    "day-plural": "DAGAR"
   },
   "message": {
     "no-memos": "inga anteckningar 🌃",

--- a/web/src/locales/vi.json
+++ b/web/src/locales/vi.json
@@ -171,8 +171,11 @@
   },
   "amount-text": {
     "memo": "MEMO",
+    "memo-plural": "MEMO",
     "tag": "THẺ",
-    "day": "NGÀY"
+    "tag-plural": "THẺ",
+    "day": "NGÀY",
+    "day-plural": "NGÀY"
   },
   "message": {
     "no-memos": "Không có memo nào 🌃",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -177,8 +177,11 @@
   },
   "amount-text": {
     "memo": "MEMO",
+    "memo-plural": "MEMOS",
     "tag": "TAG",
-    "day": "DAY"
+    "tag-plural": "TAGS",
+    "day": "DAY",
+    "day-plural": "DAYS"
   },
   "message": {
     "no-memos": "没有 Memo 了 🌃",


### PR DESCRIPTION
Implemented plurals for stats, including translations for all included languages.
If amount of memos = 0, 'memos', as in "there are 0 memos"
If amount of memos = 1, 'memo', as in "there is 1 memo"