### PR TITLE
feat: read content from search params

### DIFF
--- a/web/src/components/MemoEditor.tsx
+++ b/web/src/components/MemoEditor.tsx
@@ -14,12 +14,17 @@ import ResourceIcon from "./ResourceIcon";
 import showResourcesSelectorDialog from "./ResourcesSelectorDialog";
 import showCreateResourceDialog from "./CreateResourceDialog";
 import "@/less/memo-editor.less";
+import { clearContentQueryParam, getContentQueryParam } from "@/helpers/utils";
 
 const listItemSymbolList = ["- [ ] ", "- [x] ", "- [X] ", "* ", "- "];
 const emptyOlReg = /^(\d+)\. $/;
 
 const getEditorContentCache = (): string => {
   return storage.get(["editorContentCache"]).editorContentCache ?? "";
+};
+
+const getInitialContent = (): string => {
+  return getContentQueryParam() ?? getEditorContentCache();
 };
 
 const setEditorContentCache = (content: string) => {
@@ -286,6 +291,7 @@ const MemoEditor = () => {
     editorStore.clearResourceList();
     setEditorContentCache("");
     editorRef.current?.setContent("");
+    clearContentQueryParam();
   };
 
   const handleCancelEdit = () => {
@@ -378,7 +384,7 @@ const MemoEditor = () => {
   const editorConfig = useMemo(
     () => ({
       className: `memo-editor`,
-      initialContent: getEditorContentCache(),
+      initialContent: getInitialContent(),
       placeholder: t("editor.placeholder"),
       fullscreen: state.fullscreen,
       onContentChange: handleContentChange,

--- a/web/src/helpers/utils.ts
+++ b/web/src/helpers/utils.ts
@@ -105,3 +105,18 @@ export const formatBytes = (bytes: number) => {
     i = Math.floor(Math.log(bytes) / Math.log(k));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
 };
+
+export const getContentQueryParam = (): string | undefined => {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get("content") ?? undefined;
+};
+
+export const clearContentQueryParam = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  urlParams.delete("content");
+  let url = window.location.pathname;
+  if (urlParams.toString()) {
+    url += `?${urlParams.toString()}`;
+  }
+  window.history.replaceState({}, "", url);
+};


### PR DESCRIPTION
Wanted to add this feature to prefill the memo editor content from the URL.

<img width="651" alt="Screenshot 2023-04-26 at 21 31 22" src="https://user-images.githubusercontent.com/430872/234683010-63d0bbd5-463a-456e-b6b7-15c662845152.png">

Had some trouble running the e2e tests, could someone tell me how to get them running so I can add tests if needed?
