### PR TITLE
chore: update save button style

### DIFF
--- a/web/src/components/Dialog/BaseDialog.tsx
+++ b/web/src/components/Dialog/BaseDialog.tsx
@@ -25,6 +25,7 @@ const BaseDialog: React.FC<Props> = (props: Props) => {
   const dialogIndex = dialogStore.state.dialogStack.findIndex((item) => item === dialogName);
 
   useEffect(() => {
+    document.body.classList.add("overflow-hidden");
     dialogStore.pushDialogStack(dialogName);
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.code === "Escape") {
@@ -39,6 +40,9 @@ const BaseDialog: React.FC<Props> = (props: Props) => {
     return () => {
       document.body.removeEventListener("keydown", handleKeyDown);
       dialogStore.removeDialog(dialogName);
+      if (dialogStore.state.dialogStack.length === 0) {
+        document.body.classList.remove("overflow-hidden");
+      }
     };
   }, []);
 

--- a/web/src/components/LocaleSelect.tsx
+++ b/web/src/components/LocaleSelect.tsx
@@ -18,7 +18,7 @@ const LocaleSelect: FC<Props> = (props: Props) => {
 
   return (
     <Select
-      className={`!min-w-[12rem] w-auto whitespace-nowrap ${className ?? ""}`}
+      className={`!min-w-[10rem] w-auto whitespace-nowrap ${className ?? ""}`}
       startDecorator={<Icon.Globe className="w-4 h-auto" />}
       value={value}
       onChange={(_, value) => handleSelectChange(value as Locale)}

--- a/web/src/less/memo-editor.less
+++ b/web/src/less/memo-editor.less
@@ -137,7 +137,7 @@
       }
 
       > .confirm-btn {
-        @apply border-none select-none rounded flex flex-row justify-center items-center shadow cursor-pointer px-3 py-0 leading-8 bg-green-600 text-white text-sm hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-60;
+        @apply border-none select-none rounded-full flex flex-row justify-center items-center shadow cursor-pointer px-4 py-0 leading-8 bg-green-600 text-white text-sm hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-60;
       }
     }
   }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5ee4119</samp>

### Summary
📏🟢🛑

<!--
1.  📏 for the change in the locale select component width. This emoji can be used to indicate changes related to size, dimensions, or measurements.
2.  🟢 for the change in the confirm button style. This emoji can be used to indicate changes related to colors, shapes, or appearance.
3.  🛑 for the change in the scrolling behavior of the web app. This emoji can be used to indicate changes related to stopping, preventing, or blocking something.
-->
This pull request improves the web app's user interface by fixing some issues with scrolling, layout, and button design in the `BaseDialog` and `LocaleSelect` components and the `memo-editor.less` file.

> _Oh, we're the web devs of the sea, me hearties_
> _We tweak the styles and fix the bugs with ease_
> _We make the `locale select` fit and `confirm` button round_
> _And stop the scroll when `BaseDialog` is on the ground_

### Walkthrough
*  Prevent scrolling behind open dialogs by adding and removing a class to the document body ([link](https://github.com/usememos/memos/pull/1542/files?diff=unified&w=0#diff-43584aa2f8735d7e5b466202357b4212144432516bcb604545d7ed8a30e32ce5R28), [link](https://github.com/usememos/memos/pull/1542/files?diff=unified&w=0#diff-43584aa2f8735d7e5b466202357b4212144432516bcb604545d7ed8a30e32ce5R43-R45)) in `BaseDialog.tsx`

