### PR TITLE
Hiding dialog using X button should remove class "overflow-hidden" too.

### DIFF
--- a/web/src/components/Dialog/BaseDialog.tsx
+++ b/web/src/components/Dialog/BaseDialog.tsx
@@ -92,6 +92,7 @@ export function generateDialog<T extends DialogProps>(
     hide: () => {
       tempDiv.firstElementChild?.classList.remove("showup");
       tempDiv.firstElementChild?.classList.add("showoff");
+      document.body.classList.remove("overflow-hidden");
     },
   };
 


### PR DESCRIPTION
Hiding dialogs result in the body to stay frozen due to mounting behaviour of the dialog, but using 'X' button hides the dialog and won't let user scroll any further. Removing overflow behaviour during hiding procedure will improve User Experience.