### PR TITLE
add support for s3 path

### DIFF
--- a/api/storage.go
+++ b/api/storage.go
@@ -12,6 +12,7 @@ type StorageConfig struct {
 
 type StorageS3Config struct {
 	EndPoint  string `json:"endPoint"`
+	Path      string `json:"path"`
 	Region    string `json:"region"`
 	AccessKey string `json:"accessKey"`
 	SecretKey string `json:"secretKey"`

--- a/plugin/storage/s3/s3.go
+++ b/plugin/storage/s3/s3.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	s3config "github.com/aws/aws-sdk-go-v2/config"
@@ -56,7 +57,7 @@ func (client *Client) UploadFile(ctx context.Context, filename string, fileType 
 	uploader := manager.NewUploader(client.Client)
 	uploadOutput, err := uploader.Upload(ctx, &awss3.PutObjectInput{
 		Bucket:      aws.String(client.Config.Bucket),
-		Key:         aws.String(client.Config.Path + filename),
+		Key:         aws.String(path.Join(client.Config.Path, filename)),
 		Body:        src,
 		ContentType: aws.String(fileType),
 		ACL:         types.ObjectCannedACL(*aws.String("public-read")),

--- a/plugin/storage/s3/s3.go
+++ b/plugin/storage/s3/s3.go
@@ -18,6 +18,7 @@ type Config struct {
 	SecretKey string
 	Bucket    string
 	EndPoint  string
+	Path      string
 	Region    string
 	URLPrefix string
 }
@@ -55,7 +56,7 @@ func (client *Client) UploadFile(ctx context.Context, filename string, fileType 
 	uploader := manager.NewUploader(client.Client)
 	uploadOutput, err := uploader.Upload(ctx, &awss3.PutObjectInput{
 		Bucket:      aws.String(client.Config.Bucket),
-		Key:         aws.String(filename),
+		Key:         aws.String(client.Config.Path + filename),
 		Body:        src,
 		ContentType: aws.String(fileType),
 		ACL:         types.ObjectCannedACL(*aws.String("public-read")),

--- a/server/resource.go
+++ b/server/resource.go
@@ -139,6 +139,7 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 					AccessKey: s3Config.AccessKey,
 					SecretKey: s3Config.SecretKey,
 					EndPoint:  s3Config.EndPoint,
+					Path:      s3Config.Path,
 					Region:    s3Config.Region,
 					Bucket:    s3Config.Bucket,
 					URLPrefix: s3Config.URLPrefix,

--- a/web/src/components/CreateStorageServiceDialog.tsx
+++ b/web/src/components/CreateStorageServiceDialog.tsx
@@ -173,17 +173,6 @@ const CreateStorageServiceDialog: React.FC<Props> = (props: Props) => {
         />
         <Typography className="!mb-1" level="body2">
           Bucket
-          <span className="text-sm text-gray-400 ml-1">(Storage Path)</span>
-        </Typography>
-        <Input
-          className="mb-2"
-          placeholder="Path"
-          value={s3Config.path}
-          onChange={(e) => setPartialS3Config({ path: e.target.value })}
-          fullWidth
-        />
-        <Typography className="!mb-1" level="body2">
-          Bucket
           <span className="text-sm text-gray-400 ml-1">(Bucket name)</span>
         </Typography>
         <Input
@@ -191,6 +180,17 @@ const CreateStorageServiceDialog: React.FC<Props> = (props: Props) => {
           placeholder="Bucket"
           value={s3Config.bucket}
           onChange={(e) => setPartialS3Config({ bucket: e.target.value })}
+          fullWidth
+        />
+        <Typography className="!mb-1" level="body2">
+          Path
+          <span className="text-sm text-gray-400 ml-1">(Storage Path)</span>
+        </Typography>
+        <Input
+          className="mb-2"
+          placeholder="Path"
+          value={s3Config.path}
+          onChange={(e) => setPartialS3Config({ path: e.target.value })}
           fullWidth
         />
         <Typography className="!mb-1" level="body2">

--- a/web/src/components/CreateStorageServiceDialog.tsx
+++ b/web/src/components/CreateStorageServiceDialog.tsx
@@ -21,6 +21,7 @@ const CreateStorageServiceDialog: React.FC<Props> = (props: Props) => {
     region: "",
     accessKey: "",
     secretKey: "",
+    path: "",
     bucket: "",
     urlPrefix: "",
   });
@@ -168,6 +169,17 @@ const CreateStorageServiceDialog: React.FC<Props> = (props: Props) => {
           placeholder="SecretKey"
           value={s3Config.secretKey}
           onChange={(e) => setPartialS3Config({ secretKey: e.target.value })}
+          fullWidth
+        />
+        <Typography className="!mb-1" level="body2">
+          Bucket
+          <span className="text-sm text-gray-400 ml-1">(Storage Path)</span>
+        </Typography>
+        <Input
+          className="mb-2"
+          placeholder="Path"
+          value={s3Config.path}
+          onChange={(e) => setPartialS3Config({ path: e.target.value })}
           fullWidth
         />
         <Typography className="!mb-1" level="body2">

--- a/web/src/types/modules/storage.d.ts
+++ b/web/src/types/modules/storage.d.ts
@@ -7,6 +7,7 @@ interface StorageS3Config {
   region: string;
   accessKey: string;
   secretKey: string;
+  path: string;
   bucket: string;
   urlPrefix: string;
 }


### PR DESCRIPTION
This pr added support for the s3 path.

If you want to upload your images to like `image` folder, you can set path variable to `path/`. (default value will be empty)