### PR TITLE
fix(css): reorder the font fallback list (#1495)

### DIFF
--- a/web/src/css/global.css
+++ b/web/src/css/global.css
@@ -1,9 +1,9 @@
 html,
 body {
   @apply text-base w-full h-full dark:bg-zinc-800;
-  font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Noto Sans", "Noto Sans CJK SC", "Microsoft YaHei UI", "Microsoft YaHei",
-    "WenQuanYi Micro Hei", sans-serif, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-    "Noto Color Emoji";
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Noto Sans", "Noto Sans CJK SC",
+    "Microsoft YaHei UI", "Microsoft YaHei", "WenQuanYi Micro Hei", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji",
+    sans-serif;
 }
 
 #root {


### PR DESCRIPTION
This PR fixes #1495.

Now the font fallback list looks like:

- [system-ui](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#:~:text=MT%2C%20Harrington%2C%20fantasy.-,system%2Dui,-Glyphs%20are%20taken)
- Common western fonts (e.g. Helvetica, Arial, etc)
- Common Chinese fonts
- Emoji and symbols fonts
- [sans-serif](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#:~:text=URW%20Palladio%2C%20serif.-,sans%2Dserif,-Glyphs%20have%20stroke)