### PR TITLE
vscode setting enforcement for go111module="on" and installability of go extension's schema.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
+  "json.schemaDownload.enable":true,
   "go.lintOnSave": "workspace",
   "go.lintTool": "golangci-lint",
-  "go.inferGopath": false
+  "go.inferGopath": false,
+  "go.toolsEnvVars": {
+    "GO111MODULE": "on"
+  }
 }


### PR DESCRIPTION
We have to specifically ensure that GO111MODULE isn't set to "off", which could lead to looking for package at GOPATH/src or GOROOT/src. VSCode need to know that module-mode is enabled for the go command.