### PR TITLE
fix: infinite loop in home page

### DIFF
--- a/web/src/components/MemoList.tsx
+++ b/web/src/components/MemoList.tsx
@@ -119,6 +119,7 @@ const MemoList = () => {
     }
     if (sortedMemos.length < DEFAULT_MEMO_LIMIT) {
       handleFetchMoreClick();
+      return;
     }
     const observer = new IntersectionObserver(([entry]) => {
       if (entry.isIntersecting) {


### PR DESCRIPTION
Just fix #1759 .

How to reproduce this bug?

1. Initial a fresh Memos.
2. Feed some memo with script `feed.sh` below.
3. Open the home page, and click on the default tag filter `inbox`.

Now, you can see an infinite request in your API server.


feed.sh

```bash
!#/bin/sh
OPENID=YOUR-OPEN-ID-OF-MEMOS

for i in {1..111} ; do
	m=$( expr $i % 5)

	[ $m -eq 0 ] && curl -X POST "http://localhost:3001/api/memo?openId=${OPENID}" \
		-H 'Content-Type: application/json; charset=utf-8' \
		-d "{\"content\": \"`date +%Y-%m-%d_%H:%M:%S` ${i} Just test\"}"
	[ $m -ne 0 ] && curl -X POST "http://localhost:3001/api/memo?openId=${OPENID}" \
		-H 'Content-Type: application/json; charset=utf-8' \
		-d "{\"content\": \"#tag${m}\n`date +%Y-%m-%d_%H:%M:%S` ${i} Just test\"}"
done
```