### PR TITLE
fix: failed to upload OSS with S3 SDK

### DIFF
--- a/plugin/storage/s3/s3.go
+++ b/plugin/storage/s3/s3.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	s3config "github.com/aws/aws-sdk-go-v2/config"
@@ -29,13 +30,18 @@ type Client struct {
 }
 
 func NewClient(ctx context.Context, config *Config) (*Client, error) {
+	// For some s3-compatible object stores, converting the hostname is not required,
+	// and not setting this option will result in not being able to access the corresponding object store address.
+	// But Aliyun OSS should disable this option
+	hostnameImmutable := true
+	if strings.HasSuffix(config.EndPoint, "aliyuncs.com") {
+		hostnameImmutable = false
+	}
 	resolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...any) (aws.Endpoint, error) {
 		return aws.Endpoint{
-			URL:           config.EndPoint,
-			SigningRegion: config.Region,
-			// For some s3-compatible object stores, converting the hostname is not required,
-			// and not setting this option will result in not being able to access the corresponding object store address.
-			HostnameImmutable: true,
+			URL:               config.EndPoint,
+			SigningRegion:     config.Region,
+			HostnameImmutable: hostnameImmutable,
 		}, nil
 	})
 


### PR DESCRIPTION
This PR fixed #1756.

In #1230 we set an option `HostnameImmutable` to `true` for s3 SDK. But it'll break while use this SDK to upload to Aliyun OSS, which is wildly used.

Maybe we should split a `OSS` backend storage instead share with S3, but before that, we can fixed this issue ASAP.