### PR TITLE
feat: implement translation for days

### DIFF
--- a/web/src/components/UsageHeatMap.tsx
+++ b/web/src/components/UsageHeatMap.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocationStore, useMemoStore, useUserStore } from "../store/module";
+import { useTranslation } from "react-i18next";
 import { getMemoStats } from "../helpers/api";
 import { DAILY_TIMESTAMP } from "../helpers/consts";
 import * as utils from "../helpers/utils";
@@ -27,6 +28,7 @@ interface DailyUsageStat {
 }
 
 const UsageHeatMap = () => {
+  const { t } = useTranslation();
   const locationStore = useLocationStore();
   const userStore = useUserStore();
   const memoStore = useMemoStore();
@@ -97,13 +99,13 @@ const UsageHeatMap = () => {
   return (
     <div className="usage-heat-map-wrapper" ref={containerElRef}>
       <div className="day-tip-text-container">
-        <span className="tip-text">Sun</span>
+        <span className="tip-text">{t("days.sun")}</span>
         <span className="tip-text"></span>
-        <span className="tip-text">Tue</span>
+        <span className="tip-text">{t("days.tue")}</span>
         <span className="tip-text"></span>
-        <span className="tip-text">Thu</span>
+        <span className="tip-text">{t("days.thu")}</span>
         <span className="tip-text"></span>
-        <span className="tip-text">Sat</span>
+        <span className="tip-text">{t("days.sat")}</span>
       </div>
       <div className="usage-heat-map">
         {allStat.map((v, i) => {

--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -211,5 +211,21 @@
     "too-long": "Zu lang",
     "not-allow-space": "Keine Leerzeichen erlaubt",
     "not-allow-chinese": "Keine chinesischen Zeichen erlaubt"
+  },
+  "days": {
+    "monday": "Montag",
+    "mon": "Mo",
+    "tuesday": "Dienstag",
+    "tue": "Di",
+    "wednesday": "Mittwoch",
+    "wed": "Mi",
+    "thursday": "Donnerstag",
+    "thu": "Do",
+    "friday": "Freitag",
+    "fri": "Fr",
+    "saturday": "Samstag",
+    "sat": "Sa",
+    "sunday": "Sonntag",
+    "sun": "So"
   }
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -211,5 +211,21 @@
     "too-long": "Too long",
     "not-allow-space": "Don't allow space",
     "not-allow-chinese": "Don't allow chinese"
+  },
+  "days": {
+    "monday": "Monday",
+    "mon": "Mon",
+    "tuesday": "Tuesday",
+    "tue": "Tue",
+    "wednesday": "Wednesday",
+    "wed": "Wed",
+    "thursday": "Thursday",
+    "thu": "Thu",
+    "friday": "Friday",
+    "fri": "Fri",
+    "saturday": "Saturday",
+    "sat": "Sat",
+    "sunday": "Sunday",
+    "sun": "Sun"
   }
 }

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -211,5 +211,21 @@
         "too-long": "Demasiado largo",
         "not-allow-space": "No se admiten espacios",
         "not-allow-chinese": "El chino no está permitido"
+    },
+    "days": {
+      "monday": "Lunes",
+      "mon": "Lun",
+      "tuesday": "Martes",
+      "tue": "Mart",
+      "wednesday": "Miércoles",
+      "wed": "Miérc",
+      "thursday": "Jueves",
+      "thu": "Juev",
+      "friday": "Viernes",
+      "fri": "Vier",
+      "saturday": "Sábado",
+      "sat": "Sáb",
+      "sunday": "Domingo",
+      "sun": "Dom"
     }
 }

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -206,5 +206,21 @@
     "too-long": "Too long",
     "not-allow-space": "Don't allow space",
     "not-allow-chinese": "Don't allow chinese"
+  },
+  "days": {
+    "monday": "Lundi",
+    "mon": "Lu",
+    "tuesday": "Mardi",
+    "tue": "Ma",
+    "wednesday": "Mercredi",
+    "wed": "Me",
+    "thursday": "Jeudi",
+    "thu": "Je",
+    "friday": "Vendredi",
+    "fri": "Ve",
+    "saturday": "Samedi",
+    "sat": "Sa",
+    "sunday": "Dimanche",
+    "sun": "Di"
   }
 }

