### PR TITLE
feat(ci): Add GHCR mirror and major/minor rolling tags

### DIFF
--- a/.github/workflows/build-and-push-release-image.yml
+++ b/.github/workflows/build-and-push-release-image.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-and-push-release-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-and-push-release-image.yml
+++ b/.github/workflows/build-and-push-release-image.yml
@@ -27,12 +27,29 @@ jobs:
           username: neosmemo
           password: ${{ secrets.DOCKER_NEOSMEMO_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
         with:
           install: true
           version: v0.9.1
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            neosmemo/memos
+            ghcr.io/usememos/memos
+          tags: |
+            type=semver,pattern={{version}}
 
       - name: Build and Push
         id: docker_build
@@ -42,4 +59,5 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: neosmemo/memos:latest, neosmemo/memos:${{ env.VERSION }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-and-push-release-image.yml
+++ b/.github/workflows/build-and-push-release-image.yml
@@ -50,6 +50,8 @@ jobs:
             ghcr.io/usememos/memos
           tags: |
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Build and Push
         id: docker_build

--- a/.github/workflows/build-and-push-test-image.yml
+++ b/.github/workflows/build-and-push-test-image.yml
@@ -19,12 +19,31 @@ jobs:
           username: neosmemo
           password: ${{ secrets.DOCKER_NEOSMEMO_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
         with:
           install: true
           version: v0.9.1
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            neosmemo/memos
+            ghcr.io/usememos/memos
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=test
 
       - name: Build and Push
         id: docker_build
@@ -34,4 +53,5 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: neosmemo/memos:test
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-and-push-test-image.yml
+++ b/.github/workflows/build-and-push-test-image.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build-and-push-test-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This PR will add a GHCR container image mirror during the test and release CI jobs.

Fixes #1502.

After merging this PR, release images will also contain a major and minor tag, so `v0.12.1` will be available at `0.12.1`, `0.12`, `0`. This is useful for users that want to pin the major or minor version, but don't care about the current patch version.

### After Merge

The package repository will be created automatically during the first run, but may default to `private` visibility. If so, you will need to:

1. Go to https://ghcr.io/usememos/memos
2. Package Settings
3. Change package visibility
4. Set to `Public`

After changing visibility, I'd also suggest that you go to this repo's homepage, click the settings cog on the right, then enable `Packages` on the homepage.