### PR TITLE
feat: add URLSuffix resource option with S3

### DIFF
--- a/api/storage.go
+++ b/api/storage.go
@@ -18,6 +18,7 @@ type StorageS3Config struct {
 	SecretKey string `json:"secretKey"`
 	Bucket    string `json:"bucket"`
 	URLPrefix string `json:"urlPrefix"`
+	URLSuffix string `json:"urlSuffix"`
 }
 
 type Storage struct {

--- a/plugin/storage/s3/s3.go
+++ b/plugin/storage/s3/s3.go
@@ -20,6 +20,7 @@ type Config struct {
 	EndPoint  string
 	Region    string
 	URLPrefix string
+	URLSuffix string
 }
 
 type Client struct {
@@ -67,7 +68,7 @@ func (client *Client) UploadFile(ctx context.Context, filename string, fileType 
 	link := uploadOutput.Location
 	// If url prefix is set, use it as the file link.
 	if client.Config.URLPrefix != "" {
-		link = fmt.Sprintf("%s/%s", client.Config.URLPrefix, filename)
+		link = fmt.Sprintf("%s/%s%s", client.Config.URLPrefix, filename, client.Config.URLSuffix)
 	}
 	if link == "" {
 		return "", fmt.Errorf("failed to get file link")

--- a/server/resource.go
+++ b/server/resource.go
@@ -194,6 +194,7 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 					Region:    s3Config.Region,
 					Bucket:    s3Config.Bucket,
 					URLPrefix: s3Config.URLPrefix,
+					URLSuffix: s3Config.URLSuffix,
 				})
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to new s3 client").SetInternal(err)

--- a/web/src/components/CreateStorageServiceDialog.tsx
+++ b/web/src/components/CreateStorageServiceDialog.tsx
@@ -228,7 +228,7 @@ const CreateStorageServiceDialog: React.FC<Props> = (props: Props) => {
         </Typography>
         <Input
             className="mb-2"
-            placeholder="URLPrefix"
+            placeholder="URLSuffix"
             value={s3Config.urlSuffix}
             onChange={(e) => setPartialS3Config({ urlSuffix: e.target.value })}
             fullWidth

--- a/web/src/components/CreateStorageServiceDialog.tsx
+++ b/web/src/components/CreateStorageServiceDialog.tsx
@@ -25,6 +25,7 @@ const CreateStorageServiceDialog: React.FC<Props> = (props: Props) => {
     path: "",
     bucket: "",
     urlPrefix: "",
+    urlSuffix: "",
   });
   const isCreating = storage === undefined;
 
@@ -220,6 +221,17 @@ const CreateStorageServiceDialog: React.FC<Props> = (props: Props) => {
           value={s3Config.urlPrefix}
           onChange={(e) => setPartialS3Config({ urlPrefix: e.target.value })}
           fullWidth
+        />
+        <Typography className="!mb-1" level="body2">
+          URLSuffix
+          <span className="text-sm text-gray-400 ml-1">(Custom URL suffix; Optional)</span>
+        </Typography>
+        <Input
+            className="mb-2"
+            placeholder="URLPrefix"
+            value={s3Config.urlSuffix}
+            onChange={(e) => setPartialS3Config({ urlSuffix: e.target.value })}
+            fullWidth
         />
         <div className="mt-2 w-full flex flex-row justify-end items-center space-x-1">
           <Button variant="plain" color="neutral" onClick={handleCloseBtnClick}>

--- a/web/src/components/CreateStorageServiceDialog.tsx
+++ b/web/src/components/CreateStorageServiceDialog.tsx
@@ -227,11 +227,11 @@ const CreateStorageServiceDialog: React.FC<Props> = (props: Props) => {
           <span className="text-sm text-gray-400 ml-1">(Custom URL suffix; Optional)</span>
         </Typography>
         <Input
-            className="mb-2"
-            placeholder="URLSuffix"
-            value={s3Config.urlSuffix}
-            onChange={(e) => setPartialS3Config({ urlSuffix: e.target.value })}
-            fullWidth
+          className="mb-2"
+          placeholder="URLSuffix"
+          value={s3Config.urlSuffix}
+          onChange={(e) => setPartialS3Config({ urlSuffix: e.target.value })}
+          fullWidth
         />
         <div className="mt-2 w-full flex flex-row justify-end items-center space-x-1">
           <Button variant="plain" color="neutral" onClick={handleCloseBtnClick}>

--- a/web/src/types/modules/storage.d.ts
+++ b/web/src/types/modules/storage.d.ts
@@ -10,6 +10,7 @@ interface StorageS3Config {
   path: string;
   bucket: string;
   urlPrefix: string;
+  urlSuffix: string;
 }
 
 interface StorageConfig {


### PR DESCRIPTION
If using mobile app upload image, original image is very large

Aliyun OSS supports image processing, compression, and only needs to add a suffix, so add this option

```
{URLPrefix}/{filename}{URLSuffix}
https://xxx.com/test.png?x-oss-process=image/resize,h_100,m_lfit
```
https://help.aliyun.com/document_detail/183902.html