### PR TITLE
docs: upgrade on fly.io

### DIFF
--- a/docs/updates.md
+++ b/docs/updates.md
@@ -1,0 +1,11 @@
+# Updating memos after deploying
+
+## fly.io
+
+### update to latest
+Under the directory where you had your `fly.toml` file
+
+```
+flyctl deploy
+```
+


### PR DESCRIPTION
Added a document detailing how to update to the latest version of memos after deploying on fly.io