### PR TITLE
fix: copy-to-clipboard not works well in Safari

### DIFF
--- a/web/src/components/MemoList.tsx
+++ b/web/src/components/MemoList.tsx
@@ -9,13 +9,6 @@ import { checkShouldShowMemoWithFilters } from "@/helpers/filter";
 import Memo from "./Memo";
 import "@/less/memo-list.less";
 import { PLAIN_LINK_REG } from "@/labs/marked/parser";
-import copy from "copy-to-clipboard";
-
-declare global {
-  interface Window {
-    clipboardData: any;
-  }
-}
 
 const MemoList = () => {
   const { t } = useTranslation();
@@ -154,32 +147,6 @@ const MemoList = () => {
     } catch (error: any) {
       console.error(error);
       toast.error(error.response.data.message);
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener("copy", handleCopy);
-    return () => {
-      window.removeEventListener("copy", handleCopy);
-    };
-  }, []);
-
-  const handleCopy = (event: ClipboardEvent) => {
-    event.preventDefault();
-    const rawStr = document.getSelection()?.toString();
-    if (rawStr !== undefined) {
-      let hacked = false;
-      if (typeof window.clipboardData === "undefined") {
-        window.clipboardData = event.clipboardData;
-        hacked = true;
-      }
-      try {
-        copy(rawStr.split("\n\n").join("\n"));
-      } finally {
-        if (hacked) {
-          window.clipboardData = undefined;
-        }
-      }
     }
   };
 

--- a/web/src/components/MemoList.tsx
+++ b/web/src/components/MemoList.tsx
@@ -162,7 +162,18 @@ const MemoList = () => {
     event.preventDefault();
     const rawStr = document.getSelection()?.toString();
     if (rawStr !== undefined) {
-      copy(rawStr.split("\n\n").join("\n"));
+      let hacked = false;
+      if (typeof window.clipboardData === "undefined") {
+        window.clipboardData = event.clipboardData;
+        hacked = true;
+      }
+      try {
+        copy(rawStr.split("\n\n").join("\n"));
+      } finally {
+        if (hacked) {
+          window.clipboardData = undefined;
+        }
+      }
     }
   };
 

--- a/web/src/components/MemoList.tsx
+++ b/web/src/components/MemoList.tsx
@@ -11,6 +11,12 @@ import "@/less/memo-list.less";
 import { PLAIN_LINK_REG } from "@/labs/marked/parser";
 import copy from "copy-to-clipboard";
 
+declare global {
+  interface Window {
+    clipboardData: any;
+  }
+}
+
 const MemoList = () => {
   const { t } = useTranslation();
   const memoStore = useMemoStore();


### PR DESCRIPTION
While copy anything in Safari, there's always shown a dialog like below:

<img width="452" alt="bug" src="https://github.com/usememos/memos/assets/126313/99859c70-2753-4634-ba0d-3284c8bb6670">

I have checked the relative code, and this bug may caused by the `copy-to-clipboard` module which `copy` inject depends on. This module use `document.execCommand("copy")` to copy text into clipboard, but this call will always return `false`, which will enter into `copy-to-clipboard`'s fallback code.

In the fallback code, the module try to use `window.clipboardData.setData` to copy first, if that failed, it'll use `prompt` dialog at last.

In Safari, there is no `clipboardData` on `window` object. But the copy event do.

I can't simply replace the `copy-to-clipboard` module, because maybe some others need that.

So I just make a hook around `copy` call. This hook will determine whether `window.clipboardData` is `undefined`, if it is, just set it from the copy event, and remove it after `copy`.