### PR TITLE
fix: pop search when touch textarea in Android Chrome

### DIFF
--- a/web/src/components/HomeSidebar.tsx
+++ b/web/src/components/HomeSidebar.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from "react";
-import { resolution } from "../utils/layout";
 import { useLayoutStore, useUserStore } from "../store/module";
 import ShortcutList from "./ShortcutList";
 import TagList from "./TagList";

--- a/web/src/components/HomeSidebar.tsx
+++ b/web/src/components/HomeSidebar.tsx
@@ -11,35 +11,6 @@ const HomeSidebar = () => {
   const userStore = useUserStore();
   const showHomeSidebar = layoutStore.state.showHomeSidebar;
 
-  useEffect(() => {
-    let initialized = false;
-    let lastStatus = layoutStore.state.showHomeSidebar;
-    const handleWindowResize = () => {
-      let nextStatus = window.innerWidth < resolution.md;
-      if (lastStatus !== nextStatus) {
-        if (!initialized && nextStatus) {
-          // Don't show sidebar on first load in mobile view.
-          nextStatus = false;
-        }
-
-        layoutStore.setHomeSidebarStatus(nextStatus);
-        lastStatus = nextStatus;
-      }
-
-      if (!initialized) {
-        initialized = true;
-        return;
-      }
-    };
-
-    window.addEventListener("resize", handleWindowResize);
-    handleWindowResize();
-
-    return () => {
-      window.removeEventListener("resize", handleWindowResize);
-    };
-  }, []);
-
   return (
     <div
       className={`fixed md:sticky top-0 left-0 w-full md:w-56 h-full shrink-0 pointer-events-none md:pointer-events-auto z-10 ${


### PR DESCRIPTION
close: #1667 #1594
the Bug caused by touch textarea will tigger resize event in Android chrome🤔 I try to set `resize: none` or anything. But these didn't work. But I found to delete the resize function. all functions are working fine! 🤯


# Now:
## Android
https://github.com/usememos/memos/assets/29306285/48d393d5-ab74-47f3-8002-330aaebcdae4

## desktop scale:
adjust width when opening search:
![CleanShot 2023-05-21 at 15 29 54](https://github.com/usememos/memos/assets/29306285/0ade59aa-7b7b-4ebd-9c8b-2788e553da2e)
the error highlight fixed in #1699

## adjust width when closing search:
![CleanShot 2023-05-21 at 15 36 40](https://github.com/usememos/memos/assets/29306285/f69485a1-954e-423b-b9e9-98165f0c94c1)
