### PR TITLE
chore: update resource link template

### DIFF
--- a/server/resource.go
+++ b/server/resource.go
@@ -314,6 +314,7 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 }
 
 func (s *Server) registerResourcePublicRoutes(g *echo.Group) {
+	// (DEPRECATED) use /r/:resourceId/:publicId/:filename instead.
 	g.GET("/r/:resourceId/:publicId", func(c echo.Context) error {
 		ctx := c.Request().Context()
 		resourceID, err := strconv.Atoi(c.Param("resourceId"))
@@ -327,6 +328,56 @@ func (s *Server) registerResourcePublicRoutes(g *echo.Group) {
 		resourceFind := &api.ResourceFind{
 			ID:       &resourceID,
 			PublicID: &publicID,
+			GetBlob:  true,
+		}
+		resource, err := s.Store.FindResource(ctx, resourceFind)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to find resource by ID: %v", resourceID)).SetInternal(err)
+		}
+
+		blob := resource.Blob
+		if resource.InternalPath != "" {
+			src, err := os.Open(resource.InternalPath)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to open the local resource: %s", resource.InternalPath)).SetInternal(err)
+			}
+			defer src.Close()
+			blob, err = io.ReadAll(src)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to read the local resource: %s", resource.InternalPath)).SetInternal(err)
+			}
+		}
+
+		c.Response().Writer.Header().Set(echo.HeaderCacheControl, "max-age=31536000, immutable")
+		c.Response().Writer.Header().Set(echo.HeaderContentSecurityPolicy, "default-src 'self'")
+		resourceType := strings.ToLower(resource.Type)
+		if strings.HasPrefix(resourceType, "text") {
+			resourceType = echo.MIMETextPlainCharsetUTF8
+		} else if strings.HasPrefix(resourceType, "video") || strings.HasPrefix(resourceType, "audio") {
+			http.ServeContent(c.Response(), c.Request(), resource.Filename, time.Unix(resource.UpdatedTs, 0), bytes.NewReader(blob))
+			return nil
+		}
+		return c.Stream(http.StatusOK, resourceType, bytes.NewReader(blob))
+	})
+
+	g.GET("/r/:resourceId/:publicId/:filename", func(c echo.Context) error {
+		ctx := c.Request().Context()
+		resourceID, err := strconv.Atoi(c.Param("resourceId"))
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("ID is not a number: %s", c.Param("resourceId"))).SetInternal(err)
+		}
+		publicID, err := url.QueryUnescape(c.Param("publicId"))
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("publicID is invalid: %s", c.Param("publicId"))).SetInternal(err)
+		}
+		filename, err := url.QueryUnescape(c.Param("filename"))
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("filename is invalid: %s", c.Param("filename"))).SetInternal(err)
+		}
+		resourceFind := &api.ResourceFind{
+			ID:       &resourceID,
+			PublicID: &publicID,
+			Filename: &filename,
 			GetBlob:  true,
 		}
 		resource, err := s.Store.FindResource(ctx, resourceFind)

--- a/web/src/utils/resource.ts
+++ b/web/src/utils/resource.ts
@@ -3,5 +3,5 @@ export const getResourceUrl = (resource: Resource, withOrigin = true) => {
     return resource.externalLink;
   }
 
-  return `${withOrigin ? window.location.origin : ""}/o/r/${resource.id}/${resource.publicId}`;
+  return `${withOrigin ? window.location.origin : ""}/o/r/${resource.id}/${resource.publicId}/${resource.filename}`;
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b0e5a11</samp>

### Summary
🛣️🚀🗑️

<!--
1.  🛣️ - This emoji represents a road or a route, and can be used to indicate the addition of a new route for serving resources with better URLs.
2.  🚀 - This emoji represents a rocket or a launch, and can be used to indicate the enhancement of the resource serving logic to handle local and blob resources more efficiently and with caching.
3.  🗑️ - This emoji represents a trash can or a bin, and can be used to indicate the deprecation of the old route for serving resources with less optimal URLs.
-->
This pull request improves the resource serving functionality by adding a new route with better URLs and caching, and updating the frontend and backend to use it. It also deprecates the old route and handles different types of resources.

> _We serve the resources of doom_
> _With better URLs and caching_
> _We deprecate the old and weak_
> _We handle local and blob with raging_

### Walkthrough
* Deprecate old route for serving resources and suggest new route with filename ([link](https://github.com/usememos/memos/pull/1537/files?diff=unified&w=0#diff-91bb7c2a19c70096a547a320bb6ba893a5762ab37c652a0fc633187cedc2306eR317))
* Implement new route for serving resources with validation, error handling, and caching logic ([link](https://github.com/usememos/memos/pull/1537/files?diff=unified&w=0#diff-91bb7c2a19c70096a547a320bb6ba893a5762ab37c652a0fc633187cedc2306eR362-R411))
* Support serving local resources from internal path or blob depending on availability ([link](https://github.com/usememos/memos/pull/1537/files?diff=unified&w=0#diff-91bb7c2a19c70096a547a320bb6ba893a5762ab37c652a0fc633187cedc2306eR362-R411))
* Update frontend function to generate resource URL with filename ([link](https://github.com/usememos/memos/pull/1537/files?diff=unified&w=0#diff-81c2958a12eb0b50e285018947da7ec020907d6b49dac4bd9c436d113c685994L6-R6))

