### PR TITLE
feat(system): support for disabling public memos

### DIFF
--- a/api/system.go
+++ b/api/system.go
@@ -10,6 +10,8 @@ type SystemStatus struct {
 	// System settings
 	// Allow sign up.
 	AllowSignUp bool `json:"allowSignUp"`
+	// Disable public memos.
+	DisablePublicMemos bool `json:"disablePublicMemos"`
 	// Additional style.
 	AdditionalStyle string `json:"additionalStyle"`
 	// Additional script.

--- a/api/system_setting.go
+++ b/api/system_setting.go
@@ -17,6 +17,8 @@ const (
 	SystemSettingSecretSessionName SystemSettingName = "secretSessionName"
 	// SystemSettingAllowSignUpName is the key type of allow signup setting.
 	SystemSettingAllowSignUpName SystemSettingName = "allowSignUp"
+	// SystemSettingsDisablePublicMemos is the key type of disable public memos setting.
+	SystemSettingDisablePublicMemosName SystemSettingName = "disablePublicMemos"
 	// SystemSettingAdditionalStyleName is the key type of additional style.
 	SystemSettingAdditionalStyleName SystemSettingName = "additionalStyle"
 	// SystemSettingAdditionalScriptName is the key type of additional script.
@@ -49,6 +51,8 @@ func (key SystemSettingName) String() string {
 		return "secretSessionName"
 	case SystemSettingAllowSignUpName:
 		return "allowSignUp"
+	case SystemSettingDisablePublicMemosName:
+		return "disablePublicMemos"
 	case SystemSettingAdditionalStyleName:
 		return "additionalStyle"
 	case SystemSettingAdditionalScriptName:
@@ -60,7 +64,8 @@ func (key SystemSettingName) String() string {
 }
 
 var (
-	SystemSettingAllowSignUpValue = []bool{true, false}
+	SystemSettingAllowSignUpValue        = []bool{true, false}
+	SystemSettingDisbalePublicMemosValue = []bool{true, false}
 )
 
 type SystemSetting struct {
@@ -95,6 +100,24 @@ func (upsert SystemSettingUpsert) Validate() error {
 		}
 		if invalid {
 			return fmt.Errorf("invalid system setting allow signup value")
+		}
+	} else if upsert.Name == SystemSettingDisablePublicMemosName {
+		value := false
+		err := json.Unmarshal([]byte(upsert.Value), &value)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal system setting disable public memos value")
+		}
+
+		invalid := true
+		for _, v := range SystemSettingDisbalePublicMemosValue {
+			if value == v {
+				invalid = false
+				break
+			}
+		}
+
+		if invalid {
+			return fmt.Errorf("invalid system setting disable public memos value")
 		}
 	} else if upsert.Name == SystemSettingAdditionalStyleName {
 		value := ""

--- a/server/system.go
+++ b/server/system.go
@@ -42,12 +42,13 @@ func (s *Server) registerSystemRoutes(g *echo.Group) {
 		}
 
 		systemStatus := api.SystemStatus{
-			Host:             hostUser,
-			Profile:          *s.Profile,
-			DBSize:           0,
-			AllowSignUp:      false,
-			AdditionalStyle:  "",
-			AdditionalScript: "",
+			Host:               hostUser,
+			Profile:            *s.Profile,
+			DBSize:             0,
+			AllowSignUp:        false,
+			DisablePublicMemos: false,
+			AdditionalStyle:    "",
+			AdditionalScript:   "",
 			CustomizedProfile: api.CustomizedProfile{
 				Name:        "memos",
 				LogoURL:     "",
@@ -75,6 +76,8 @@ func (s *Server) registerSystemRoutes(g *echo.Group) {
 
 			if systemSetting.Name == api.SystemSettingAllowSignUpName {
 				systemStatus.AllowSignUp = value.(bool)
+			} else if systemSetting.Name == api.SystemSettingDisablePublicMemosName {
+				systemStatus.DisablePublicMemos = value.(bool)
 			} else if systemSetting.Name == api.SystemSettingAdditionalStyleName {
 				systemStatus.AdditionalStyle = value.(string)
 			} else if systemSetting.Name == api.SystemSettingAdditionalScriptName {

--- a/web/src/components/MemoEditor.tsx
+++ b/web/src/components/MemoEditor.tsx
@@ -4,7 +4,15 @@ import { useTranslation } from "react-i18next";
 import { getMatchedNodes } from "../labs/marked";
 import { deleteMemoResource, upsertMemoResource } from "../helpers/api";
 import { TAB_SPACE_WIDTH, UNKNOWN_ID, VISIBILITY_SELECTOR_ITEMS } from "../helpers/consts";
-import { useEditorStore, useLocationStore, useMemoStore, useResourceStore, useTagStore, useUserStore } from "../store/module";
+import {
+  useEditorStore,
+  useGlobalStore,
+  useLocationStore,
+  useMemoStore,
+  useResourceStore,
+  useTagStore,
+  useUserStore,
+} from "../store/module";
 import * as storage from "../helpers/storage";
 import Icon from "./Icon";
 import toastHelper from "./Toast";
@@ -49,6 +57,9 @@ const MemoEditor = () => {
   const memoStore = useMemoStore();
   const tagStore = useTagStore();
   const resourceStore = useResourceStore();
+  const {
+    state: { systemStatus },
+  } = useGlobalStore();
 
   const [state, setState] = useState<State>({
     isUploadingResource: false,
@@ -548,7 +559,9 @@ const MemoEditor = () => {
         <Selector
           className="visibility-selector"
           value={editorState.memoVisibility}
+          tooltipTitle={t("memo.visibility.disabled")}
           dataSource={memoVisibilityOptionSelectorItems}
+          disabled={systemStatus.disablePublicMemos}
           handleValueChanged={handleMemoVisibilityOptionChanged}
         />
         <div className="buttons-container">

--- a/web/src/components/Settings/SystemSection.tsx
+++ b/web/src/components/Settings/SystemSection.tsx
@@ -6,10 +6,13 @@ import * as api from "../../helpers/api";
 import toastHelper from "../Toast";
 import showUpdateCustomizedProfileDialog from "../UpdateCustomizedProfileDialog";
 import "@/less/settings/system-section.less";
+import { useAppDispatch } from "../../store";
+import { setGlobalState } from "../../store/reducer/global";
 
 interface State {
   dbSize: number;
   allowSignUp: boolean;
+  disablePublicMemos: boolean;
   additionalStyle: string;
   additionalScript: string;
 }
@@ -32,7 +35,10 @@ const SystemSection = () => {
     allowSignUp: systemStatus.allowSignUp,
     additionalStyle: systemStatus.additionalStyle,
     additionalScript: systemStatus.additionalScript,
+    disablePublicMemos: systemStatus.disablePublicMemos,
   });
+
+  const dispatch = useAppDispatch();
 
   useEffect(() => {
     globalStore.fetchSystemStatus();
@@ -44,6 +50,7 @@ const SystemSection = () => {
       allowSignUp: systemStatus.allowSignUp,
       additionalStyle: systemStatus.additionalStyle,
       additionalScript: systemStatus.additionalScript,
+      disablePublicMemos: systemStatus.disablePublicMemos,
     });
   }, [systemStatus]);
 
@@ -100,6 +107,19 @@ const SystemSection = () => {
     });
   };
 
+  const handleDisablePublicMemosChanged = async (value: boolean) => {
+    setState({
+      ...state,
+      disablePublicMemos: value,
+    });
+    // Update global store immediately as MemoEditor/Selector is dependent on this value.
+    dispatch(setGlobalState({ systemStatus: { ...systemStatus, disablePublicMemos: value } }));
+    await api.upsertSystemSetting({
+      name: "disablePublicMemos",
+      value: JSON.stringify(value),
+    });
+  };
+
   const handleSaveAdditionalScript = async () => {
     try {
       await api.upsertSystemSetting({
@@ -132,6 +152,10 @@ const SystemSection = () => {
       <div className="form-label">
         <span className="normal-text">{t("setting.system-section.allow-user-signup")}</span>
         <Switch checked={state.allowSignUp} onChange={(event) => handleAllowSignUpChanged(event.target.checked)} />
+      </div>
+      <div className="form-label">
+        <span className="normal-text">{t("setting.system-section.disable-public-memos")}</span>
+        <Switch checked={state.disablePublicMemos} onChange={(event) => handleDisablePublicMemosChanged(event.target.checked)} />
       </div>
       <div className="form-label">
         <span className="normal-text">{t("setting.system-section.additional-style")}</span>

--- a/web/src/components/common/Selector.tsx
+++ b/web/src/components/common/Selector.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import useToggle from "../../hooks/useToggle";
 import Icon from "../Icon";
 import "../../less/common/selector.less";
+import { Tooltip } from "@mui/joy";
 
 interface SelectorItem {
   text: string;
@@ -14,6 +15,8 @@ interface Props {
   value: string;
   dataSource: SelectorItem[];
   handleValueChanged?: (value: string) => void;
+  disabled?: boolean;
+  tooltipTitle?: string;
 }
 
 const nullItem = {
@@ -22,7 +25,7 @@ const nullItem = {
 };
 
 const Selector: React.FC<Props> = (props: Props) => {
-  const { className, dataSource, handleValueChanged, value } = props;
+  const { className, dataSource, handleValueChanged, value, disabled, tooltipTitle } = props;
   const { t } = useTranslation();
   const [showSelector, toggleSelectorStatus] = useToggle(false);
 
@@ -58,39 +61,52 @@ const Selector: React.FC<Props> = (props: Props) => {
   };
 
   const handleCurrentValueClick = (event: React.MouseEvent) => {
+    if (disabled) return;
     event.stopPropagation();
     toggleSelectorStatus();
   };
 
   return (
-    <div className={`selector-wrapper ${className ?? ""}`} ref={selectorElRef}>
-      <div className={`current-value-container ${showSelector ? "active" : ""}`} onClick={handleCurrentValueClick}>
-        <span className="value-text">{currentItem.text}</span>
-        <span className="arrow-text">
-          <Icon.ChevronDown className="icon-img" />
-        </span>
-      </div>
+    <Tooltip title={tooltipTitle} hidden={!disabled}>
+      <div className={`selector-wrapper ${className ?? ""} `} ref={selectorElRef}>
+        <div
+          className={`current-value-container ${showSelector ? "active" : ""} ${disabled && "selector-disabled"}`}
+          onClick={handleCurrentValueClick}
+        >
+          {disabled && (
+            <span className="lock-text">
+              <Icon.Lock className="icon-img" />
+            </span>
+          )}
+          <span className="value-text">{currentItem.text}</span>
+          {!disabled && (
+            <span className="arrow-text">
+              <Icon.ChevronDown className="icon-img" />
+            </span>
+          )}
+        </div>
 
-      <div className={`items-wrapper ${showSelector ? "" : "!hidden"}`}>
-        {dataSource.length > 0 ? (
-          dataSource.map((d) => {
-            return (
-              <div
-                className={`item-container ${d.value === value ? "selected" : ""}`}
-                key={d.value}
-                onClick={() => {
-                  handleItemClick(d);
-                }}
-              >
-                {d.text}
-              </div>
-            );
-          })
-        ) : (
-          <p className="tip-text">{t("common.null")}</p>
-        )}
+        <div className={`items-wrapper ${showSelector ? "" : "!hidden"}`}>
+          {dataSource.length > 0 ? (
+            dataSource.map((d) => {
+              return (
+                <div
+                  className={`item-container ${d.value === value ? "selected" : ""}`}
+                  key={d.value}
+                  onClick={() => {
+                    handleItemClick(d);
+                  }}
+                >
+                  {d.text}
+                </div>
+              );
+            })
+          ) : (
+            <p className="tip-text">{t("common.null")}</p>
+          )}
+        </div>
       </div>
-    </div>
+    </Tooltip>
   );
 };
 

--- a/web/src/less/common/selector.less
+++ b/web/src/less/common/selector.less
@@ -14,6 +14,10 @@
       width: calc(100% - 20px);
     }
 
+    > .lock-text {
+      @apply flex flex-row justify-center items-center w-4 shrink-0 mr-1;
+    }
+
     > .arrow-text {
       @apply flex flex-row justify-center items-center w-4 shrink-0;
 
@@ -40,5 +44,12 @@
     > .tip-text {
       @apply px-3 py-1 text-sm text-gray-600;
     }
+  }
+
+  > .selector-disabled {
+    @apply cursor-not-allowed;
+    @apply pointer-events-none;
+
+    @apply bg-gray-200 dark:bg-zinc-700 dark:border-zinc-600 text-gray-400;
   }
 }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -101,7 +101,8 @@
     "visibility": {
       "private": "Only visible to you",
       "protected": "Visible to members",
-      "public": "Everyone can see"
+      "public": "Everyone can see",
+      "disabled": "Public memos are disabled"
     }
   },
   "memo-list": {
@@ -180,6 +181,7 @@
       },
       "database-file-size": "Database File Size",
       "allow-user-signup": "Allow user signup",
+      "disable-public-memos": "Disable public memos",
       "additional-style": "Additional style",
       "additional-script": "Additional script",
       "additional-style-placeholder": "Additional CSS codes",

--- a/web/src/store/module/global.ts
+++ b/web/src/store/module/global.ts
@@ -9,6 +9,7 @@ export const initialGlobalState = async () => {
     appearance: "system" as Appearance,
     systemStatus: {
       allowSignUp: false,
+      disablePublicMemos: false,
       additionalStyle: "",
       additionalScript: "",
       customizedProfile: {

--- a/web/src/store/reducer/global.ts
+++ b/web/src/store/reducer/global.ts
@@ -19,6 +19,7 @@ const globalSlice = createSlice({
       },
       dbSize: 0,
       allowSignUp: false,
+      disablePublicMemos: false,
       additionalStyle: "",
       additionalScript: "",
       customizedProfile: {

--- a/web/src/types/modules/system.d.ts
+++ b/web/src/types/modules/system.d.ts
@@ -18,6 +18,7 @@ interface SystemStatus {
   dbSize: number;
   // System settings
   allowSignUp: boolean;
+  disablePublicMemos: boolean;
   additionalStyle: string;
   additionalScript: string;
   customizedProfile: CustomizedProfile;


### PR DESCRIPTION
This PR opens the possibility to disable public memos as requested in https://github.com/usememos/memos/issues/919

**Changes:**
1. Tooltip and disabled styling on the MemoEditor visibility selector.
2. System setting for disabling public memos

![Screenshot 2023-01-31 at 18 00 10](https://user-images.githubusercontent.com/59088889/215830822-2a2648db-24cf-4e1f-bd56-1a491a11034e.png)

![Screenshot 2023-01-31 at 18 00 28](https://user-images.githubusercontent.com/59088889/215830884-533077c8-5ae2-48f2-ba4a-2fea19b70e75.png)

