### PR TITLE
chore: remove search key binding

### DIFF
--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -1,36 +1,14 @@
 import { useEffect, useState, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import useDebounce from "@/hooks/useDebounce";
-import { useFilterStore, useDialogStore } from "@/store/module";
+import { useFilterStore } from "@/store/module";
 import Icon from "./Icon";
 
 const SearchBar = () => {
   const { t } = useTranslation();
   const filterStore = useFilterStore();
-  const dialogStore = useDialogStore();
   const [queryText, setQueryText] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (!inputRef.current) {
-        return;
-      }
-      if (dialogStore.getState().dialogStack.length) {
-        return;
-      }
-      const isMetaKey = event.ctrlKey || event.metaKey;
-      if (isMetaKey && event.key === "f") {
-        event.preventDefault();
-        inputRef.current.focus();
-        return;
-      }
-    };
-    document.body.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.body.removeEventListener("keydown", handleKeyDown);
-    };
-  }, []);
 
   useEffect(() => {
     const text = filterStore.getState().text;


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0fc08ad</samp>

### Summary
🗑️🛠️🧹

<!--
1.  🗑️ - This emoji conveys the idea of deleting or removing something, which is what happened to the keyboard shortcut logic and the unused imports and variables.
2.  🛠️ - This emoji suggests fixing or improving something, which is what the goal of avoiding browser conflicts and enhancing user experience was.
3.  🧹 - This emoji implies cleaning or tidying up something, which is what the simplification of the component code achieved.
-->
Refactored `SearchBar` component to remove keyboard shortcuts and clean up code.

> _Sing, O Muse, of the skillful coder who refined_
> _The `SearchBar` component, and freed it from the bind_
> _Of keyboard shortcuts that clashed with browsers and annoyed_
> _The users, who the graceful code now better enjoyed._

### Walkthrough
* Remove keyboard shortcut logic from `SearchBar` component ([link](https://github.com/usememos/memos/pull/1536/files?diff=unified&w=0#diff-81f484299a9c306101779976f6d00e31402b948f788dbe263f1ed88285037e77L4-R4), [link](https://github.com/usememos/memos/pull/1536/files?diff=unified&w=0#diff-81f484299a9c306101779976f6d00e31402b948f788dbe263f1ed88285037e77L10-R13))
* Delete unused `useDialogStore` import from `SearchBar.tsx` ([link](https://github.com/usememos/memos/pull/1536/files?diff=unified&w=0#diff-81f484299a9c306101779976f6d00e31402b948f788dbe263f1ed88285037e77L4-R4))

