### PR TITLE
feat: use accent color when confirming deletion

### DIFF
--- a/web/src/less/memo.less
+++ b/web/src/less/memo.less
@@ -104,6 +104,10 @@
           }
         }
       }
+
+      .final-confirm {
+          color: red 
+      }
     }
   }
 


### PR DESCRIPTION
When deleting an archived memo, I will be prompted "Delete!" after clicking the text button "Delete", but in the same colour. 

Typically such confirmation should be displayed in an eye-caching colour, especially red, to warn people before this kind of irreversible operations. 

So I suggest changing the property of the CSS class `.final-confirm` to fix that. 