### PR TITLE
feat: add docker compose file for development

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,28 @@
+# 1.Prepare your workspace by:
+#     docker compose run api go install github.com/cosmtrek/air@latest
+#     docker compose run web npm install
+#
+# 2. Start you work by:
+#     docker compose up -d
+#
+# 3. Check logs by:
+#     docker compose logs -f
+#
+services:
+  api:
+    image: golang:1.19.3-alpine3.16
+    working_dir: /work
+    command: air -c ./scripts/.air.toml
+    volumes:
+      - .:/work/
+      - ./.air/go/:/go/ # Cache for go mod database
+  web:
+    image: node:18.12.1-alpine3.16
+    working_dir: /work
+    depends_on: ["api"]
+    ports: ["3001:3001"]
+    environment: ["DEV_PROXY_SERVER=http://api:8081/"]
+    command: npm run dev
+    volumes:
+      - ./web:/work
+      - ./.air/node_modules/:/work/node_modules/ # Cache for Node Modules

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,7 +2,11 @@ import { resolve } from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 
-const devProxyServer = "http://localhost:8081/";
+let devProxyServer = "http://localhost:8081/";
+if (process.env.DEV_PROXY_SERVER && process.env.DEV_PROXY_SERVER.length > 0) {
+  console.log("Use devProxyServer from environment: ", process.env.DEV_PROXY_SERVER);
+  devProxyServer = process.env.DEV_PROXY_SERVER;
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
Run a dev environment with `docker compose -f docker-compose.dev.yaml up -d`, and keep no command console.

Before do that, do some setup command as below:
```bash
docker compose -f docker-compose.dev.yaml run api go install github.com/cosmtrek/air@latest
docker compose -f docker-compose.dev.yaml run web npm install
```

PS: If this proposal was approved, maybe we can move `docker-compose.dev.yaml` to `docker-compose.yaml`.