### PR TITLE
fix: navigate faild silently

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^18.2.0",
     "react-i18next": "^11.18.6",
     "react-redux": "^8.0.1",
-    "react-router-dom": "^6.4.0",
+    "react-router-dom": "^6.8.2",
     "semver": "^7.3.8",
     "tailwindcss": "^3.2.4"
   },

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,7 +2,7 @@ import { resolve } from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 
-const devProxyServer = "https://memos.flyneko.com/";
+const devProxyServer = "http://localhost:8081/";
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,7 +2,7 @@ import { resolve } from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 
-const devProxyServer = "http://localhost:8081/";
+const devProxyServer = "https://memos.flyneko.com/";
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -482,10 +482,10 @@
     redux-thunk "^2.4.2"
     reselect "^4.1.7"
 
-"@remix-run/router@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.3.0.tgz#b6ee542c7f087b73b3d8215b9bf799f648be71cb"
-  integrity sha512-nwQoYb3m4DDpHTeOwpJEuDt8lWVcujhYYSFGLluC+9es2PyLjm+jjq3IeRBQbwBtPLJE/lkuHuGHr8uQLgmJRA==
+"@remix-run/router@1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.3.3.tgz#d6d531d69c0fa3a44fda7dc00b20d49b44549164"
+  integrity sha512-YRHie1yQEj0kqqCTCJEfHqYSSNlZQ696QJG+MMiW4mxSl9I0ojz/eRhJS4fs88Z5i6D1SmoF9d3K99/QOhI8/w==
 
 "@swc/core-darwin-arm64@1.3.28":
   version "1.3.28"
@@ -2451,20 +2451,20 @@ react-redux@^8.0.1:
     react-is "^18.0.0"
     use-sync-external-store "^1.0.0"
 
-react-router-dom@^6.4.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.7.0.tgz#0249f4ca4eb704562b8b0ff29caeb928c3a6ed38"
-  integrity sha512-jQtXUJyhso3kFw430+0SPCbmCmY1/kJv8iRffGHwHy3CkoomGxeYzMkmeSPYo6Egzh3FKJZRAL22yg5p2tXtfg==
+react-router-dom@^6.8.2:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.8.2.tgz#a6654a3400be9aafd504d7125573568921b78b57"
+  integrity sha512-N/oAF1Shd7g4tWy+75IIufCGsHBqT74tnzHQhbiUTYILYF0Blk65cg+HPZqwC+6SqEyx033nKqU7by38v3lBZg==
   dependencies:
-    "@remix-run/router" "1.3.0"
-    react-router "6.7.0"
+    "@remix-run/router" "1.3.3"
+    react-router "6.8.2"
 
-react-router@6.7.0:
-  version "6.7.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.7.0.tgz#db262684c13b5c2970694084ae9e8531718a0681"
-  integrity sha512-KNWlG622ddq29MAM159uUsNMdbX8USruoKnwMMQcs/QWZgFUayICSn2oB7reHce1zPj6CG18kfkZIunSSRyGHg==
+react-router@6.8.2:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.8.2.tgz#98f83582a73f316a3287118b440f0cee30ed6f33"
+  integrity sha512-lF7S0UmXI5Pd8bmHvMdPKI4u4S5McxmHnzJhrYi9ZQ6wE+DA8JN5BzVC5EEBuduWWDaiJ8u6YhVOCmThBli+rw==
   dependencies:
-    "@remix-run/router" "1.3.0"
+    "@remix-run/router" "1.3.3"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
reproduce:  navigate from the home page /  to /explore, then use the browser back button, navigate action will be failed and show a  warning console log.
![V4a2PecCGD](https://user-images.githubusercontent.com/14177215/223294169-ecd1c2d0-8843-4a1b-af33-7c7a07283f53.jpg)



how to fix: upgrade the react-router version above 6.8.1.

[react-router issue #9998](https://github.com/remix-run/react-router/issues/9998)