### PR TITLE
fix: the incorrectly height of grid row in safari

### DIFF
--- a/web/src/pages/ResourcesDashboard.tsx
+++ b/web/src/pages/ResourcesDashboard.tsx
@@ -141,7 +141,7 @@ const ResourcesDashboard = () => {
               <p className="w-full text-center text-base my-6 mt-8">{t("resources.fetching-data")}</p>
             </div>
           ) : (
-            <div className="w-full h-full grid grid-cols-2 md:grid-cols-4 md:px-6 gap-6">
+            <div className="w-full h-auto grid grid-cols-2 md:grid-cols-4 md:px-6 gap-6">
               {resources.length === 0 ? (
                 <p className="w-full text-center text-base my-6 mt-8">{t("resources.no-resources")}</p>
               ) : (


### PR DESCRIPTION
There is bug in the resource dashboard. 
![CS_2023-03-15_at_23 19 412x](https://user-images.githubusercontent.com/29306285/225827029-16009d3d-9558-44c3-ba97-8094e7dcc1f4.png)
![CS_2023-03-17_at_13 27 432x](https://user-images.githubusercontent.com/29306285/225827037-90cfeedf-be62-49db-880e-b7e17a252f0a.png)

The bug cause the incorrectly calc for grid row height in safari. to fix it using `h-auto` intead of  `h-full` in container div.

fixed
<img width="684" alt="CS_2023-03-17_at_14 17 39@2x" src="https://user-images.githubusercontent.com/29306285/225827666-8c09162c-7f63-4f01-bc81-7c15fdab5c88.png">
