### PR TITLE
feat: add `HostnameImmutable` to aws endpoint config

### DIFF
--- a/plugin/storage/s3/s3.go
+++ b/plugin/storage/s3/s3.go
@@ -32,8 +32,8 @@ func NewClient(ctx context.Context, config *Config) (*Client, error) {
 		return aws.Endpoint{
 			URL:           config.EndPoint,
 			SigningRegion: config.Region,
-			//For some s3-compatible object stores, converting the hostname is not required,
-			//and not setting this option will result in not being able to access the corresponding object store address.
+			// For some s3-compatible object stores, converting the hostname is not required,
+			// and not setting this option will result in not being able to access the corresponding object store address.
 			HostnameImmutable: true,
 		}, nil
 	})

--- a/plugin/storage/s3/s3.go
+++ b/plugin/storage/s3/s3.go
@@ -30,8 +30,10 @@ type Client struct {
 func NewClient(ctx context.Context, config *Config) (*Client, error) {
 	resolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
 		return aws.Endpoint{
-			URL:               config.EndPoint,
-			SigningRegion:     config.Region,
+			URL:           config.EndPoint,
+			SigningRegion: config.Region,
+			//For some s3-compatible object stores, converting the hostname is not required,
+			//and not setting this option will result in not being able to access the corresponding object store address.
 			HostnameImmutable: true,
 		}, nil
 	})

--- a/plugin/storage/s3/s3.go
+++ b/plugin/storage/s3/s3.go
@@ -30,8 +30,9 @@ type Client struct {
 func NewClient(ctx context.Context, config *Config) (*Client, error) {
 	resolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
 		return aws.Endpoint{
-			URL:           config.EndPoint,
-			SigningRegion: config.Region,
+			URL:               config.EndPoint,
+			SigningRegion:     config.Region,
+			HostnameImmutable: true,
 		}, nil
 	})
 


### PR DESCRIPTION
When uploading files without the old config.  Server url like "https://minio.test.com" would be converted to "https://bucketname.minio.test.com". For the self-host minio instance, the upload would get errors. With this config enabled, everything would just work perfectly! 

some resource related: https://stackoverflow.com/questions/67575681/is-aws-go-sdk-v2-integrated-with-local-minio-server