### PR TITLE
feat: public in days

### DIFF
--- a/api/user_setting.go
+++ b/api/user_setting.go
@@ -19,6 +19,8 @@ const (
 	UserSettingMemoVisibilityKey UserSettingKey = "memo-visibility"
 	// UserSettingTelegramUserID is the key type for telegram UserID of memos user.
 	UserSettingTelegramUserIDKey UserSettingKey = "telegram-user-id"
+	// UserSettingPublicInDays is the key type for visiable days of public memo.
+	UserSettingPublicInDays UserSettingKey = "public-in-days"
 )
 
 // String returns the string format of UserSettingKey type.
@@ -32,6 +34,8 @@ func (key UserSettingKey) String() string {
 		return "memo-visibility"
 	case UserSettingTelegramUserIDKey:
 		return "telegram-user-id"
+	case UserSettingPublicInDays:
+		return "public-in-days"
 	}
 	return ""
 }
@@ -113,6 +117,16 @@ func (upsert UserSettingUpsert) Validate() error {
 		}
 		if _, err := strconv.Atoi(s); err != nil {
 			return fmt.Errorf("invalid user setting telegram user id value")
+		}
+	} else if upsert.Key == UserSettingPublicInDays {
+		var s string
+		err := json.Unmarshal([]byte(upsert.Value), &s)
+		if err != nil {
+			return fmt.Errorf("invalid user setting public in days value")
+		}
+
+		if v, err := strconv.Atoi(s); err != nil || v < 0 {
+			return fmt.Errorf("invalid user setting public in days value")
 		}
 	} else {
 		return fmt.Errorf("invalid user setting key")

--- a/server/rss.go
+++ b/server/rss.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -33,6 +34,11 @@ func (s *Server) registerRSSRoutes(g *echo.Group) {
 		memoList, err := s.Store.ListMemos(ctx, &memoFind)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to find memo list").SetInternal(err)
+		}
+
+		memoList, err = FilterPublicMemosByDays(ctx, s.Store, memoList)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to filter by public-in-days %s", err)).SetInternal(err)
 		}
 
 		baseURL := c.Scheme() + "://" + c.Request().Host
@@ -65,6 +71,11 @@ func (s *Server) registerRSSRoutes(g *echo.Group) {
 		memoList, err := s.Store.ListMemos(ctx, &memoFind)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to find memo list").SetInternal(err)
+		}
+
+		memoList, err = FilterPublicMemosByDays(ctx, s.Store, memoList)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("Failed to filter by public-in-days %s", err)).SetInternal(err)
 		}
 
 		baseURL := c.Scheme() + "://" + c.Request().Host

--- a/web/src/components/Settings/PreferencesSection.tsx
+++ b/web/src/components/Settings/PreferencesSection.tsx
@@ -17,6 +17,7 @@ const PreferencesSection = () => {
   const { appearance, locale } = globalStore.state;
   const { setting, localSetting } = userStore.state.user as User;
   const [telegramUserId, setTelegramUserId] = useState<string>(setting.telegramUserId);
+  const [publicInDays, setPublicInDays] = useState<string>(setting.publicInDays);
   const visibilitySelectorItems = VISIBILITY_SELECTOR_ITEMS.map((item) => {
     return {
       value: item.value,
@@ -66,6 +67,17 @@ const PreferencesSection = () => {
     setTelegramUserId(value);
   };
 
+  const handlePublicInDaysChanged = async (value: string) => {
+    try {
+      await userStore.upsertUserSetting("public-in-days", value);
+      setPublicInDays(value);
+      toast.success(t("common.dialog.success"));
+    } catch (error: any) {
+      console.error(error);
+      toast.error(error.response.data.message);
+    }
+  };
+
   return (
     <div className="section-container preferences-section-container">
       <p className="title-text">{t("common.basic")}</p>
@@ -96,6 +108,10 @@ const PreferencesSection = () => {
           ))}
         </Select>
       </div>
+      <label className="form-label selector">
+        <span className="text-sm">{t("setting.preference-section.public-in-days")}</span>
+        <Input className="w-16" type="number" value={publicInDays} onChange={(event) => handlePublicInDaysChanged(event.target.value)} />
+      </label>
       <div className="form-label selector">
         <span className="text-sm break-keep text-ellipsis overflow-hidden">{t("setting.preference-section.daily-review-time-offset")}</span>
         <span className="w-auto inline-flex">

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -185,6 +185,7 @@
     },
     "preference-section": {
       "theme": "Theme",
+      "public-in-days": "Visible days of Public Memo",
       "default-memo-visibility": "Default memo visibility",
       "default-resource-visibility": "Default resource visibility",
       "enable-folding-memo": "Enable folding memo",

--- a/web/src/locales/zh-Hans.json
+++ b/web/src/locales/zh-Hans.json
@@ -324,6 +324,7 @@
     "preference": "偏好设置",
     "preference-section": {
       "auto-collapse": "自动折叠",
+      "public-in-days": "公开Memo可见天数",
       "created_ts": "创建时间",
       "daily-review-time-offset": "每日回顾时间偏移",
       "default-memo-sort-option": "备忘录显示时间",

--- a/web/src/store/module/user.ts
+++ b/web/src/store/module/user.ts
@@ -12,6 +12,7 @@ const defaultSetting: Setting = {
   appearance: getSystemColorScheme(),
   memoVisibility: "PRIVATE",
   telegramUserId: "",
+  publicInDays: "",
 };
 
 const defaultLocalSetting: LocalSetting = {

--- a/web/src/types/modules/setting.d.ts
+++ b/web/src/types/modules/setting.d.ts
@@ -9,6 +9,7 @@ interface Setting {
   appearance: Appearance;
   memoVisibility: Visibility;
   telegramUserId: string;
+  publicInDays: string;
 }
 
 interface LocalSetting {


### PR DESCRIPTION
Add support for filter public memos by days.

Any user can config a `public-in-days` setting, which will hide all public memos create before that. Both `/memos/all` in `Explore` and RSS feed will affect by this.

This PR also close #1122 

