### PR TITLE
chore: ignore inappropriate files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ web/dist
 
 # build folder
 build
+memos
+memos_demo.db
 
 .DS_Store
 


### PR DESCRIPTION
When I execute the memos from the code, the memo backend generates two files: a binary program called "memos" and a database file called "memos_demo.db". Git then prompts me to add these files. However, these files should not be managed by Git. Therefore, I have added them to .gitignore.