### PR TITLE
reappearing of dialog should add body scrolling class.

### DIFF
--- a/web/src/components/AskAIDialog.tsx
+++ b/web/src/components/AskAIDialog.tsx
@@ -145,6 +145,7 @@ function showAskAIDialog() {
   if (dialogElement) {
     dialogElement.classList.remove("showoff");
     dialogElement.classList.add("showup");
+    document.body.classList.add("overflow-hidden");
   } else {
     generateDialog(
       {


### PR DESCRIPTION
When dialog is reappeared after being in a hidden state. Then reappeaning should block further body scrolling for consistent UX.