--- a/web/src/locales/nl.json
+++ b/web/src/locales/nl.json
@@ -198,5 +198,21 @@
     "invalid-resource-filename": "Onjuiste bestandsnaam.",
     "click-to-save-the-image": "Klik om de afbeelding op te slaan",
     "generating-the-screenshot": "Screenshot genereren..."
+  },
+  "days": {
+    "monday": "Maandag",
+    "mon": "ma",
+    "tuesday": "Dinsdag",
+    "tue": "di",
+    "wednesday": "Woensdag",
+    "wed": "woe",
+    "thursday": "Donderdag",
+    "thu": "don",
+    "friday": "Vrijdag",
+    "fri": "vrij",
+    "saturday": "Zaterdag",
+    "sat": "zat",
+    "sunday": "Zondag",
+    "sun": "zon"
   }
 }

--- a/web/src/locales/sv.json
+++ b/web/src/locales/sv.json
@@ -211,5 +211,21 @@
     "too-long": "För långt",
     "not-allow-space": "Tillåt inte mellanslag",
     "not-allow-chinese": "Tillåt inte kinesiska"
+  },
+  "days": {
+    "monday": "Måndag",
+    "mon": "Mån",
+    "tuesday": "Tisdag",
+    "tue": "Tis",
+    "wednesday": "Onsdag",
+    "wed": "Ons",
+    "thursday": "Torsdag",
+    "thu": "Tors",
+    "friday": "Fredag",
+    "fri": "Fre",
+    "saturday": "Lördag",
+    "sat": "Lör",
+    "sunday": "Söndag",
+    "sun": "Sön"
   }
 }

--- a/web/src/locales/vi.json
+++ b/web/src/locales/vi.json
@@ -205,5 +205,21 @@
     "too-long": "Too long",
     "not-allow-space": "Don't allow space",
     "not-allow-chinese": "Don't allow chinese"
+  },
+  "days": {
+    "monday": "thứ hai",
+    "mon": "T2",
+    "tuesday": "thứ ba",
+    "tue": "T3",
+    "wednesday": "thứ tư",
+    "wed": "T4",
+    "thursday": "thứ năm",
+    "thu": "T5",
+    "friday": "thứ sáu",
+    "fri": "T6",
+    "saturday": "thứ bảy",
+    "sat": "T7",
+    "sunday": "chủ nhật",
+    "sun": "CN"
   }
 }

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -211,5 +211,21 @@
     "too-long": "过长",
     "not-allow-space": "不允许包含空格",
     "not-allow-chinese": "不允许包含中文"
+  },
+  "days": {
+    "monday": "星期一",
+    "mon": "一",
+    "tuesday": "星期二",
+    "tue": "二",
+    "wednesday": "星期三",
+    "wed": "三",
+    "thursday": "星期四",
+    "thu": "四",
+    "friday": "星期五",
+    "fri": "五",
+    "saturday": "星期六",
+    "sat": "六",
+    "sunday": "星期天",
+    "sun": "日"
   }
 }


### PR DESCRIPTION
Translation for weekdays on the heatmap (top left)

Sources:
European languages: https://www.ema.europa.eu/en/documents/other/abbreviation-names-days-calendarised-blisters_en.pdf
Vietnamese: https://en.wikipedia.org/wiki/Date_and_time_notation_in_Vietnam
Chinese: https://improvemandarin.com/days-of-the-week-in-chinese/ and https://linguistics.stackexchange.com/questions/17157/weekday-abbreviations-in-multiple-languages

Let me know if any translation is incorrect!