### PR TITLE
fix: video and audio can't play on safari

### DIFF
--- a/server/resource.go
+++ b/server/resource.go
@@ -274,6 +274,10 @@ func (s *Server) registerResourcePublicRoutes(g *echo.Group) {
 		}
 		c.Response().Writer.Header().Set(echo.HeaderCacheControl, "max-age=31536000, immutable")
 		c.Response().Writer.Header().Set(echo.HeaderContentSecurityPolicy, "default-src 'self'")
+		if strings.HasPrefix(resourceType, "video") {
+			http.ServeContent(c.Response(), c.Request(), resource.Filename, time.Unix(resource.UpdatedTs, 0), bytes.NewReader(resource.Blob))
+			return nil
+		}
 		return c.Stream(http.StatusOK, resourceType, bytes.NewReader(resource.Blob))
 	})
 }

--- a/server/resource.go
+++ b/server/resource.go
@@ -274,7 +274,7 @@ func (s *Server) registerResourcePublicRoutes(g *echo.Group) {
 		}
 		c.Response().Writer.Header().Set(echo.HeaderCacheControl, "max-age=31536000, immutable")
 		c.Response().Writer.Header().Set(echo.HeaderContentSecurityPolicy, "default-src 'self'")
-		if strings.HasPrefix(resourceType, "video") {
+		if strings.HasPrefix(resourceType, "video") || strings.HasPrefix(resourceType, "audio") {
 			http.ServeContent(c.Response(), c.Request(), resource.Filename, time.Unix(resource.UpdatedTs, 0), bytes.NewReader(resource.Blob))
 			return nil
 		}


### PR DESCRIPTION
Problem is video (and audio) can't play on safari and on iOS webapp mode .
<img width="222" alt="image" src="https://user-images.githubusercontent.com/16509323/213633849-e86bf3fa-bd7d-4ff1-8596-41681245e34c.png">
<img width="291" alt="image" src="https://user-images.githubusercontent.com/16509323/213637398-568dfdfd-8945-4e8a-853f-c46ac8544cd4.png">

video resource also can't play when direct request the url like 
```
https://memos_host/o/r/<id>/filename.mp4
```
a error in console is `Failed to Load Resource, Plugin Handled Load`.

And after some searching ,it looks like current `c.Stream()` function cannot response request with Header `Range: bytes=0-1` correctly. According to [rfc7233](https://www.rfc-editor.org/rfc/rfc7233#section-4.1) it should respone with code 206.And `c.Stream()` function also can't return part of content, it can be test use the following code:
```
curl --range 0-99  https://memos_host/o/r/<id>/filename.mp4 -o output.mp4
# if output.mp4 file size is precisely 100bytes then the api can return part of content
```

So for the video&audio content I use `http.ServeContent` Instead of `Stream()` to return the data because it support Range Header and work well on safari and iOS ,And I haven't found similar function in Echo4.
After saving resource file out of dbfile ,it can be change to use `c.File()`.

After Fix:
<img width="335" alt="image" src="https://user-images.githubusercontent.com/16509323/213642289-8c28abc9-1b60-49f9-88fe-462f8dd5800f.png">

sry for my bad description, and happy new year.