### PR TITLE
fix: md without search icon

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -32,7 +32,7 @@ const Header = () => {
 
   return (
     <div
-      className={`fixed sm:sticky top-0 left-0 w-full sm:w-56 h-full shrink-0 pointer-events-none sm:pointer-events-auto z-20 ${
+      className={`fixed sm:sticky top-0 left-0 w-full sm:w-56 h-full shrink-0 pointer-events-none sm:pointer-events-auto z-10 ${
         showHeader && "pointer-events-auto"
       }`}
     >

--- a/web/src/components/MobileHeader.tsx
+++ b/web/src/components/MobileHeader.tsx
@@ -28,7 +28,7 @@ const MobileHeader = (props: Props) => {
   }, [filter, shortcuts]);
 
   return (
-    <div className="sticky top-0 pt-4 pb-1 mb-1 backdrop-blur-sm flex sm:hidden flex-row justify-between items-center w-full h-auto flex-nowrap shrink-0 z-2">
+    <div className="sticky top-0 pt-4 pb-1 mb-1 backdrop-blur-sm flex md:hidden flex-row justify-between items-center w-full h-auto flex-nowrap shrink-0 z-2">
       <div className="flex flex-row justify-start items-center mr-2 shrink-0 overflow-hidden">
         <div
           className="flex sm:hidden flex-row justify-center items-center w-6 h-6 mr-1 shrink-0 bg-transparent"


### PR DESCRIPTION
Old:
<img width="762" alt="CleanShot 2023-05-21 at 14 38 33@2x" src="https://github.com/usememos/memos/assets/29306285/c0aaf906-a33e-4733-b98a-b580296d155f">
When the width is md. the user interface has no search button and no home side.

## What does PR do:
- show the search button when the width is md
- fix error z-index
otherwise:
<img width="733" alt="CleanShot 2023-05-21 at 14 44 34@2x" src="https://github.com/usememos/memos/assets/29306285/1aa902e9-ba5b-40f1-bee8-b7f3d07827f7">

New:
<img width="737" alt="CleanShot 2023-05-21 at 14 45 18@2x" src="https://github.com/usememos/memos/assets/29306285/41b769d1-5b29-461a-a2cd-d28ad8f97553">
