### PR TITLE
fix: missing prop key

### DIFF
--- a/web/src/labs/marked/parser/Br.tsx
+++ b/web/src/labs/marked/parser/Br.tsx
@@ -4,7 +4,7 @@ const renderer = (rawStr: string) => {
   const length = rawStr.split("\n").length - 1;
   const brList = [];
   for (let i = 0; i < length; i++) {
-    brList.push(<br />);
+    brList.push(<br key={i} />);
   }
   return <>{...brList}</>;
 };


### PR DESCRIPTION
fix warning due to parser br  missing prop key

<img width="583" alt="image" src="https://user-images.githubusercontent.com/14177215/223056029-7a7746c3-2781-4d31-a2ed-644283875c9a.png">

[lists-and-keys.html#keys](https://reactjs.org/docs/lists-and-keys.html#keys)