### PR TITLE
Unexpected empty lines when copying-pasting #563

### DIFF
--- a/web/src/components/Editor/Editor.tsx
+++ b/web/src/components/Editor/Editor.tsx
@@ -24,7 +24,7 @@ interface Props {
 }
 
 const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<EditorRefActions>) {
-  const { className, initialContent, placeholder, fullscreen, onContentChange: handleContentChangeCallback } = props;
+  const { className, initialContent, placeholder, fullscreen, onPaste, onContentChange: handleContentChangeCallback } = props;
   const editorRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -119,19 +119,6 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
     []
   );
 
-  const handlePaste = (event: React.ClipboardEvent) => {
-    event.preventDefault();
-    const pastedText = event.clipboardData.getData("text");
-    const currentCursorPosition = editorRef.current?.selectionStart ?? 0;
- 
-    if (editorRef.current) {
-      editorRef.current.value = editorRef.current.value.slice(0, currentCursorPosition) + pastedText + editorRef.current.value.slice(editorRef.current.selectionEnd);
-      editorRef.current.selectionStart = editorRef.current.selectionEnd = currentCursorPosition + pastedText.length;
-      handleContentChangeCallback(editorRef.current.value);
-      updateEditorHeight();
-    }
-  };
-
   const handleEditorInput = useCallback(() => {
     handleContentChangeCallback(editorRef.current?.value ?? "");
     updateEditorHeight();
@@ -144,7 +131,7 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
         rows={1}
         placeholder={placeholder}
         ref={editorRef}
-        onPaste={handlePaste}
+        onPaste={onPaste}
         onInput={handleEditorInput}
       ></textarea>
     </div>

--- a/web/src/components/Editor/Editor.tsx
+++ b/web/src/components/Editor/Editor.tsx
@@ -24,7 +24,7 @@ interface Props {
 }
 
 const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<EditorRefActions>) {
-  const { className, initialContent, placeholder, fullscreen, onPaste, onContentChange: handleContentChangeCallback } = props;
+  const { className, initialContent, placeholder, fullscreen, onContentChange: handleContentChangeCallback } = props;
   const editorRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -119,6 +119,19 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
     []
   );
 
+  const handlePaste = (event: React.ClipboardEvent) => {
+    event.preventDefault();
+    const pastedText = event.clipboardData.getData("text");
+    const currentCursorPosition = editorRef.current?.selectionStart ?? 0;
+ 
+    if (editorRef.current) {
+      editorRef.current.value = editorRef.current.value.slice(0, currentCursorPosition) + pastedText + editorRef.current.value.slice(editorRef.current.selectionEnd);
+      editorRef.current.selectionStart = editorRef.current.selectionEnd = currentCursorPosition + pastedText.length;
+      handleContentChangeCallback(editorRef.current.value);
+      updateEditorHeight();
+    }
+  };
+
   const handleEditorInput = useCallback(() => {
     handleContentChangeCallback(editorRef.current?.value ?? "");
     updateEditorHeight();
@@ -131,7 +144,7 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
         rows={1}
         placeholder={placeholder}
         ref={editorRef}
-        onPaste={onPaste}
+        onPaste={handlePaste}
         onInput={handleEditorInput}
       ></textarea>
     </div>

--- a/web/src/components/MemoContent.tsx
+++ b/web/src/components/MemoContent.tsx
@@ -69,7 +69,7 @@ const MemoContent: React.FC<Props> = (props: Props) => {
     const rawStr = (event.target as HTMLElement).innerText;
     const code = event.which || event.keyCode;
 
-    let charCode = String.fromCharCode(code).toLowerCase();
+    const charCode = String.fromCharCode(code).toLowerCase();
     if ((event.ctrlKey || event.metaKey) && charCode === "c") {
       const splitString = rawStr.split("\n\n");
       const brList = [];

--- a/web/src/components/MemoContent.tsx
+++ b/web/src/components/MemoContent.tsx
@@ -64,26 +64,26 @@ const MemoContent: React.FC<Props> = (props: Props) => {
     });
   };
 
-  const handleKeyDown =  (event: React.KeyboardEvent<HTMLInputElement>)=>{
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     event.preventDefault();
     const rawStr = (event.target as HTMLElement).innerText;
     const code = event.which || event.keyCode;
 
     let charCode = String.fromCharCode(code).toLowerCase();
-    if ((event.ctrlKey || event.metaKey) && charCode === 'c'){
+    if ((event.ctrlKey || event.metaKey) && charCode === "c") {
       const splitString = rawStr.split("\n\n");
       const brList = [];
       for (let i = 0; i < splitString.length; i++) {
-        brList.push(splitString[i])
-        if(i!==splitString.length-1){
-          brList.push("\n")
+        brList.push(splitString[i]);
+        if (i !== splitString.length - 1) {
+          brList.push("\n");
         }
       }
-    const text = brList.join("")
-    copy(text);
+      const text = brList.join("");
+      copy(text);
     }
-  }
-  
+  };
+
   return (
     <div className={`memo-content-wrapper ${className || ""}`}>
       <div
@@ -91,7 +91,7 @@ const MemoContent: React.FC<Props> = (props: Props) => {
         className={`memo-content-text ${state.expandButtonStatus === 0 ? "max-h-64 overflow-y-hidden" : ""}`}
         onClick={handleMemoContentClick}
         onDoubleClick={handleMemoContentDoubleClick}
-        onKeyDown={handleKeyDown} 
+        onKeyDown={handleKeyDown}
         tabIndex={0}
       >
         {marked(content)}

--- a/web/src/components/MemoContent.tsx
+++ b/web/src/components/MemoContent.tsx
@@ -1,3 +1,4 @@
+import copy from "copy-to-clipboard";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { marked } from "@/labs/marked";
@@ -63,6 +64,26 @@ const MemoContent: React.FC<Props> = (props: Props) => {
     });
   };
 
+  const handleKeyDown =  (event: React.KeyboardEvent<HTMLInputElement>)=>{
+    event.preventDefault();
+    const rawStr = (event.target as HTMLElement).innerText;
+    const code = event.which || event.keyCode;
+
+    let charCode = String.fromCharCode(code).toLowerCase();
+    if ((event.ctrlKey || event.metaKey) && charCode === 'c'){
+      const splitString = rawStr.split("\n\n");
+      const brList = [];
+      for (let i = 0; i < splitString.length; i++) {
+        brList.push(splitString[i])
+        if(i!==splitString.length-1){
+          brList.push("\n")
+        }
+      }
+    const text = brList.join("")
+    copy(text);
+    }
+  }
+  
   return (
     <div className={`memo-content-wrapper ${className || ""}`}>
       <div
@@ -70,6 +91,8 @@ const MemoContent: React.FC<Props> = (props: Props) => {
         className={`memo-content-text ${state.expandButtonStatus === 0 ? "max-h-64 overflow-y-hidden" : ""}`}
         onClick={handleMemoContentClick}
         onDoubleClick={handleMemoContentDoubleClick}
+        onKeyDown={handleKeyDown} 
+        tabIndex={0}
       >
         {marked(content)}
       </div>


### PR DESCRIPTION
I looked into the issue and I found out when you copy from the memos using keyboard it added an extra line between lines, so what I did was manipulating the innerText when copying using crtl+c and removing the extra line added. looking forward to your feedback.
