### PR TITLE
revert: fix: add public base path (#1748) (#1775)

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -10,7 +10,6 @@ if (process.env.DEV_PROXY_SERVER && process.env.DEV_PROXY_SERVER.length > 0) {
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: "./",
   plugins: [react()],
   server: {
     host: "0.0.0.0",


### PR DESCRIPTION
This reverts commit d205a7683a3ab55c7500fe3507b3f0e95265ea1e.

#1775 has changed the base path in `vite.config.js`, which will breaks all links in subpath , such as `/m/:memoid`.
