### PR TITLE
use $PWD/memos-data as default docker volume path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ build
 .idea
 
 bin/air
+
+# docker volume
+memos-data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,6 @@ services:
     image: neosmemo/memos:latest
     container_name: memos
     volumes:
-      - ~/.memos/:/var/opt/memos
+      - ./memos-data/memos:/var/opt/memos
     ports:
       - 5230:5230


### PR DESCRIPTION
`~/.memos` might not be a path friendly for maintenance. It's likely that the db will be simply forgotten in the home folder. 

Using `./memos-data` could be a better idea. 