### PR TITLE
fix: systemSetting in UI changed unexpectedly

### DIFF
--- a/web/src/components/Settings/SystemSection.tsx
+++ b/web/src/components/Settings/SystemSection.tsx
@@ -74,6 +74,7 @@ const SystemSection = () => {
       ...state,
       allowSignUp: value,
     });
+    globalStore.setSystemStatus({ allowSignUp: value });
     await api.upsertSystemSetting({
       name: "allow-signup",
       value: JSON.stringify(value),
@@ -197,7 +198,7 @@ const SystemSection = () => {
       ...state,
       memoDisplayWithUpdatedTs: value,
     });
-    globalStore.setSystemStatus({ disablePublicMemos: value });
+    globalStore.setSystemStatus({ memoDisplayWithUpdatedTs: value });
     await api.upsertSystemSetting({
       name: "memo-display-with-updated-ts",
       value: JSON.stringify(value),


### PR DESCRIPTION
In `Admin-System` section of `Setting` page, some settings state always be changed unexpectedly without any toggle on it. These settings include:

## `Allow user signup`
This setting was changed unexpectedly because itself. 

While it was toggled, it only call server API and update `state` store in page, the value in `globalStore` was not affected.

But if the `globalStore` was changed by any other settings, it will reset the `state` store in page to the value cached in `globalStore`.


## `Disable public memos` & `Display with updated time`
These two settings confused the local storage keys, so it changed each other while toggle.