### PR TITLE
Replace filename to publicid

### DIFF
--- a/server/resource.go
+++ b/server/resource.go
@@ -143,14 +143,10 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to find local storage path setting").SetInternal(err)
 			}
 			localStoragePath := "assets/{publicid}"
-			if systemSettingLocalStoragePath != nil {
-				var s string
-				err = json.Unmarshal([]byte(systemSettingLocalStoragePath.Value), &s)
+			if systemSettingLocalStoragePath != nil && systemSettingLocalStoragePath.Value != "" {
+				err = json.Unmarshal([]byte(systemSettingLocalStoragePath.Value), &localStoragePath)
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to unmarshal local storage path setting").SetInternal(err)
-				}
-				if s != "" {
-					localStoragePath = s
 				}
 			}
 			filePath := filepath.FromSlash(localStoragePath)

--- a/server/resource.go
+++ b/server/resource.go
@@ -142,7 +142,7 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 			if err != nil && common.ErrorCode(err) != common.NotFound {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to find local storage path setting").SetInternal(err)
 			}
-			localStoragePath := "assets/{timestamp}_{filename}"
+			localStoragePath := "assets/{publicid}"
 			if systemSettingLocalStoragePath != nil {
 				err = json.Unmarshal([]byte(systemSettingLocalStoragePath.Value), &localStoragePath)
 				if err != nil {
@@ -150,11 +150,12 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 				}
 			}
 			filePath := filepath.FromSlash(localStoragePath)
-			if !strings.Contains(filePath, "{filename}") {
-				filePath = filepath.Join(filePath, "{filename}")
+			if !strings.Contains(filePath, "{publicid}") {
+				filePath = filepath.Join(filePath, "{publicid}")
 			}
-			dir, filename := filepath.Split(filePath)
 			filePath = filepath.Join(s.Profile.Data, replacePathTemplate(filePath, file.Filename, publicID))
+
+			dir := filepath.Dir(filePath)
 			if err = os.MkdirAll(dir, os.ModePerm); err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create directory").SetInternal(err)
 			}
@@ -170,7 +171,7 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 
 			resourceCreate = &api.ResourceCreate{
 				CreatorID:    userID,
-				Filename:     filename,
+				Filename:     file.Filename,
 				Type:         filetype,
 				Size:         size,
 				InternalPath: filePath,
@@ -197,8 +198,8 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 				}
 
 				filePath := s3Config.Path
-				if !strings.Contains(filePath, "{filename}") {
-					filePath = path.Join(filePath, "{filename}")
+				if !strings.Contains(filePath, "{publicid}") {
+					filePath = path.Join(filePath, "{publicid}")
 				}
 				filePath = replacePathTemplate(filePath, file.Filename, publicID)
 				_, filename := filepath.Split(filePath)

--- a/server/resource.go
+++ b/server/resource.go
@@ -157,7 +157,7 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 			if !strings.Contains(filePath, "{publicid}") {
 				filePath = filepath.Join(filePath, "{publicid}")
 			}
-			filePath = filepath.Join(s.Profile.Data, replacePathTemplate(filePath, file.Filename, publicID))
+			filePath = filepath.Join(s.Profile.Data, replacePathTemplate(filePath, file.Filename, publicID+filepath.Ext(file.Filename)))
 
 			dir := filepath.Dir(filePath)
 			if err = os.MkdirAll(dir, os.ModePerm); err != nil {
@@ -205,7 +205,7 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 				if !strings.Contains(filePath, "{publicid}") {
 					filePath = path.Join(filePath, "{publicid}")
 				}
-				filePath = replacePathTemplate(filePath, file.Filename, publicID)
+				filePath = replacePathTemplate(filePath, file.Filename, publicID+filepath.Ext(file.Filename))
 				_, filename := filepath.Split(filePath)
 				link, err := s3Client.UploadFile(ctx, filePath, filetype, sourceFile)
 				if err != nil {

--- a/server/resource.go
+++ b/server/resource.go
@@ -153,8 +153,8 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 			if !strings.Contains(filePath, "{filename}") {
 				filePath = filepath.Join(filePath, "{filename}")
 			}
-			filePath = filepath.Join(s.Profile.Data, replacePathTemplate(filePath, file.Filename))
 			dir, filename := filepath.Split(filePath)
+			filePath = filepath.Join(s.Profile.Data, replacePathTemplate(filePath, file.Filename, publicID))
 			if err = os.MkdirAll(dir, os.ModePerm); err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create directory").SetInternal(err)
 			}
@@ -200,7 +200,7 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 				if !strings.Contains(filePath, "{filename}") {
 					filePath = path.Join(filePath, "{filename}")
 				}
-				filePath = replacePathTemplate(filePath, file.Filename)
+				filePath = replacePathTemplate(filePath, file.Filename, publicID)
 				_, filename := filepath.Split(filePath)
 				link, err := s3Client.UploadFile(ctx, filePath, filetype, sourceFile)
 				if err != nil {
@@ -476,10 +476,12 @@ func (s *Server) createResourceCreateActivity(c echo.Context, resource *api.Reso
 	return err
 }
 
-func replacePathTemplate(path string, filename string) string {
+func replacePathTemplate(path, filename, publicID string) string {
 	t := time.Now()
 	path = fileKeyPattern.ReplaceAllStringFunc(path, func(s string) string {
 		switch s {
+		case "{publicid}":
+			return publicID
 		case "{filename}":
 			return filename
 		case "{timestamp}":

--- a/server/resource.go
+++ b/server/resource.go
@@ -144,9 +144,13 @@ func (s *Server) registerResourceRoutes(g *echo.Group) {
 			}
 			localStoragePath := "assets/{publicid}"
 			if systemSettingLocalStoragePath != nil {
-				err = json.Unmarshal([]byte(systemSettingLocalStoragePath.Value), &localStoragePath)
+				var s string
+				err = json.Unmarshal([]byte(systemSettingLocalStoragePath.Value), &s)
 				if err != nil {
 					return echo.NewHTTPError(http.StatusInternalServerError, "Failed to unmarshal local storage path setting").SetInternal(err)
+				}
+				if s != "" {
+					localStoragePath = s
 				}
 			}
 			filePath := filepath.FromSlash(localStoragePath)

--- a/web/src/components/UpdateLocalStorageDialog.tsx
+++ b/web/src/components/UpdateLocalStorageDialog.tsx
@@ -52,7 +52,7 @@ const UpdateLocalStorageDialog: React.FC<Props> = (props: Props) => {
         <p className="text-sm break-words mb-1">{t("setting.storage-section.update-local-path-description")}</p>
         <div className="flex flex-row">
           <p className="text-sm text-gray-400 mb-2 break-all">
-            {t("common.e.g")} {"assets/{timestamp}_{filename}"}
+            {t("common.e.g")} {"assets/{publicid}"}
           </p>
           <HelpButton hint={t("common.learn-more")} url="https://usememos.com/docs/local-storage" />
         </div>


### PR DESCRIPTION
Currently, we use filename in the storage path. Because the filename comes from the user's input, it may cause some problems, such as:

- Same filename will replace each other.
- Characters in filename is difference between all OS. Valid name in Windows may cause problems in Linux.

So I replace the origin filename into a UUID which exists in the code. The new filename used to storage only, and the origin filename still save in the database for review and shown in UI.

