### PR TITLE
feat: allow instance moderators to post public via the API

### DIFF
--- a/server/memo.go
+++ b/server/memo.go
@@ -64,7 +64,18 @@ func (s *Server) registerMemoRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to unmarshal system setting").SetInternal(err)
 			}
 			if disablePublicMemos {
-				memoCreate.Visibility = api.Private
+				// Allow if the user is an admin.
+				userobj, err := s.Store.FindUser(ctx, &api.UserFind{
+					ID: &userID,
+				})
+				if err != nil {
+					return echo.NewHTTPError(http.StatusInternalServerError, "Something went horribly wrong - Failed to locate user (but user settings object was found before).").SetInternal(err)
+				}
+				// Only enforce private if you're a regular user.
+				// Admins should know what they're doing.
+				if userobj.Role == "USER" {
+					memoCreate.Visibility = api.Private
+				}
 			}
 		}
 

--- a/server/memo.go
+++ b/server/memo.go
@@ -65,15 +65,15 @@ func (s *Server) registerMemoRoutes(g *echo.Group) {
 			}
 			if disablePublicMemos {
 				// Allow if the user is an admin.
-				userobj, err := s.Store.FindUser(ctx, &api.UserFind{
+				user, err := s.Store.FindUser(ctx, &api.UserFind{
 					ID: &userID,
 				})
 				if err != nil {
-					return echo.NewHTTPError(http.StatusInternalServerError, "Something went horribly wrong - Failed to locate user (but user settings object was found before).").SetInternal(err)
+					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to find user").SetInternal(err)
 				}
 				// Only enforce private if you're a regular user.
 				// Admins should know what they're doing.
-				if userobj.Role == "USER" {
+				if user.Role == "USER" {
 					memoCreate.Visibility = api.Private
 				}
 			}


### PR DESCRIPTION
Something that I noticed on my instance was that I needed to lock users from posting publically, but didn't want to prevent my moderators from doing so. This patch allows moderators to bypass the visibility: private enforcement.