### PR TITLE
feat: Automatic matching of input punctuation

### DIFF
--- a/web/src/components/Editor/Editor.tsx
+++ b/web/src/components/Editor/Editor.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode, useCallback, useEffect, useImperativeHandle, useRef } from "react";
+import { forwardRef, ReactNode, SyntheticEvent, useCallback, useEffect, useImperativeHandle, useRef } from "react";
 import "../../less/editor.less";
 
 export interface EditorRefActions {
@@ -18,7 +18,7 @@ interface Props {
   placeholder: string;
   fullscreen: boolean;
   tools?: ReactNode;
-  onContentChange: (content: string) => void;
+  onContentChange: (content: string, ev?: SyntheticEvent) => void;
   onPaste: (event: React.ClipboardEvent) => void;
 }
 
@@ -112,11 +112,10 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
     []
   );
 
-  const handleEditorInput = useCallback(() => {
-    handleContentChangeCallback(editorRef.current?.value ?? "");
+  const handleEditorInput = useCallback((ev: SyntheticEvent) => {
+    handleContentChangeCallback(editorRef.current?.value ?? "", ev);
     updateEditorHeight();
   }, []);
-
   return (
     <div className={"common-editor-wrapper " + className}>
       <textarea

--- a/web/src/components/MemoEditor.tsx
+++ b/web/src/components/MemoEditor.tsx
@@ -318,7 +318,7 @@ const MemoEditor = () => {
       editorRef.current?.insertText(quote);
       editorRef.current?.setCursorPosition(cursorPosition);
     }
-  }
+  };
 
   const handleCheckBoxBtnClick = () => {
     if (!editorRef.current) {

--- a/web/src/components/MemoEditor.tsx
+++ b/web/src/components/MemoEditor.tsx
@@ -1,5 +1,5 @@
 import { isNumber, last, toLower } from "lodash";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { deleteMemoResource, upsertMemoResource } from "../helpers/api";
 import { TAB_SPACE_WIDTH, UNKNOWN_ID, VISIBILITY_SELECTOR_ITEMS } from "../helpers/consts";
@@ -284,10 +284,41 @@ const MemoEditor = () => {
     }
   };
 
-  const handleContentChange = (content: string) => {
+  const handleContentChange = (content: string, ev?: SyntheticEvent) => {
     setAllowSave(content !== "");
     setEditorContentCache(content);
+    handleQuotesReverse(content, ev);
   };
+
+  const handleQuotesReverse = (content: string, ev?: SyntheticEvent) => {
+    const quotes: {[key: string]: string} = {
+      "'": "'",
+      '"': '"',
+      "(": ")",
+      "（": "）",
+      "【": "】",
+      "[": "]",
+      "《": "》",
+      "「": "」",
+      "『": "』",
+      "{": "}",
+      "“": "”",
+      "‘": "’",
+      "”": "“",
+      "’": "‘",
+      "`": "`",
+    };
+    if (!editorRef.current) {
+      return;
+    }
+    const cursorPosition = editorRef.current.getCursorPosition();
+    const inputValue = (ev?.nativeEvent as InputEvent)?.data as string;
+    const quote = quotes[inputValue];
+    if (quote && ev?.type === 'input') {
+      editorRef.current?.insertText(quote);
+      editorRef.current?.setCursorPosition(cursorPosition);
+    }
+  }
 
   const handleCheckBoxBtnClick = () => {
     if (!editorRef.current) {

--- a/web/src/components/MemoEditor.tsx
+++ b/web/src/components/MemoEditor.tsx
@@ -291,7 +291,7 @@ const MemoEditor = () => {
   };
 
   const handleQuotesReverse = (content: string, ev?: SyntheticEvent) => {
-    const quotes: {[key: string]: string} = {
+    const quotes: { [key: string]: string } = {
       "'": "'",
       '"': '"',
       "(": ")",

--- a/web/src/components/MemoEditor.tsx
+++ b/web/src/components/MemoEditor.tsx
@@ -314,7 +314,7 @@ const MemoEditor = () => {
     const cursorPosition = editorRef.current.getCursorPosition();
     const inputValue = (ev?.nativeEvent as InputEvent)?.data as string;
     const quote = quotes[inputValue];
-    if (quote && ev?.type === 'input') {
+    if (quote && ev?.type === "input") {
       editorRef.current?.insertText(quote);
       editorRef.current?.setCursorPosition(cursorPosition);
     }


### PR DESCRIPTION
#788 For example, type
`hello "|world` will be `hello "|"world`
