### PR TITLE
fix: add public base path (#1748)

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -10,6 +10,7 @@ if (process.env.DEV_PROXY_SERVER && process.env.DEV_PROXY_SERVER.length > 0) {
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: "./",
   plugins: [react()],
   server: {
     host: "0.0.0.0",


### PR DESCRIPTION
Base is the public basic path for development or production environment services. It defaults to "/", is an absolute path, and is modified to "./" to be a relative path available for nginx proxy.