### PR TITLE
feat: Allow linking memos from other memos

### DIFF
--- a/web/src/components/Dialog/BaseDialog.tsx
+++ b/web/src/components/Dialog/BaseDialog.tsx
@@ -7,6 +7,7 @@ import store from "@/store";
 import { useDialogStore } from "@/store/module";
 import theme from "@/theme";
 import "@/less/base-dialog.less";
+import { BrowserRouter } from "react-router-dom";
 
 interface DialogConfig {
   dialogName: string;
@@ -104,11 +105,13 @@ export function generateDialog<T extends DialogProps>(
 
   const Fragment = (
     <Provider store={store}>
-      <CssVarsProvider theme={theme}>
-        <BaseDialog destroy={cbs.destroy} hide={cbs.hide} clickSpaceDestroy={true} {...config}>
-          <DialogComponent {...dialogProps} />
-        </BaseDialog>
-      </CssVarsProvider>
+      <BrowserRouter>
+        <CssVarsProvider theme={theme}>
+          <BaseDialog destroy={cbs.destroy} hide={cbs.hide} clickSpaceDestroy={true} {...config}>
+            <DialogComponent {...dialogProps} />
+          </BaseDialog>
+        </CssVarsProvider>
+      </BrowserRouter>
     </Provider>
   );
 

--- a/web/src/components/Memo.tsx
+++ b/web/src/components/Memo.tsx
@@ -187,7 +187,8 @@ const Memo: React.FC<Props> = (props: Props) => {
       <div className="memo-top-wrapper">
         <div className="status-text-container">
           <Link className="time-text" to={`/m/${memo.id}`} onClick={handleMemoCreatedTimeClick}>
-            {createdTimeStr}
+            m/{memo.id}
+            <span className="ml-2 italic">{createdTimeStr}</span>
           </Link>
           {isVisitorMode && (
             <Link className="name-text" to={`/u/${memo.creatorId}`}>

--- a/web/src/components/MemoEditor.tsx
+++ b/web/src/components/MemoEditor.tsx
@@ -12,6 +12,7 @@ import Selector from "./kit/Selector";
 import Editor, { EditorRefActions } from "./Editor/Editor";
 import ResourceIcon from "./ResourceIcon";
 import showResourcesSelectorDialog from "./ResourcesSelectorDialog";
+import showMemosSelectorDialog from "@/components/MemosSelectorDialog";
 import showCreateResourceDialog from "./CreateResourceDialog";
 import "@/less/memo-editor.less";
 
@@ -340,6 +341,15 @@ const MemoEditor = () => {
     });
   };
 
+  const handleSelectMemo = (memoId: number) => {
+    if (!editorRef.current) {
+      return;
+    }
+
+    editorRef.current?.insertText(`m/${memoId} `);
+    editorRef.current?.scrollToCursor();
+  };
+
   const handleFullscreenBtnClick = () => {
     setState((state) => {
       return {
@@ -426,7 +436,7 @@ const MemoEditor = () => {
             <Icon.Code className="icon-img" onClick={handleCodeBlockBtnClick} />
           </button>
           <div className="action-btn resource-btn">
-            <Icon.FileText className="icon-img" />
+            <Icon.Paperclip className="icon-img" />
             <div className="resource-action-list">
               <div className="resource-action-item" onClick={handleUploadFileBtnClick}>
                 <Icon.Plus className="icon-img" />
@@ -438,6 +448,9 @@ const MemoEditor = () => {
               </div>
             </div>
           </div>
+          <button className="action-btn" onClick={() => showMemosSelectorDialog({ onSelectMemo: handleSelectMemo })}>
+            <Icon.FileText className="icon-img" />
+          </button>
           <button className="action-btn" onClick={handleFullscreenBtnClick}>
             {state.fullscreen ? <Icon.Minimize className="icon-img" /> : <Icon.Maximize className="icon-img" />}
           </button>

--- a/web/src/components/MemosSelectorDialog.tsx
+++ b/web/src/components/MemosSelectorDialog.tsx
@@ -1,0 +1,91 @@
+import { useTranslation } from "react-i18next";
+import Icon from "./Icon";
+import { generateDialog } from "./Dialog";
+import "@/less/memos-selector-dialog.less";
+import { useMemoStore } from "@/store/module";
+import InputField from "@/components/kit/InputField";
+import { useCallback, useState } from "react";
+import { marked } from "@/labs/marked";
+import { blockElementParserListNonInteractive, inlineElementParserListNonInteractive } from "@/labs/marked/parser";
+import { getRelativeTimeString } from "@/helpers/datetime";
+import useDebounce from "@/hooks/useDebounce";
+
+type Props = DialogProps & { onSelectMemo?: (memoId: number) => void };
+
+const MemosSelectorDialog: React.FC<Props> = (props: Props) => {
+  const { destroy } = props;
+  const { t } = useTranslation();
+  const memos = useMemoStore().state.memos ?? [];
+  const [textSearch, setTextSearch] = useState("");
+  const [textSearchDebounced, setTextSearchDebounced] = useState(textSearch);
+
+  useDebounce(() => setTextSearchDebounced(textSearch), 200, [textSearch]);
+
+  const selectMemo = useCallback(
+    (memoId: number) => {
+      if (props.onSelectMemo) {
+        props.onSelectMemo(memoId);
+      }
+    },
+    [props.onSelectMemo]
+  );
+
+  return (
+    <>
+      <div className="dialog-header-container">
+        <p className="title-text">{t("memo.select")}</p>
+        <button className="btn close-btn" onClick={destroy}>
+          <Icon.X className="icon-img" />
+        </button>
+      </div>
+      <div className="dialog-content-container">
+        <InputField
+          type="search"
+          icon={Icon.Search}
+          placeholder={t("memo.search-placeholder")}
+          onChange={(e) => {
+            setTextSearch(e.target.value);
+          }}
+        />
+
+        {memos
+          .filter((m) => (textSearchDebounced ? m.content.toLowerCase().includes(textSearchDebounced.toLowerCase()) : true))
+          .map((memo) => (
+            <button
+              key={memo.id}
+              className="memo-wrapper text-left"
+              onClick={() => {
+                selectMemo(memo.id);
+                destroy();
+              }}
+            >
+              <div className="memo-top-wrapper">
+                <div className="status-text-container">
+                  <span className="time-text">
+                    m/{memo.id}
+                    <span className="ml-2 italic">{getRelativeTimeString(memo.createdTs)}</span>
+                  </span>
+                </div>
+              </div>
+              <div className="memo-content-wrapper max-h-32 overflow-y-hidden">
+                <div className="memo-content-text">
+                  {marked(memo.content, blockElementParserListNonInteractive, inlineElementParserListNonInteractive)}
+                </div>
+              </div>
+            </button>
+          ))}
+      </div>
+    </>
+  );
+};
+
+export default function showMemosSelectorDialog({ onSelectMemo }: Pick<Props, "onSelectMemo">) {
+  generateDialog(
+    {
+      className: "memos-selector-dialog",
+      dialogName: "memos-selector-dialog",
+    },
+    MemosSelectorDialog,
+    { onSelectMemo }
+  );
+}

--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import useDebounce from "@/hooks/useDebounce";
 import { useFilterStore } from "@/store/module";
+import InputField from "./kit/InputField";
 import Icon from "./Icon";
 
 const SearchBar = () => {
@@ -29,17 +30,14 @@ const SearchBar = () => {
   };
 
   return (
-    <div className="w-full h-9 flex flex-row justify-start items-center py-2 px-3 rounded-md bg-gray-200 dark:bg-zinc-700">
-      <Icon.Search className="w-4 h-auto opacity-30 dark:text-gray-200" />
-      <input
-        className="flex ml-2 w-24 grow text-sm outline-none bg-transparent dark:text-gray-200"
-        type="text"
-        placeholder={t("memo.search-placeholder")}
-        ref={inputRef}
-        value={queryText}
-        onChange={handleTextQueryInput}
-      />
-    </div>
+    <InputField
+      icon={Icon.Search}
+      type="search"
+      placeholder={t("memo.search-placeholder")}
+      ref={inputRef}
+      value={queryText}
+      onChange={handleTextQueryInput}
+    />
   );
 };
 

--- a/web/src/components/kit/InputField.tsx
+++ b/web/src/components/kit/InputField.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { LucideIcon } from "lucide-react";
+
+interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
+  className?: string;
+  containerClassName?: string;
+  icon?: LucideIcon;
+  iconProps?: React.ComponentProps<LucideIcon>;
+}
+
+const InputField = React.forwardRef<HTMLInputElement, Props>(({ icon, iconProps, containerClassName, className, ...props }, ref) => {
+  const Icon = icon; // can't use lowercase jsx elements as custom react elements, so we must change the casing
+  return (
+    <div
+      className={
+        "w-full h-9 flex flex-row justify-start items-center py-2 px-3 rounded-md bg-gray-200 dark:bg-zinc-700" +
+        (containerClassName ? ` ${containerClassName}` : "")
+      }
+    >
+      {Icon && (
+        <Icon
+          {...iconProps}
+          className={"w-4 h-auto opacity-30 dark:text-gray-200" + (iconProps?.className ? ` ${iconProps.className}` : "")}
+        />
+      )}
+      <input
+        ref={ref}
+        {...props}
+        className={"flex ml-2 w-24 grow text-sm outline-none bg-transparent dark:text-gray-200" + (className ? `  ${className}` : "")}
+      />
+    </div>
+  );
+});
+InputField.displayName = "InputField";
+
+export default InputField;

--- a/web/src/labs/marked/index.tsx
+++ b/web/src/labs/marked/index.tsx
@@ -1,11 +1,6 @@
 import { matcher } from "./matcher";
 import { blockElementParserList, inlineElementParserList } from "./parser";
-
-type Parser = {
-  name: string;
-  regexp: RegExp;
-  renderer: (rawStr: string) => JSX.Element | string;
-};
+import type { Parser } from "./parser/Parser";
 
 const findMatchingParser = (parsers: Parser[], markdownStr: string): Parser | undefined => {
   let matchedParser = undefined;
@@ -46,17 +41,17 @@ export const marked = (
       if (matchedBlockParser.name === "br") {
         return (
           <>
-            {matchedBlockParser.renderer(matchedStr)}
+            {matchedBlockParser.renderer()(matchedStr)}
             {marked(retainContent, blockParsers, inlineParsers)}
           </>
         );
       } else {
         if (retainContent === "") {
-          return matchedBlockParser.renderer(matchedStr);
+          return matchedBlockParser.renderer()(matchedStr);
         } else if (retainContent.startsWith("\n")) {
           return (
             <>
-              {matchedBlockParser.renderer(matchedStr)}
+              {matchedBlockParser.renderer()(matchedStr)}
               {marked(retainContent.slice(1), blockParsers, inlineParsers)}
             </>
           );
@@ -77,7 +72,7 @@ export const marked = (
       return (
         <>
           {marked(prefixStr, [], inlineParsers)}
-          {matchedInlineParser.renderer(matchedStr)}
+          {matchedInlineParser.renderer()(matchedStr)}
           {marked(suffixStr, [], inlineParsers)}
         </>
       );

--- a/web/src/labs/marked/parser/Blockquote.tsx
+++ b/web/src/labs/marked/parser/Blockquote.tsx
@@ -1,21 +1,29 @@
-import { inlineElementParserList } from ".";
+import { inlineElementParserList, inlineElementParserListNonInteractive } from ".";
 import { marked } from "..";
 import { matcher } from "../matcher";
+import { Parser } from "./Parser";
 
 export const BLOCKQUOTE_REG = /^> ([^\n]+)/;
 
-const renderer = (rawStr: string) => {
+// eslint-disable-next-line react/display-name
+const renderer = (inlineParsers: Parser[]) => (rawStr: string) => {
   const matchResult = matcher(rawStr, BLOCKQUOTE_REG);
   if (!matchResult) {
     return <>{rawStr}</>;
   }
 
-  const parsedContent = marked(matchResult[1], [], inlineElementParserList);
+  const parsedContent = marked(matchResult[1], [], inlineParsers);
   return <blockquote>{parsedContent}</blockquote>;
 };
 
 export default {
   name: "blockquote",
   regexp: BLOCKQUOTE_REG,
-  renderer,
+  renderer: () => renderer(inlineElementParserList),
+};
+
+export const BlockquoteNonInteractive = {
+  name: "blockquote non-interactive",
+  regexp: BLOCKQUOTE_REG,
+  renderer: () => renderer(inlineElementParserListNonInteractive),
 };

--- a/web/src/labs/marked/parser/Bold.tsx
+++ b/web/src/labs/marked/parser/Bold.tsx
@@ -1,22 +1,31 @@
 import { marked } from "..";
 import { matcher } from "../matcher";
-import Link from "./Link";
+import Link, { LinkNonInteractive } from "./Link";
 import PlainText from "./PlainText";
+import PlainLink, { PlainLinkNonInteractive } from "./PlainLink";
+import { Parser } from "./Parser";
 
 export const BOLD_REG = /\*\*(.+?)\*\*/;
 
-const renderer = (rawStr: string) => {
+// eslint-disable-next-line react/display-name
+const renderer = (inlineParsers: Parser[]) => (rawStr: string) => {
   const matchResult = matcher(rawStr, BOLD_REG);
   if (!matchResult) {
-    return <>{rawStr}</>;
+    return rawStr;
   }
 
-  const parsedContent = marked(matchResult[1], [], [Link, PlainText]);
+  const parsedContent = marked(matchResult[1], [], inlineParsers);
   return <strong>{parsedContent}</strong>;
 };
 
 export default {
   name: "bold",
   regexp: BOLD_REG,
-  renderer,
+  renderer: () => renderer([Link, PlainLink, PlainText]),
+};
+
+export const BoldNonInteractive = {
+  name: "bold non-interactive",
+  regexp: BOLD_REG,
+  renderer: () => renderer([LinkNonInteractive, PlainLinkNonInteractive, PlainText]),
 };

--- a/web/src/labs/marked/parser/BoldEmphasis.tsx
+++ b/web/src/labs/marked/parser/BoldEmphasis.tsx
@@ -1,17 +1,20 @@
 import { marked } from "..";
 import { matcher } from "../matcher";
-import Link from "./Link";
+import Link, { LinkNonInteractive } from "./Link";
 import PlainText from "./PlainText";
+import PlainLink, { PlainLinkNonInteractive } from "./PlainLink";
+import { Parser } from "./Parser";
 
 export const BOLD_EMPHASIS_REG = /\*\*\*(.+?)\*\*\*/;
 
-const renderer = (rawStr: string) => {
+// eslint-disable-next-line react/display-name
+const renderer = (inlineParsers: Parser[]) => (rawStr: string) => {
   const matchResult = matcher(rawStr, BOLD_EMPHASIS_REG);
   if (!matchResult) {
     return rawStr;
   }
 
-  const parsedContent = marked(matchResult[1], [], [Link, PlainText]);
+  const parsedContent = marked(matchResult[1], [], inlineParsers);
   return (
     <strong>
       <em>{parsedContent}</em>
@@ -22,5 +25,11 @@ const renderer = (rawStr: string) => {
 export default {
   name: "bold emphasis",
   regexp: BOLD_EMPHASIS_REG,
-  renderer,
+  renderer: () => renderer([Link, PlainLink, PlainText]),
+};
+
+export const BoldEmphasisNonInteractive = {
+  name: "bold emphasis non-interactive",
+  regexp: BOLD_EMPHASIS_REG,
+  renderer: () => renderer([LinkNonInteractive, PlainLinkNonInteractive, PlainText]),
 };

--- a/web/src/labs/marked/parser/Br.tsx
+++ b/web/src/labs/marked/parser/Br.tsx
@@ -12,5 +12,5 @@ const renderer = (rawStr: string) => {
 export default {
   name: "br",
   regexp: BR_REG,
-  renderer,
+  renderer: () => renderer,
 };

--- a/web/src/labs/marked/parser/CodeBlock.tsx
+++ b/web/src/labs/marked/parser/CodeBlock.tsx
@@ -44,5 +44,5 @@ const renderer = (rawStr: string) => {
 export default {
   name: "code block",
   regexp: CODE_BLOCK_REG,
-  renderer,
+  renderer: () => renderer,
 };

--- a/web/src/labs/marked/parser/DoneList.tsx
+++ b/web/src/labs/marked/parser/DoneList.tsx
@@ -25,5 +25,5 @@ const renderer = (rawStr: string) => {
 export default {
   name: "done list",
   regexp: DONE_LIST_REG,
-  renderer,
+  renderer: () => renderer,
 };

--- a/web/src/labs/marked/parser/Emphasis.tsx
+++ b/web/src/labs/marked/parser/Emphasis.tsx
@@ -1,23 +1,31 @@
 import { marked } from "..";
 import { matcher } from "../matcher";
-import Link from "./Link";
-import PlainLink from "./PlainLink";
+import Link, { LinkNonInteractive } from "./Link";
+import PlainLink, { PlainLinkNonInteractive } from "./PlainLink";
 import PlainText from "./PlainText";
+import type { Parser } from "./Parser";
 
 export const EMPHASIS_REG = /\*(.+?)\*/;
 
-const renderer = (rawStr: string) => {
+// eslint-disable-next-line react/display-name
+const renderer = (inlineParsers: Parser[]) => (rawStr: string) => {
   const matchResult = matcher(rawStr, EMPHASIS_REG);
   if (!matchResult) {
     return rawStr;
   }
 
-  const parsedContent = marked(matchResult[1], [], [Link, PlainLink, PlainText]);
+  const parsedContent = marked(matchResult[1], [], inlineParsers);
   return <em>{parsedContent}</em>;
 };
 
 export default {
   name: "emphasis",
   regexp: EMPHASIS_REG,
-  renderer,
+  renderer: () => renderer([Link, PlainLink, PlainText]),
+};
+
+export const EmphasisNonInteractive = {
+  name: "emphasis non-interactive",
+  regexp: EMPHASIS_REG,
+  renderer: () => renderer([LinkNonInteractive, PlainLinkNonInteractive, PlainText]),
 };

--- a/web/src/labs/marked/parser/Heading.tsx
+++ b/web/src/labs/marked/parser/Heading.tsx
@@ -1,19 +1,21 @@
 import { marked } from "..";
 import { matcher } from "../matcher";
-import Link from "./Link";
-import PlainLink from "./PlainLink";
+import Link, { LinkNonInteractive } from "./Link";
+import PlainLink, { PlainLinkNonInteractive } from "./PlainLink";
 import PlainText from "./PlainText";
+import type { Parser } from "./Parser";
 
 export const HEADING_REG = /^(#+) ([^\n]+)/;
 
-const renderer = (rawStr: string) => {
+// eslint-disable-next-line react/display-name
+const renderer = (inlineParsers: Parser[]) => (rawStr: string) => {
   const matchResult = matcher(rawStr, HEADING_REG);
   if (!matchResult) {
     return rawStr;
   }
 
   const level = matchResult[1].length;
-  const parsedContent = marked(matchResult[2], [], [Link, PlainLink, PlainText]);
+  const parsedContent = marked(matchResult[2], [], inlineParsers);
   if (level === 1) {
     return <h1>{parsedContent}</h1>;
   } else if (level === 2) {
@@ -29,5 +31,11 @@ const renderer = (rawStr: string) => {
 export default {
   name: "heading",
   regexp: HEADING_REG,
-  renderer,
+  renderer: () => renderer([Link, PlainLink, PlainText]),
+};
+
+export const HeadingNonInteractive = {
+  name: "heading non-interactive",
+  regexp: HEADING_REG,
+  renderer: () => renderer([LinkNonInteractive, PlainLinkNonInteractive, PlainText]),
 };

--- a/web/src/labs/marked/parser/HorizontalRules.tsx
+++ b/web/src/labs/marked/parser/HorizontalRules.tsx
@@ -8,5 +8,5 @@ export const renderer = (rawStr: string) => {
 export default {
   name: "horizontal rules",
   regexp: HORIZONTAL_RULES_REG,
-  renderer,
+  renderer: () => renderer,
 };

--- a/web/src/labs/marked/parser/Image.tsx
+++ b/web/src/labs/marked/parser/Image.tsx
@@ -16,5 +16,5 @@ const renderer = (rawStr: string) => {
 export default {
   name: "image",
   regexp: IMAGE_REG,
-  renderer,
+  renderer: () => renderer,
 };

--- a/web/src/labs/marked/parser/InlineCode.tsx
+++ b/web/src/labs/marked/parser/InlineCode.tsx
@@ -14,5 +14,5 @@ const renderer = (rawStr: string) => {
 export default {
   name: "inline code",
   regexp: INLINE_CODE_REG,
-  renderer,
+  renderer: () => renderer,
 };

--- a/web/src/labs/marked/parser/Link.tsx
+++ b/web/src/labs/marked/parser/Link.tsx
@@ -1,8 +1,8 @@
-import Emphasis from "./Emphasis";
-import Bold from "./Bold";
+import Emphasis, { EmphasisNonInteractive } from "./Emphasis";
+import Bold, { BoldNonInteractive } from "./Bold";
 import { marked } from "..";
 import InlineCode from "./InlineCode";
-import BoldEmphasis from "./BoldEmphasis";
+import BoldEmphasis, { BoldEmphasisNonInteractive } from "./BoldEmphasis";
 import PlainText from "./PlainText";
 import { matcher } from "../matcher";
 
@@ -21,8 +21,27 @@ const renderer = (rawStr: string) => {
   );
 };
 
+const rendererNonInteractive = (rawStr: string) => {
+  const matchResult = matcher(rawStr, LINK_REG);
+  if (!matchResult) {
+    return rawStr;
+  }
+  const parsedContent = marked(
+    matchResult[1],
+    [],
+    [InlineCode, BoldEmphasisNonInteractive, EmphasisNonInteractive, BoldNonInteractive, PlainText]
+  );
+  return <span className="link">{parsedContent}</span>;
+};
+
 export default {
   name: "link",
   regexp: LINK_REG,
-  renderer,
+  renderer: () => renderer,
+};
+
+export const LinkNonInteractive = {
+  name: "link non-interactive",
+  regexp: LINK_REG,
+  renderer: () => rendererNonInteractive,
 };

--- a/web/src/labs/marked/parser/MemoRef.tsx
+++ b/web/src/labs/marked/parser/MemoRef.tsx
@@ -1,0 +1,38 @@
+import { matcher } from "../matcher";
+import { Link } from "react-router-dom";
+
+export const MEMO_REF_REG = /(m\/\d+)/;
+
+const renderer = (rawStr: string) => {
+  const matchResult = matcher(rawStr, MEMO_REF_REG);
+  if (!matchResult) {
+    return rawStr;
+  }
+
+  return (
+    <Link className="memo-ref" to={"/" + matchResult[1]}>
+      {matchResult[1]}
+    </Link>
+  );
+};
+
+const rendererNonInteractive = (rawStr: string) => {
+  const matchResult = matcher(rawStr, MEMO_REF_REG);
+  if (!matchResult) {
+    return rawStr;
+  }
+
+  return <span className="memo-ref">{matchResult[1]}</span>;
+};
+
+export default {
+  name: "memo ref",
+  regexp: MEMO_REF_REG,
+  renderer: () => renderer,
+};
+
+export const MemoRefNonInteractive = {
+  name: "memo ref non-interactive",
+  regexp: MEMO_REF_REG,
+  renderer: () => rendererNonInteractive,
+};

--- a/web/src/labs/marked/parser/OrderedList.tsx
+++ b/web/src/labs/marked/parser/OrderedList.tsx
@@ -1,16 +1,18 @@
-import { inlineElementParserList } from ".";
+import { inlineElementParserList, inlineElementParserListNonInteractive } from ".";
 import { marked } from "..";
 import { matcher } from "../matcher";
+import type { Parser } from "./Parser";
 
 export const ORDERED_LIST_REG = /^( *)(\d+)\. (.+)/;
 
-const renderer = (rawStr: string) => {
+// eslint-disable-next-line react/display-name
+const renderer = (inlineParsers: Parser[]) => (rawStr: string) => {
   const matchResult = matcher(rawStr, ORDERED_LIST_REG);
   if (!matchResult) {
     return rawStr;
   }
   const space = matchResult[1];
-  const parsedContent = marked(matchResult[3], [], inlineElementParserList);
+  const parsedContent = marked(matchResult[3], [], inlineParsers);
   return (
     <p className="li-container">
       <span className="whitespace-pre">{space}</span>
@@ -23,5 +25,11 @@ const renderer = (rawStr: string) => {
 export default {
   name: "ordered list",
   regexp: ORDERED_LIST_REG,
-  renderer,
+  renderer: () => renderer(inlineElementParserList),
+};
+
+export const OrderedListNonInteractive = {
+  name: "ordered list non-interactive",
+  regexp: ORDERED_LIST_REG,
+  renderer: () => renderer(inlineElementParserListNonInteractive),
 };

--- a/web/src/labs/marked/parser/Paragraph.tsx
+++ b/web/src/labs/marked/parser/Paragraph.tsx
@@ -1,15 +1,23 @@
-import { inlineElementParserList } from ".";
+import { inlineElementParserList, inlineElementParserListNonInteractive } from ".";
 import { marked } from "..";
+import type { Parser } from "./Parser";
 
 export const PARAGRAPH_REG = /^([^\n]+)/;
 
-const renderer = (rawStr: string) => {
-  const parsedContent = marked(rawStr, [], inlineElementParserList);
+// eslint-disable-next-line react/display-name
+const renderer = (inlineParsers: Parser[]) => (rawStr: string) => {
+  const parsedContent = marked(rawStr, [], inlineParsers);
   return <p>{parsedContent}</p>;
 };
 
 export default {
   name: "paragraph",
   regexp: PARAGRAPH_REG,
-  renderer,
+  renderer: () => renderer(inlineElementParserList),
+};
+
+export const ParagraphNonInteractive = {
+  name: "paragraph non-interactive",
+  regexp: PARAGRAPH_REG,
+  renderer: () => renderer(inlineElementParserListNonInteractive),
 };

--- a/web/src/labs/marked/parser/Parser.ts
+++ b/web/src/labs/marked/parser/Parser.ts
@@ -1,0 +1,5 @@
+export interface Parser {
+  name: string;
+  regexp: RegExp;
+  renderer: () => (rawStr: string) => React.ReactElement | string;
+}

--- a/web/src/labs/marked/parser/PlainLink.tsx
+++ b/web/src/labs/marked/parser/PlainLink.tsx
@@ -15,8 +15,23 @@ const renderer = (rawStr: string) => {
   );
 };
 
+const rendererNonInteractive = (rawStr: string) => {
+  const matchResult = matcher(rawStr, PLAIN_LINK_REG);
+  if (!matchResult) {
+    return rawStr;
+  }
+
+  return <span className="link">{matchResult[1]}</span>;
+};
+
 export default {
   name: "plain link",
   regexp: PLAIN_LINK_REG,
-  renderer,
+  renderer: () => renderer,
+};
+
+export const PlainLinkNonInteractive = {
+  name: "plain link non-interactive",
+  regexp: PLAIN_LINK_REG,
+  renderer: () => rendererNonInteractive,
 };

--- a/web/src/labs/marked/parser/PlainText.tsx
+++ b/web/src/labs/marked/parser/PlainText.tsx
@@ -14,5 +14,5 @@ const renderer = (rawStr: string): string => {
 export default {
   name: "plain text",
   regexp: PLAIN_TEXT_REG,
-  renderer,
+  renderer: () => renderer,
 };

--- a/web/src/labs/marked/parser/Strikethrough.tsx
+++ b/web/src/labs/marked/parser/Strikethrough.tsx
@@ -14,5 +14,5 @@ const renderer = (rawStr: string) => {
 export default {
   name: "Strikethrough",
   regexp: STRIKETHROUGH_REG,
-  renderer,
+  renderer: () => renderer,
 };

--- a/web/src/labs/marked/parser/Tag.tsx
+++ b/web/src/labs/marked/parser/Tag.tsx
@@ -14,5 +14,5 @@ const renderer = (rawStr: string) => {
 export default {
   name: "tag",
   regexp: TAG_REG,
-  renderer,
+  renderer: () => renderer,
 };

--- a/web/src/labs/marked/parser/TodoList.tsx
+++ b/web/src/labs/marked/parser/TodoList.tsx
@@ -1,16 +1,18 @@
-import { inlineElementParserList } from ".";
+import { inlineElementParserList, inlineElementParserListNonInteractive } from ".";
 import { marked } from "..";
 import { matcher } from "../matcher";
+import { Parser } from "./Parser";
 
 export const TODO_LIST_REG = /^( *)- \[ \] ([^\n]+)/;
 
-const renderer = (rawStr: string) => {
+// eslint-disable-next-line react/display-name
+const renderer = (inlineParsers: Parser[]) => (rawStr: string) => {
   const matchResult = matcher(rawStr, TODO_LIST_REG);
   if (!matchResult) {
     return rawStr;
   }
   const space = matchResult[1];
-  const parsedContent = marked(matchResult[2], [], inlineElementParserList);
+  const parsedContent = marked(matchResult[2], [], inlineParsers);
   return (
     <p className="li-container">
       <span className="whitespace-pre">{space}</span>
@@ -23,5 +25,11 @@ const renderer = (rawStr: string) => {
 export default {
   name: "todo list",
   regexp: TODO_LIST_REG,
-  renderer,
+  renderer: () => renderer(inlineElementParserList),
+};
+
+export const TodoListNonInteractive = {
+  name: "todo list non-interactive",
+  regexp: TODO_LIST_REG,
+  renderer: () => renderer(inlineElementParserListNonInteractive),
 };

--- a/web/src/labs/marked/parser/UnorderedList.tsx
+++ b/web/src/labs/marked/parser/UnorderedList.tsx
@@ -1,16 +1,18 @@
-import { inlineElementParserList } from ".";
+import { inlineElementParserList, inlineElementParserListNonInteractive } from ".";
 import { marked } from "..";
 import { matcher } from "../matcher";
+import type { Parser } from "./Parser";
 
 export const UNORDERED_LIST_REG = /^( *)[*-] ([^\n]+)/;
 
-const renderer = (rawStr: string) => {
+// eslint-disable-next-line react/display-name
+const renderer = (inlineParsers: Parser[]) => (rawStr: string) => {
   const matchResult = matcher(rawStr, UNORDERED_LIST_REG);
   if (!matchResult) {
     return rawStr;
   }
   const space = matchResult[1];
-  const parsedContent = marked(matchResult[2], [], inlineElementParserList);
+  const parsedContent = marked(matchResult[2], [], inlineParsers);
   return (
     <p className="li-container">
       <span className="whitespace-pre">{space}</span>
@@ -23,5 +25,11 @@ const renderer = (rawStr: string) => {
 export default {
   name: "unordered list",
   regexp: UNORDERED_LIST_REG,
-  renderer,
+  renderer: () => renderer(inlineElementParserList),
+};
+
+export const UnorderedListNonInteractive = {
+  name: "unordered list non-interactive",
+  regexp: UNORDERED_LIST_REG,
+  renderer: () => renderer(inlineElementParserListNonInteractive),
 };

--- a/web/src/labs/marked/parser/index.ts
+++ b/web/src/labs/marked/parser/index.ts
@@ -1,29 +1,31 @@
+import type { Parser } from "./Parser";
 import CodeBlock from "./CodeBlock";
-import TodoList from "./TodoList";
+import TodoList, { TodoListNonInteractive } from "./TodoList";
 import DoneList from "./DoneList";
-import OrderedList from "./OrderedList";
-import UnorderedList from "./UnorderedList";
-import Paragraph from "./Paragraph";
+import OrderedList, { OrderedListNonInteractive } from "./OrderedList";
+import UnorderedList, { UnorderedListNonInteractive } from "./UnorderedList";
+import Paragraph, { ParagraphNonInteractive } from "./Paragraph";
 import Br from "./Br";
 import Tag from "./Tag";
 import Image from "./Image";
-import Link from "./Link";
-import Bold from "./Bold";
-import Emphasis from "./Emphasis";
-import PlainLink from "./PlainLink";
+import Link, { LinkNonInteractive } from "./Link";
+import Bold, { BoldNonInteractive } from "./Bold";
+import Emphasis, { EmphasisNonInteractive } from "./Emphasis";
+import PlainLink, { PlainLinkNonInteractive } from "./PlainLink";
 import InlineCode from "./InlineCode";
 import PlainText from "./PlainText";
-import BoldEmphasis from "./BoldEmphasis";
-import Blockquote from "./Blockquote";
+import BoldEmphasis, { BoldEmphasisNonInteractive } from "./BoldEmphasis";
+import Blockquote, { BlockquoteNonInteractive } from "./Blockquote";
 import HorizontalRules from "./HorizontalRules";
 import Strikethrough from "./Strikethrough";
-import Heading from "./Heading";
+import Heading, { HeadingNonInteractive } from "./Heading";
+import MemoRef, { MemoRefNonInteractive } from "./MemoRef";
 
 export { TAG_REG } from "./Tag";
 export { LINK_REG } from "./Link";
 
 // The order determines the order of execution.
-export const blockElementParserList = [
+export const blockElementParserList: Parser[] = [
   Br,
   CodeBlock,
   Blockquote,
@@ -36,4 +38,42 @@ export const blockElementParserList = [
   Paragraph,
 ];
 
-export const inlineElementParserList = [Image, BoldEmphasis, Bold, Emphasis, Link, InlineCode, PlainLink, Strikethrough, Tag, PlainText];
+export const inlineElementParserList: Parser[] = [
+  Image,
+  BoldEmphasis,
+  Bold,
+  Emphasis,
+  Link,
+  MemoRef,
+  InlineCode,
+  PlainLink,
+  Strikethrough,
+  Tag,
+  PlainText,
+];
+
+export const blockElementParserListNonInteractive: Parser[] = [
+  Br,
+  CodeBlock,
+  BlockquoteNonInteractive,
+  HeadingNonInteractive,
+  TodoListNonInteractive,
+  OrderedListNonInteractive,
+  UnorderedListNonInteractive,
+  HorizontalRules,
+  ParagraphNonInteractive,
+];
+
+export const inlineElementParserListNonInteractive: Parser[] = [
+  Image,
+  BoldEmphasisNonInteractive,
+  BoldNonInteractive,
+  EmphasisNonInteractive,
+  LinkNonInteractive,
+  MemoRefNonInteractive,
+  PlainLinkNonInteractive,
+  InlineCode,
+  Strikethrough,
+  Tag,
+  PlainText,
+];

--- a/web/src/less/memo-content.less
+++ b/web/src/less/memo-content.less
@@ -33,7 +33,7 @@
       @apply block max-w-full rounded cursor-pointer hover:shadow;
     }
 
-    .tag-span {
+    .tag-span, .memo-ref {
       @apply inline-block w-auto text-blue-600 dark:text-blue-400 cursor-pointer;
     }
 

--- a/web/src/less/memos-selector-dialog.less
+++ b/web/src/less/memos-selector-dialog.less
@@ -1,0 +1,5 @@
+.memos-selector-dialog {
+  > .dialog-container {
+    @apply w-180;
+  }
+}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -99,7 +99,8 @@
       "disabled": "Public memos are disabled"
     },
     "delete-memo": "Delete Memo",
-    "delete-confirm": "Are you sure to delete this memo?\n\nTHIS ACTION IS IRREVERSIBLE❗"
+    "delete-confirm": "Are you sure to delete this memo?\n\nTHIS ACTION IS IRREVERSIBLE❗",
+    "select": "Select Memo"
   },
   "resource": {
     "no-resources": "No resources.",


### PR DESCRIPTION
Hello,
Thanks for a fun and good app! Here's a suggestion on how one could reference memos from other memos. This is my first PR here and I didn't find much docs about contributing, so  I figured I'd just give it a go and see what you think 👍 no harsh feelings if you don't like it or want a different approach - it's completely unsolicited haha.

Changes worth noting
- [x] The killer feature: Created an inline markdown parser that links "memo references" (`m/123`) to actual memos
- [x] Refactored search input field to be reusable
- [x] Created an "non-interactive" version of the markdown parser to allow the memo content to be used as buttons
- [x] Changed the editor icon for "resources" to match the sidebar icon and used the "file" one for selecting memos instead 

What's left before this PR is complete
- [ ] Updating locales (I didn't quite understand how to do this and didn't find any docs, cc @boojack i guess?)

Future suggestions
- [ ] Creating an index of referenced memos, so that I can see on `m/2` that `m/1` mentions it. Seems like a larger thing though so leaving it out of scope for now.

![memo](https://user-images.githubusercontent.com/3954425/232699320-f5615e79-5733-4b12-890a-6987ec274a4a.gif)
