### PR TITLE
feat: add support for image thumbnail

### DIFF
--- a/common/image.go
+++ b/common/image.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+
+	"image/jpeg"
+	"image/png"
+)
+
+func ResizeImageBlob(data []byte, maxSize int, mime string) ([]byte, error) {
+	var err error
+	var oldImage image.Image
+
+	switch mime {
+	case "image/jpeg":
+		oldImage, err = jpeg.Decode(bytes.NewReader(data))
+	case "image/png":
+		oldImage, err = png.Decode(bytes.NewReader(data))
+	default:
+		return nil, fmt.Errorf("mime %s is not support", mime)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	bounds := oldImage.Bounds()
+	if bounds.Dx() <= maxSize && bounds.Dy() <= maxSize {
+		return data, nil
+	}
+
+	oldBounds := oldImage.Bounds()
+
+	dy := maxSize
+	r := float32(oldBounds.Dy()) / float32(maxSize)
+	dx := int(float32(oldBounds.Dx()) / r)
+	if oldBounds.Dx() > oldBounds.Dy() {
+		dx = maxSize
+		r = float32(oldBounds.Dx()) / float32(maxSize)
+		dy = int(float32(oldBounds.Dy()) / r)
+	}
+
+	newBounds := image.Rect(0, 0, dx, dy)
+	newImage := image.NewRGBA(newBounds)
+	for x := 0; x < newBounds.Dx(); x++ {
+		for y := 0; y < newBounds.Dy(); y++ {
+			newImage.Set(x, y, oldImage.At(int(float32(x)*r), int(float32(y)*r)))
+		}
+	}
+
+	var newBuffer bytes.Buffer
+	switch mime {
+	case "image/jpeg":
+		err = jpeg.Encode(&newBuffer, newImage, nil)
+	case "image/png":
+		err = png.Encode(&newBuffer, newImage)
+	}
+
+	return newBuffer.Bytes(), nil
+}

--- a/common/image.go
+++ b/common/image.go
@@ -9,6 +9,8 @@ import (
 	"image/png"
 )
 
+const ThumbnailPath = ".thumbnail_cache"
+
 func ResizeImageBlob(data []byte, maxSize int, mime string) ([]byte, error) {
 	var err error
 	var oldImage image.Image

--- a/common/image.go
+++ b/common/image.go
@@ -57,6 +57,9 @@ func ResizeImageBlob(data []byte, maxSize int, mime string) ([]byte, error) {
 	case "image/png":
 		err = png.Encode(&newBuffer, newImage)
 	}
+	if err != nil {
+		return nil, err
+	}
 
 	return newBuffer.Bytes(), nil
 }

--- a/server/resource.go
+++ b/server/resource.go
@@ -157,9 +157,13 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 			}
 
 			fileBytes, err := io.ReadAll(sourceFile)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to read resource file").SetInternal(err)
+			}
+
 			err = os.WriteFile(filePath, fileBytes, 0666)
 			if err != nil {
-				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create file").SetInternal(err)
+				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to write resource file").SetInternal(err)
 			}
 
 			if filetype == "image/jpeg" || filetype == "image/png" {

--- a/server/resource.go
+++ b/server/resource.go
@@ -172,7 +172,7 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to generate image thumbnail").SetInternal(err)
 				}
 
-				thumbnailPath := filepath.Join(dir, publicID+"-thumbnail"+filepath.Ext(file.Filename))
+				thumbnailPath := filepath.Join(dir, publicID+"-thumbnail"+path.Ext(filePath))
 				err = os.WriteFile(thumbnailPath, thumbnailBytes, 0666)
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create thumbnail file").SetInternal(err)

--- a/server/resource.go
+++ b/server/resource.go
@@ -335,6 +335,13 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 			if err != nil {
 				log.Warn(fmt.Sprintf("failed to delete local file with path %s", resource.InternalPath), zap.Error(err))
 			}
+
+			ext := filepath.Ext(resource.InternalPath)
+			thumbnailPath := strings.TrimSuffix(resource.InternalPath, ext) + "-thumbnail" + ext
+			err = os.Remove(thumbnailPath)
+			if err != nil {
+				log.Warn(fmt.Sprintf("failed to delete local file with path %s", thumbnailPath), zap.Error(err))
+			}
 		}
 
 		resourceDelete := &api.ResourceDelete{

--- a/web/src/components/MemoResources.tsx
+++ b/web/src/components/MemoResources.tsx
@@ -46,7 +46,7 @@ const MemoResources: React.FC<Props> = (props: Props) => {
               if (resource.type.startsWith("image")) {
                 return (
                   <SquareDiv key={resource.id} className="memo-resource">
-                    <img src={absolutifyLink(url)+"?thumbnail=1"} onClick={() => handleImageClick(url)} decoding="async" loading="lazy" />
+                    <img src={absolutifyLink(url) + "?thumbnail=1"} onClick={() => handleImageClick(url)} decoding="async" loading="lazy" />
                   </SquareDiv>
                 );
               } else if (resource.type.startsWith("video")) {

--- a/web/src/components/MemoResources.tsx
+++ b/web/src/components/MemoResources.tsx
@@ -46,7 +46,7 @@ const MemoResources: React.FC<Props> = (props: Props) => {
               if (resource.type.startsWith("image")) {
                 return (
                   <SquareDiv key={resource.id} className="memo-resource">
-                    <img src={absolutifyLink(url)} onClick={() => handleImageClick(url)} decoding="async" loading="lazy" />
+                    <img src={absolutifyLink(url)+"?thumbnail=1"} onClick={() => handleImageClick(url)} decoding="async" loading="lazy" />
                   </SquareDiv>
                 );
               } else if (resource.type.startsWith("video")) {


### PR DESCRIPTION
While publishing a large number of HD images, the memoe will take a lot of time to load.

So I just generate a smaller thumbnail while uploading image resources, and only load the thumbnail in the memo. If click on the image, it will load the original HD image lazy.