### PR TITLE
chore: update version to `0.12.2`

### DIFF
--- a/server/version/version.go
+++ b/server/version/version.go
@@ -9,10 +9,10 @@ import (
 
 // Version is the service current released version.
 // Semantic versioning: https://semver.org/
-var Version = "0.12.1"
+var Version = "0.12.2"
 
 // DevVersion is the service current development version.
-var DevVersion = "0.12.1"
+var DevVersion = "0.12.2"
 
 func GetCurrentVersion(mode string) string {
 	if mode == "dev" || mode == "demo" {

--- a/web/src/components/HomeSidebar.tsx
+++ b/web/src/components/HomeSidebar.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
 import { resolution } from "../utils/layout";
 import { useLayoutStore, useUserStore } from "../store/module";
 import ShortcutList from "./ShortcutList";
@@ -8,18 +7,28 @@ import SearchBar from "./SearchBar";
 import UsageHeatMap from "./UsageHeatMap";
 
 const HomeSidebar = () => {
-  const location = useLocation();
   const layoutStore = useLayoutStore();
   const userStore = useUserStore();
   const showHomeSidebar = layoutStore.state.showHomeSidebar;
 
   useEffect(() => {
+    let initialized = false;
     let lastStatus = layoutStore.state.showHomeSidebar;
     const handleWindowResize = () => {
-      const nextStatus = window.innerWidth < resolution.md;
+      let nextStatus = window.innerWidth < resolution.md;
       if (lastStatus !== nextStatus) {
+        if (!initialized && nextStatus) {
+          // Don't show sidebar on first load in mobile view.
+          nextStatus = false;
+        }
+
         layoutStore.setHomeSidebarStatus(nextStatus);
         lastStatus = nextStatus;
+      }
+
+      if (!initialized) {
+        initialized = true;
+        return;
       }
     };
 
@@ -29,7 +38,7 @@ const HomeSidebar = () => {
     return () => {
       window.removeEventListener("resize", handleWindowResize);
     };
-  }, [location]);
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dbff2ce</samp>

### Summary
🚀🧹📱

<!--
1.  🚀 for the version update, since this indicates a new release of the service.
2.  🧹 for the sidebar logic improvement, since this implies cleaning up or refactoring the code.
3.  📱 for the mobile view enhancement, since this affects the user interface on smaller devices.
-->
This pull request simplifies the sidebar component in the web frontend and updates the service version in the server backend. It removes unnecessary code from `HomeSidebar.tsx` and sets the `Version` and `DevVersion` variables to `0.12.2` in `version.go`.

> _`Version` updated_
> _Simpler sidebar logic now_
> _No more `useLocation`_

### Walkthrough
* Update the service release version to `0.12.2` in the `version` package ([link](https://github.com/usememos/memos/pull/1538/files?diff=unified&w=0#diff-f120c66c69c2f7715b804b8ed32f1dfae4c2474e1027017b3e30f3828a049911L12-R15))
* Simplify the logic for showing the sidebar in the `HomeSidebar` component ([link](https://github.com/usememos/memos/pull/1538/files?diff=unified&w=0#diff-8af73e1d5b76ffba5a530f1ab0072f163db3049dc96a2426ca3312201e7da380L2), [link](https://github.com/usememos/memos/pull/1538/files?diff=unified&w=0#diff-8af73e1d5b76ffba5a530f1ab0072f163db3049dc96a2426ca3312201e7da380L11), [link](https://github.com/usememos/memos/pull/1538/files?diff=unified&w=0#diff-8af73e1d5b76ffba5a530f1ab0072f163db3049dc96a2426ca3312201e7da380L17-R32), [link](https://github.com/usememos/memos/pull/1538/files?diff=unified&w=0#diff-8af73e1d5b76ffba5a530f1ab0072f163db3049dc96a2426ca3312201e7da380L32-R41))
  * Remove the unused `useLocation` hook and the `location` variable from the component ([link](https://github.com/usememos/memos/pull/1538/files?diff=unified&w=0#diff-8af73e1d5b76ffba5a530f1ab0072f163db3049dc96a2426ca3312201e7da380L2), [link](https://github.com/usememos/memos/pull/1538/files?diff=unified&w=0#diff-8af73e1d5b76ffba5a530f1ab0072f163db3049dc96a2426ca3312201e7da380L11))
  * Add an `initialized` flag to the `useEffect` hook to prevent the sidebar from showing on the first load in mobile view ([link](https://github.com/usememos/memos/pull/1538/files?diff=unified&w=0#diff-8af73e1d5b76ffba5a530f1ab0072f163db3049dc96a2426ca3312201e7da380L17-R32))
  * Remove the `location` dependency from the `useEffect` hook and only depend on the window resize event ([link](https://github.com/usememos/memos/pull/1538/files?diff=unified&w=0#diff-8af73e1d5b76ffba5a530f1ab0072f163db3049dc96a2426ca3312201e7da380L32-R41))

