### PR TITLE
chore: clean Dockerfile to exclude musl-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ RUN pnpm build
 FROM golang:1.19.3-alpine3.16 AS backend
 WORKDIR /backend-build
 
-RUN apk update && apk add --no-cache gcc musl-dev
-
 COPY . .
 COPY --from=frontend /frontend-build/dist ./server/dist
 


### PR DESCRIPTION
We already disabled `CGO_ENABLED` in golang build, so the `musl-dev` which used to install `musl-libc` doesn't need any more. Just clean it from Dockerfile