### PR TITLE
fix: File size exceeds allowed limit of 0 MiB

### DIFF
--- a/server/resource.go
+++ b/server/resource.go
@@ -70,7 +70,8 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusUnauthorized, "Missing user in session")
 		}
 
-		maxUploadSetting := s.Store.GetSystemSettingValueOrDefault(&ctx, api.SystemSettingMaxUploadSizeMiBName, "0")
+		// This is the backend default max upload size limit.
+		maxUploadSetting := s.Store.GetSystemSettingValueOrDefault(&ctx, api.SystemSettingMaxUploadSizeMiBName, "32")
 		var settingMaxUploadSizeBytes int
 		if settingMaxUploadSizeMiB, err := strconv.Atoi(maxUploadSetting); err == nil {
 			settingMaxUploadSizeBytes = settingMaxUploadSizeMiB * MebiByte

--- a/server/system.go
+++ b/server/system.go
@@ -44,7 +44,7 @@ func (s *Server) registerSystemRoutes(g *echo.Group) {
 			AllowSignUp:        false,
 			IgnoreUpgrade:      false,
 			DisablePublicMemos: false,
-			MaxUploadSizeMiB:   32,
+			MaxUploadSizeMiB:   32, // this is the frontend default value
 			AdditionalStyle:    "",
 			AdditionalScript:   "",
 			CustomizedProfile: api.CustomizedProfile{


### PR DESCRIPTION
fix: File size exceeds allowed limit of 0 MiB

This could happen in databases without "max-upload-size-mib" setting.

Now, both the front-end and the back-end will start with a default limit of 32 MiB, even if the key is absent.

It is still possible to disable uploads by setting the value to 0.