### PR TITLE
fix: incorrect cursor when text is selected in range

### DIFF
--- a/web/src/components/MemoEditor.tsx
+++ b/web/src/components/MemoEditor.tsx
@@ -179,7 +179,12 @@ const MemoEditor = () => {
     }
     if (!isShiftKey && event.key === "Tab") {
       event.preventDefault();
+      const selectedContent = editorRef.current.getSelectedContent();
+      const cursorPosition = editorRef.current.getCursorPosition();
       editorRef.current.insertText(" ".repeat(TAB_SPACE_WIDTH));
+      if (selectedContent) {
+        editorRef.current.setCursorPosition(cursorPosition + TAB_SPACE_WIDTH);
+      }
       return;
     }
 


### PR DESCRIPTION
Before: When text is selected in the range, the cursor is positioned at the current position + the length of the selected text
After: The cursor will be positioned at the start of the selected text content + TAB_SPACE_WIDTH