### PR TITLE
fix(ci): fix release builds not having any tags

### DIFF
--- a/.github/workflows/build-and-push-release-image.yml
+++ b/.github/workflows/build-and-push-release-image.yml
@@ -52,9 +52,10 @@ jobs:
             neosmemo/memos
             ghcr.io/usememos/memos
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=raw,value=latest
+            type=semver,pattern={{version}},value=${{ env.VERSION }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ env.VERSION }}
+            type=semver,pattern={{major}},value=${{ env.VERSION }}
 
       - name: Build and Push
         id: docker_build


### PR DESCRIPTION
My previous PR #1503 used the git tag to determine the Docker tags, but it should have used the git branch. This PR will fix that! Sorry for the trouble