### PR TITLE
feat: resource visibility

### DIFF
--- a/server/resource.go
+++ b/server/resource.go
@@ -356,6 +356,18 @@ func (s *Server) registerResourcePublicRoutes(g *echo.Group) {
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("ID is not a number: %s", c.Param("resourceId"))).SetInternal(err)
 		}
+
+		resourceVisibility, err := CheckResourceVisibility(ctx, s.Store, resourceID)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "Failed to get resource visibility").SetInternal(err)
+		}
+
+		// Protected resource require a logined user
+		userID, ok := c.Get(getUserIDContextKey()).(int)
+		if resourceVisibility == store.Protected && (!ok || userID <= 0) {
+			return echo.NewHTTPError(http.StatusUnauthorized, "Resource visibility not match").SetInternal(err)
+		}
+
 		publicID, err := url.QueryUnescape(c.Param("publicId"))
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("publicID is invalid: %s", c.Param("publicId"))).SetInternal(err)
@@ -368,6 +380,11 @@ func (s *Server) registerResourcePublicRoutes(g *echo.Group) {
 		resource, err := s.Store.FindResource(ctx, resourceFind)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to find resource by ID: %v", resourceID)).SetInternal(err)
+		}
+
+		// Private resource require logined user is the creator
+		if resourceVisibility == store.Private && (!ok || userID != resource.CreatorID) {
+			return echo.NewHTTPError(http.StatusUnauthorized, "Resource visibility not match").SetInternal(err)
 		}
 
 		blob := resource.Blob


### PR DESCRIPTION
Check the resource visibility while get it by
- /r/:resourceId/:publicId/:filename
- /r/:resourceId/:publicId

Resource do not have a `visibility` attribute, its visibility is depend on the memos it attaches to:

- If no memos attached, the resource is `PRIVATE`
- If any memo of attached is `PUBLIC`, the resource is `PUBLIC `
- If any memo of attached is `PROTECTED`, the resource is `PROTECTED `
- If all memo of attached is `PRIVATE`, the resource is `PRIVATE`

PS:
- `PUBLIC` means visible for anyone, include anonymous.
- `PROTECTED` means visible for all logged user
- `PRIVATE` means visible only for user who created the memo.