### PR TITLE
chore: remove unused fields of storage table

### DIFF
--- a/api/storage.go
+++ b/api/storage.go
@@ -2,9 +2,6 @@ package api
 
 type Storage struct {
 	ID        int    `json:"id"`
-	CreatorID int    `json:"creatorId"`
-	CreatedTs int64  `json:"createdTs"`
-	UpdatedTs int64  `json:"updatedTs"`
 	Name      string `json:"name"`
 	EndPoint  string `json:"endPoint"`
 	Region    string `json:"region"`
@@ -15,7 +12,6 @@ type Storage struct {
 }
 
 type StorageCreate struct {
-	CreatorID int    `json:"creatorId"`
 	Name      string `json:"name"`
 	EndPoint  string `json:"endPoint"`
 	Region    string `json:"region"`
@@ -26,8 +22,7 @@ type StorageCreate struct {
 }
 
 type StoragePatch struct {
-	ID        int `json:"id"`
-	UpdatedTs *int64
+	ID        int     `json:"id"`
 	Name      *string `json:"name"`
 	EndPoint  *string `json:"endPoint"`
 	Region    *string `json:"region"`
@@ -38,9 +33,8 @@ type StoragePatch struct {
 }
 
 type StorageFind struct {
-	ID        *int    `json:"id"`
-	Name      *string `json:"name"`
-	CreatorID *int    `json:"creatorId"`
+	ID   *int    `json:"id"`
+	Name *string `json:"name"`
 }
 
 type StorageDelete struct {

--- a/store/db/migration/dev/LATEST__SCHEMA.sql
+++ b/store/db/migration/dev/LATEST__SCHEMA.sql
@@ -107,9 +107,6 @@ CREATE TABLE activity (
 -- storage
 CREATE TABLE storage (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  creator_id INTEGER NOT NULL,
-  created_ts BIGINT NOT NULL DEFAULT (strftime('%s', 'now')),
-  updated_ts BIGINT NOT NULL DEFAULT (strftime('%s', 'now')),
   name TEXT NOT NULL DEFAULT '' UNIQUE,
   end_point TEXT NOT NULL DEFAULT '',
   region TEXT NOT NULL DEFAULT '',

--- a/web/src/types/modules/storage.d.ts
+++ b/web/src/types/modules/storage.d.ts
@@ -2,9 +2,6 @@ type StorageId = number;
 
 interface Storage {
   id: StorageId;
-  creatorId: UserId;
-  createdTs: TimeStamp;
-  updatedTs: TimeStamp;
   name: string;
   endPoint: string;
   region: string;


### PR DESCRIPTION
Since the storage belongs to system setting and only the web host can access it, so the `creator_id`, `created_ts` and `updated_ts` fields are useless.