### PR TITLE
Fix: Markdown hyperlinks with parenthesis take first closing parenthesis as final

### DIFF
--- a/web/src/labs/marked/parser/Link.tsx
+++ b/web/src/labs/marked/parser/Link.tsx
@@ -6,7 +6,7 @@ import BoldEmphasis from "./BoldEmphasis";
 import PlainText from "./PlainText";
 import { matcher } from "../matcher";
 
-export const LINK_REG = /\[(.*?)\]\((.+?)\)+/;
+export const LINK_REG = /\[(.*?)\]\((.+?)\)$/;
 
 const renderer = (rawStr: string) => {
   const matchResult = matcher(rawStr, LINK_REG);


### PR DESCRIPTION
Fixes #1162 by updating the link regex to pick up edge case with parentheses