### PR TITLE
use $PWD/memos for docker compose volume dir

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,6 @@ services:
     image: neosmemo/memos:latest
     container_name: memos
     volumes:
-      - ~/.memos/:/var/opt/memos
+      - ./memos/:/var/opt/memos
     ports:
       - 5230:5230


### PR DESCRIPTION
`~/.memos` might not be a friendly dir for maintenance. Use some path in the current working directory instead. 