### PR TITLE
feat: set memo visibility in telegram

### DIFF
--- a/plugin/telegram/api_answer_callback_query.go
+++ b/plugin/telegram/api_answer_callback_query.go
@@ -1,0 +1,21 @@
+package telegram
+
+import (
+	"context"
+	"net/url"
+)
+
+// AnswerCallbackQuery make an answerCallbackQuery api request.
+func (b *Bot) AnswerCallbackQuery(ctx context.Context, callbackQueryID, text string) error {
+	formData := url.Values{
+		"callback_query_id": {callbackQueryID},
+		"text":              {text},
+	}
+
+	err := b.postForm(ctx, "/answerCallbackQuery", formData, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/plugin/telegram/api_edit_message.go
+++ b/plugin/telegram/api_edit_message.go
@@ -2,16 +2,30 @@ package telegram
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/url"
 	"strconv"
 )
 
 // EditMessage make an editMessageText api request.
-func (b *Bot) EditMessage(ctx context.Context, chatID, messageID int, text string) (*Message, error) {
+func (b *Bot) EditMessage(ctx context.Context, chatID, messageID int, text string, inlineKeyboards [][]InlineKeyboardButton) (*Message, error) {
 	formData := url.Values{
 		"message_id": {strconv.Itoa(messageID)},
 		"chat_id":    {strconv.Itoa(chatID)},
 		"text":       {text},
+	}
+
+	if len(inlineKeyboards) > 0 {
+		var markup struct {
+			InlineKeyboard [][]InlineKeyboardButton `json:"inline_keyboard"`
+		}
+		markup.InlineKeyboard = inlineKeyboards
+		data, err := json.Marshal(markup)
+		if err != nil {
+			return nil, fmt.Errorf("fail to encode inlineKeyboard: %s", err)
+		}
+		formData.Set("reply_markup", string(data))
 	}
 
 	var result Message

--- a/plugin/telegram/bot.go
+++ b/plugin/telegram/bot.go
@@ -14,6 +14,7 @@ import (
 type Handler interface {
 	BotToken(ctx context.Context) string
 	MessageHandle(ctx context.Context, bot *Bot, message Message, blobs map[string][]byte) error
+	CallbackQueryHandle(ctx context.Context, bot *Bot, callbackQuery CallbackQuery) error
 }
 
 type Bot struct {
@@ -52,9 +53,9 @@ func (b *Bot) Start(ctx context.Context) {
 
 			// handle CallbackQuery update
 			if update.CallbackQuery != nil {
-				err := b.AnswerCallbackQuery(ctx, update.CallbackQuery.ID, "success")
+				err := b.handler.CallbackQueryHandle(ctx, b, *update.CallbackQuery)
 				if err != nil {
-					log.Error(fmt.Sprintf("fail to telegram.AnswerCallbackQuery for callbackQueryID=%s", update.CallbackQuery.ID), zap.Error(err))
+					log.Error("fail to handle CallbackQuery", zap.Error(err))
 				}
 
 				continue

--- a/plugin/telegram/bot.go
+++ b/plugin/telegram/bot.go
@@ -13,7 +13,7 @@ import (
 
 type Handler interface {
 	BotToken(ctx context.Context) string
-	MessageHandle(ctx context.Context, message Message, blobs map[string][]byte) error
+	MessageHandle(ctx context.Context, bot *Bot, message Message, blobs map[string][]byte) error
 }
 
 type Bot struct {

--- a/plugin/telegram/bot.go
+++ b/plugin/telegram/bot.go
@@ -44,6 +44,7 @@ func (b *Bot) Start(ctx context.Context) {
 			continue
 		}
 
+		singleMessages := make([]Message, 0, len(updates))
 		groupMessages := make([]Message, 0, len(updates))
 
 		for _, update := range updates {
@@ -68,11 +69,12 @@ func (b *Bot) Start(ctx context.Context) {
 				continue
 			}
 
-			err = b.handleSingleMessage(ctx, message)
-			if err != nil {
-				log.Error(fmt.Sprintf("fail to handleSingleMessage for messageID=%d", message.MessageID), zap.Error(err))
-				continue
-			}
+			singleMessages = append(singleMessages, message)
+		}
+
+		err = b.handleSingleMessages(ctx, singleMessages)
+		if err != nil {
+			log.Error("fail to handle singleMessage", zap.Error(err))
 		}
 
 		err = b.handleGroupMessages(ctx, groupMessages)

--- a/plugin/telegram/callback_query.go
+++ b/plugin/telegram/callback_query.go
@@ -1,0 +1,11 @@
+package telegram
+
+type CallbackQuery struct {
+	ID              string   `json:"id"`
+	From            User     `json:"from"`
+	Message         *Message `json:"message"`
+	InlineMessageID string   `json:"inline_message_id"`
+	ChatInstance    string   `json:"chat_instance"`
+	Data            string   `json:"data"`
+	GameShortName   string   `json:"game_short_name"`
+}

--- a/plugin/telegram/handle.go
+++ b/plugin/telegram/handle.go
@@ -37,7 +37,7 @@ func (b *Bot) handleSingleMessage(ctx context.Context, message Message) error {
 		blobs = map[string][]byte{filepath: blob}
 	}
 
-	err = b.handler.MessageHandle(ctx, message, blobs)
+	err = b.handler.MessageHandle(ctx, b, message, blobs)
 	if err != nil {
 		if _, err := b.EditMessage(ctx, message.Chat.ID, reply.MessageID, err.Error()); err != nil {
 			return fmt.Errorf("fail to EditMessage: %s", err)
@@ -88,7 +88,7 @@ func (b *Bot) handleGroupMessages(ctx context.Context, groupMessages []Message) 
 		// replace Caption with all Caption in the group
 		caption := captions[groupID]
 		message.Caption = &caption
-		if err := b.handler.MessageHandle(ctx, message, blobs[groupID]); err != nil {
+		if err := b.handler.MessageHandle(ctx, b, message, blobs[groupID]); err != nil {
 			if _, err = b.EditMessage(ctx, message.Chat.ID, reply.MessageID, err.Error()); err != nil {
 				return fmt.Errorf("fail to EditMessage: %s", err)
 			}

--- a/plugin/telegram/inline_keyboard_button.go
+++ b/plugin/telegram/inline_keyboard_button.go
@@ -1,0 +1,6 @@
+package telegram
+
+type InlineKeyboardButton struct {
+	Text         string `json:"text"`
+	CallbackData string `json:"callback_data"`
+}

--- a/plugin/telegram/update.go
+++ b/plugin/telegram/update.go
@@ -1,6 +1,7 @@
 package telegram
 
 type Update struct {
-	UpdateID int      `json:"update_id"`
-	Message  *Message `json:"message"`
+	UpdateID      int            `json:"update_id"`
+	Message       *Message       `json:"message"`
+	CallbackQuery *CallbackQuery `json:"callback_query"`
 }

--- a/server/telegram.go
+++ b/server/telegram.go
@@ -25,7 +25,7 @@ func (t *telegramHandler) BotToken(ctx context.Context) string {
 	return t.store.GetSystemSettingValueOrDefault(&ctx, api.SystemSettingTelegramBotTokenName, "")
 }
 
-func (t *telegramHandler) MessageHandle(ctx context.Context, message telegram.Message, blobs map[string][]byte) error {
+func (t *telegramHandler) MessageHandle(ctx context.Context, _ *telegram.Bot, message telegram.Message, blobs map[string][]byte) error {
 	var creatorID int
 	userSettingList, err := t.store.FindUserSettingList(ctx, &api.UserSettingFind{
 		Key: api.UserSettingTelegramUserIDKey,


### PR DESCRIPTION
This PR add a new feature, which provide ability to change/set memo's visibility after saved. The memo must be created by Telegram bot.

The detail of this feature:

1. After you send a message, the bot will reply a text message `success` before. With this feature, the reply message will also include a keyboard. And we add more info such as memo ID, memo visibility into the status text, instead of just a `success`.
2. In the new keyboard, there're some buttons for each visibility option of a memo.
3. You can just click on the button to switch visibility of the memo.
4. If some error occurred, it will notice you on telegram's process banner. You can click again to retry.
5. If everything goes OK, the reply message will update to shows the current status of memo, and the process banner will just show `success` to inform you,