### PR TITLE
chore(build): anchor setup-buildx-action@v2 to version v0.9.1

### DIFF
--- a/.github/workflows/build-and-push-release-image.yml
+++ b/.github/workflows/build-and-push-release-image.yml
@@ -32,6 +32,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           install: true
+          version: v0.9.1
 
       - name: Build and Push
         id: docker_build

--- a/.github/workflows/build-and-push-test-image.yml
+++ b/.github/workflows/build-and-push-test-image.yml
@@ -24,6 +24,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           install: true
+          version: v0.9.1
 
       - name: Build and Push
         id: docker_build


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

Closes #1005 

anchor `setup-buildx-action@v2` to version `v0.9.1`