### PR TITLE
fix: the broken install docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ docker run -d --name memos -p 5230:5230 -v ~/.memos/:/var/opt/memos ghcr.io/usem
 
 > The `~/.memos/` directory will be used as the data directory on your local machine, while `/var/opt/memos` is the directory of the volume in Docker and should not be modified.
 
-Learn more about [other installation methods](https://usememos.com/docs/install).
+Learn more about [other installation methods](https://usememos.com/docs#installation).
 
 ## Contribution
 


### PR DESCRIPTION
I re-arranged the install docs a bit to separate them into Docker and hosted options:

https://usememos.com/docs

This also breaks the said link in the README. Most appropriate alternative would be this:

https://usememos.com/docs#installation