### PR TITLE
fix: action button container not overflowing memo

### DIFF
--- a/web/src/less/memo.less
+++ b/web/src/less/memo.less
@@ -1,5 +1,5 @@
 .memo-wrapper {
-  @apply relative flex flex-col justify-start items-start w-full p-4 pt-3 mt-2 bg-white dark:bg-zinc-700 rounded-lg border border-white dark:border-zinc-600 hover:border-gray-200 dark:hover:border-zinc-600 overflow-hidden;
+  @apply relative flex flex-col justify-start items-start w-full p-4 pt-3 mt-2 bg-white dark:bg-zinc-700 rounded-lg border border-white dark:border-zinc-600 hover:border-gray-200 dark:hover:border-zinc-600;
 
   &.pinned {
     @apply border-gray-200 border-2 dark:border-zinc-600;
@@ -13,7 +13,7 @@
     @apply absolute top-0 right-0 z-1;
 
     &::after {
-      @apply absolute top-0 right-0 border-transparent border-t-green-600 border-r-green-600;
+      @apply absolute top-0 right-0 border-transparent border-t-green-600 border-r-green-600 rounded-tr;
       content: "";
       border-width: 6px;
     }


### PR DESCRIPTION
Fixes #1217 by removing hidden overflow on memo-wrapper and adding top right border-radius to corner container.