### PR TITLE
Show thumbnail in resource dashboard

### DIFF
--- a/web/src/components/ResourceCover.tsx
+++ b/web/src/components/ResourceCover.tsx
@@ -39,7 +39,7 @@ const ResourceCover = ({ resource }: ResourceCoverProps) => {
     case "image/*":
       return (
         <div className="resource-cover">
-          <img src={getResourceUrl(resource) + "?thumbnail=1"}></img>
+          <img className="h-20 w-20" src={getResourceUrl(resource) + "?thumbnail=1"}></img>
         </div>
       );
     case "video/*":

--- a/web/src/components/ResourceCover.tsx
+++ b/web/src/components/ResourceCover.tsx
@@ -37,7 +37,9 @@ const ResourceCover = ({ resource }: ResourceCoverProps) => {
   const resourceType = getResourceType(resource);
   switch (resourceType) {
     case "image/*":
-      return <div className="resource-cover"><img src={getResourceUrl(resource) + "?thumbnail=1"}></img></div>;
+      return (
+        <div className="resource-cover"><img src={getResourceUrl(resource) + "?thumbnail=1"}></img></div>
+      );
     case "video/*":
       return <Icon.FileVideo2 className="resource-cover" />;
     case "audio/*":

--- a/web/src/components/ResourceCover.tsx
+++ b/web/src/components/ResourceCover.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Icon from "./Icon";
 import { getResourceUrl } from "@/utils/resource";
+import showPreviewImageDialog from "./PreviewImageDialog";
 import "@/less/resource-cover.less";
 
 interface ResourceCoverProps {
@@ -37,7 +38,8 @@ const ResourceCover = ({ resource }: ResourceCoverProps) => {
   const resourceType = getResourceType(resource);
   switch (resourceType) {
     case "image/*":
-      return <img className="resource-cover h-20 w-20" src={getResourceUrl(resource) + "?thumbnail=1"}></img>;
+      const resourceUrl = getResourceUrl(resource);
+      return <img className="resource-cover h-20 w-20" src={resourceUrl + "?thumbnail=1"} onClick={() => showPreviewImageDialog(resourceUrl)}></img>;
     case "video/*":
       return <Icon.FileVideo2 className="resource-cover" />;
     case "audio/*":

--- a/web/src/components/ResourceCover.tsx
+++ b/web/src/components/ResourceCover.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Icon from "./Icon";
+import { getResourceUrl } from "@/utils/resource";
 import "@/less/resource-cover.less";
 
 interface ResourceCoverProps {
@@ -36,7 +37,7 @@ const ResourceCover = ({ resource }: ResourceCoverProps) => {
   const resourceType = getResourceType(resource);
   switch (resourceType) {
     case "image/*":
-      return <Icon.FileImage className="resource-cover" />;
+      return <div className="resource-cover"><img src={getResourceUrl(resource) + "?thumbnail=1"}></img></div>;
     case "video/*":
       return <Icon.FileVideo2 className="resource-cover" />;
     case "audio/*":

--- a/web/src/components/ResourceCover.tsx
+++ b/web/src/components/ResourceCover.tsx
@@ -36,10 +36,12 @@ const getResourceType = (resource: Resource) => {
 
 const ResourceCover = ({ resource }: ResourceCoverProps) => {
   const resourceType = getResourceType(resource);
+  const resourceUrl = getResourceUrl(resource);
   switch (resourceType) {
     case "image/*":
-      const resourceUrl = getResourceUrl(resource);
-      return <img className="resource-cover h-20 w-20" src={resourceUrl + "?thumbnail=1"} onClick={() => showPreviewImageDialog(resourceUrl)}></img>;
+      return (
+        <img className="resource-cover h-20 w-20" src={resourceUrl + "?thumbnail=1"} onClick={() => showPreviewImageDialog(resourceUrl)} />
+      );
     case "video/*":
       return <Icon.FileVideo2 className="resource-cover" />;
     case "audio/*":

--- a/web/src/components/ResourceCover.tsx
+++ b/web/src/components/ResourceCover.tsx
@@ -37,11 +37,7 @@ const ResourceCover = ({ resource }: ResourceCoverProps) => {
   const resourceType = getResourceType(resource);
   switch (resourceType) {
     case "image/*":
-      return (
-        <div className="resource-cover">
-          <img className="h-20 w-20" src={getResourceUrl(resource) + "?thumbnail=1"}></img>
-        </div>
-      );
+      return <img className="resource-cover h-20 w-20" src={getResourceUrl(resource) + "?thumbnail=1"}></img>;
     case "video/*":
       return <Icon.FileVideo2 className="resource-cover" />;
     case "audio/*":

--- a/web/src/components/ResourceCover.tsx
+++ b/web/src/components/ResourceCover.tsx
@@ -38,7 +38,9 @@ const ResourceCover = ({ resource }: ResourceCoverProps) => {
   switch (resourceType) {
     case "image/*":
       return (
-        <div className="resource-cover"><img src={getResourceUrl(resource) + "?thumbnail=1"}></img></div>
+        <div className="resource-cover">
+          <img src={getResourceUrl(resource) + "?thumbnail=1"}></img>
+        </div>
       );
     case "video/*":
       return <Icon.FileVideo2 className="resource-cover" />;

--- a/web/src/less/resource-cover.less
+++ b/web/src/less/resource-cover.less
@@ -1,3 +1,5 @@
 .resource-cover {
   @apply w-20 h-auto ml-auto mr-auto opacity-40;
+  height: 5rem;
+  overflow-y: hidden;
 }

--- a/web/src/less/resource-cover.less
+++ b/web/src/less/resource-cover.less
@@ -1,5 +1,3 @@
 .resource-cover {
   @apply w-20 h-auto ml-auto mr-auto opacity-40;
-  height: 5rem;
-  overflow-y: hidden;
 }


### PR DESCRIPTION
The resource dashboard now only show an icon for all resources. Change it to show the thumbnail while it was an image.

<img width="635" alt="show" src="https://github.com/usememos/memos/assets/126313/4fdbc0e4-fad2-4cac-a679-fde524bf0988">
