### PR TITLE
fix: wrong position of UsageStatItem's popup

### DIFF
--- a/web/src/helpers/utils.ts
+++ b/web/src/helpers/utils.ts
@@ -47,7 +47,7 @@ export const getElementBounding = (element: HTMLElement, relativeEl?: HTMLElemen
     }
 
     const position = window.getComputedStyle(element).getPropertyValue("position");
-	if (position === "fixed" || position === "static") {
+    if (position === "fixed" || position === "static") {
       return true;
     }
 

--- a/web/src/helpers/utils.ts
+++ b/web/src/helpers/utils.ts
@@ -46,7 +46,8 @@ export const getElementBounding = (element: HTMLElement, relativeEl?: HTMLElemen
       return false;
     }
 
-    if (window.getComputedStyle(element).getPropertyValue("position") === "fixed") {
+    const position = window.getComputedStyle(element).getPropertyValue("position");
+	if (position === "fixed" || position === "static") {
       return true;
     }
 


### PR DESCRIPTION
After scroll the page, the popup div of the UsageStatItem was wrong, like the screenshot below:

<img width="566" alt="bug" src="https://github.com/usememos/memos/assets/126313/10913eb3-3e34-4c18-b0bf-2449ae0948d1">