### PR TITLE
fix: round corner issue in resource blocks

### DIFF
--- a/web/src/less/memo-resources.less
+++ b/web/src/less/memo-resources.less
@@ -5,14 +5,14 @@
     @apply w-full grid grid-cols-2 sm:grid-cols-3 gap-2 mt-2;
 
     > .memo-resource {
-      @apply shadow overflow-auto hide-scrollbar;
+      @apply shadow rounded overflow-hidden hide-scrollbar;
 
       > img {
-        @apply cursor-pointer rounded min-h-full w-auto min-w-full object-cover;
+        @apply cursor-pointer min-h-full w-auto min-w-full object-cover;
       }
 
       > video {
-        @apply cursor-pointer rounded w-full h-full object-contain bg-zinc-100 dark:bg-zinc-800;
+        @apply cursor-pointer w-full h-full object-contain bg-zinc-100 dark:bg-zinc-800;
       }
     }
   }


### PR DESCRIPTION
when upload image scale not 1:1, it look like :
<img width="230" alt="4633b4ff-672a-4589-b5fd-d3a349f3f303" src="https://user-images.githubusercontent.com/16509323/213384106-c16ee373-8591-4456-a604-d5d34a0aba27.png">
And it can scroll inside container.
After fix:
<img width="231" alt="ec14f909-59f7-44cb-8c34-e388a3ce7315" src="https://user-images.githubusercontent.com/16509323/213384295-2fd12c8b-7531-4edf-9854-c1222ee06d02.png">
