### PR TITLE
fix: unified tag sorting logic

### DIFF
--- a/web/src/components/CreateTagDialog.tsx
+++ b/web/src/components/CreateTagDialog.tsx
@@ -103,15 +103,17 @@ const CreateTagDialog: React.FC<Props> = (props: Props) => {
           <>
             <p className="w-full mt-2 mb-1 text-sm text-gray-400">All tags</p>
             <div className="w-full flex flex-row justify-start items-start flex-wrap">
-              {tagNameList.map((tag) => (
-                <span
-                  className="max-w-[120px] text-sm mr-2 mt-1 font-mono cursor-pointer truncate dark:text-gray-300 hover:opacity-60 hover:line-through"
-                  key={tag}
-                  onClick={() => handleDeleteTag(tag)}
-                >
-                  #{tag}
-                </span>
-              ))}
+              {Array.from(tagNameList)
+                .sort()
+                .map((tag) => (
+                  <span
+                    className="max-w-[120px] text-sm mr-2 mt-1 font-mono cursor-pointer truncate dark:text-gray-300 hover:opacity-60 hover:line-through"
+                    key={tag}
+                    onClick={() => handleDeleteTag(tag)}
+                  >
+                    #{tag}
+                  </span>
+                ))}
             </div>
           </>
         )}


### PR DESCRIPTION
current behavior

<img width="552" alt="image" src="https://user-images.githubusercontent.com/14177215/223897507-4f31018b-9658-4bce-b000-df5389495cb1.png">

the tag list widget logic

<img width="507" alt="image" src="https://user-images.githubusercontent.com/14177215/223897622-bc4a9a89-44ce-42e6-9f64-e81fc560bd0b.png">
