### PR TITLE
filter display time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - uses: sonarsource/sonarqube-scan-action@master
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      # If you wish to fail your job when the Quality Gate is red, uncomment the
+      # following lines. This would typically be used to fail a deployment.
+      # - uses: sonarsource/sonarqube-quality-gate-action@master
+      #   timeout-minutes: 5
+      #   env:
+      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.projectKey=Memos

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   '@emotion/react':

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -1,8 +1,4 @@
-lockfileVersion: '6.1'
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
+lockfileVersion: '6.0'
 
 dependencies:
   '@emotion/react':

--- a/web/src/components/CreateShortcutDialog.tsx
+++ b/web/src/components/CreateShortcutDialog.tsx
@@ -9,6 +9,10 @@ import Icon from "./Icon";
 import { generateDialog } from "./Dialog";
 import Selector from "./kit/Selector";
 import "@/less/create-shortcut-dialog.less";
+import shortcut from "@/store/reducer/shortcut";
+import ShortcutList from "./ShortcutList";
+
+let isClicked = false;
 
 interface Props extends DialogProps {
   shortcutId?: ShortcutId;
@@ -98,6 +102,8 @@ const CreateShortcutDialog: React.FC<Props> = (props: Props) => {
     });
   }, []);
 
+  shortcutId ? isClicked=true : isClicked=false;
+
   return (
     <>
       <div className="dialog-header-container">
@@ -181,11 +187,18 @@ const MemoFilterInputer: React.FC<MemoFilterInputerProps> = (props: MemoFilterIn
 
   useEffect(() => {
     if (type === "DISPLAY_TIME") {
-      const nowDatetimeValue = getNormalizedTimeString();
-      handleValueChange(nowDatetimeValue);
+      if(isClicked){
+        const nowDatetimeValue = filter.value.value;
+        handleValueChange(nowDatetimeValue);
+      }
+      else {
+        const nowDatetimeValue = getNormalizedTimeString();
+        handleValueChange(nowDatetimeValue);
+      }
     } else {
       setValue(filter.value.value);
     }
+    isClicked = false;
   }, [type]);
 
   const handleRelationChange = (value: string) => {


### PR DESCRIPTION
Fix for the following issue:
Editing shortcut with display time filter resets date when editing #1698

I added an implementation on which we detect if we access the createShortcutDialog using the create new shortcut button or via editing existing shortcuts.
If we are editing an existing shortcut, the displaytime won't be altered with the current time. 