### PR TITLE
memo content availability for visitor mode.

### DIFF
--- a/web/src/components/MemoContent.tsx
+++ b/web/src/components/MemoContent.tsx
@@ -29,10 +29,12 @@ const MemoContent: React.FC<Props> = (props: Props) => {
     expandButtonStatus: -1,
   });
   const memoContentContainerRef = useRef<HTMLDivElement>(null);
-
+  
+  const isVisitorMode = userStore.isVisitorMode();
+  
   //variable for auto-collapse
   const userStore = useUserStore();
-  const { localSetting } = userStore.state.user as User;
+  const autoCollapse:boolean = isVisitorMode ? true : userStore.state.user.enableAutoCollapse;
 
   useEffect(() => {
     if (showFull) {
@@ -73,14 +75,14 @@ const MemoContent: React.FC<Props> = (props: Props) => {
       <div
         ref={memoContentContainerRef}
         className={`memo-content-text ${
-          localSetting.enableAutoCollapse && state.expandButtonStatus === 0 ? "max-h-64 overflow-y-hidden" : ""
+          autoCollapse && state.expandButtonStatus === 0 ? "max-h-64 overflow-y-hidden" : ""
         }`}
         onClick={handleMemoContentClick}
         onDoubleClick={handleMemoContentDoubleClick}
       >
         {marked(content)}
       </div>
-      {localSetting.enableAutoCollapse && state.expandButtonStatus !== -1 && (
+      {autoCollapse && state.expandButtonStatus !== -1 && (
         <div className={`expand-btn-container ${state.expandButtonStatus === 0 && "!-mt-7"}`}>
           <div className="absolute top-0 left-0 w-full h-full blur-lg bg-white dark:bg-zinc-700"></div>
           <span className={`btn z-10 ${state.expandButtonStatus === 0 ? "expand-btn" : "fold-btn"}`} onClick={handleExpandBtnClick}>


### PR DESCRIPTION
MemoContent being part of "Memo" Component and Memo part of "Explore" page. MemoContent throws error and doesn't render without User states. Since user is "undefined" for visitor mode, destructuring user states to get localSetting is not possible. Hence adding further guard to check for visitorMode and making autoCollapse state "true" by default is the right choice.