### PR TITLE
fix: Update markdown hyperlink regex

### DIFF
--- a/web/src/labs/marked/parser/Link.tsx
+++ b/web/src/labs/marked/parser/Link.tsx
@@ -6,7 +6,7 @@ import BoldEmphasis from "./BoldEmphasis";
 import PlainText from "./PlainText";
 import { matcher } from "../matcher";
 
-export const LINK_REG = /\[(.*?)\]\((.+?)\)+/;
+export const LINK_REG = /\[([^\]]+)\]\(([^\)]+)\)/;
 
 const renderer = (rawStr: string) => {
   const matchResult = matcher(rawStr, LINK_REG);

--- a/web/src/labs/marked/parser/Link.tsx
+++ b/web/src/labs/marked/parser/Link.tsx
@@ -6,7 +6,7 @@ import BoldEmphasis from "./BoldEmphasis";
 import PlainText from "./PlainText";
 import { matcher } from "../matcher";
 
-export const LINK_REG = /\[([^\]]+)\]\(([^\)]+)\)/;
+export const LINK_REG = /\[([^\]]+)\]\(([^)]+)\)/;
 
 const renderer = (rawStr: string) => {
   const matchResult = matcher(rawStr, LINK_REG);


### PR DESCRIPTION
Hey, I had the same issue as in #1162 and I noticed that the fix was revert. Here's my PR to fix the issue.

Before:
![2023-03-08_15-28](https://user-images.githubusercontent.com/32563450/223745099-8251ec0d-390e-4857-bd5e-aee40d1ff04a.png)

After:
![image](https://user-images.githubusercontent.com/32563450/223745177-4c927c51-9072-4c9e-a3ed-efbbfe4c4380.png)
