### PR TITLE
feat: add IDE-extension to handle i18n through development

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["golang.go"]
+  "recommendations": ["golang.go", "inlang.vs-code-extension"]
 }

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,18 @@
+export async function defineConfig(env) {
+	const { default: i18nextPlugin } = await env.$import(
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@2/dist/index.js",
+	)
+  const { default: standardLintRules } = await env.$import(
+		"https://cdn.jsdelivr.net/npm/@inlang/plugin-standard-lint-rules@3/dist/index.js",
+	)
+
+	return {
+		referenceLanguage: "en",
+		plugins: [
+			i18nextPlugin({
+				pathPattern: "./web/src/locales/{language}.json",
+			}),
+            standardLintRules(),
+		],
+	}
+}


### PR DESCRIPTION
> Let me know if there is anything that needs to be changed in the PR, in order to be merged.

I added the `inlang` [IDE extension](https://inlang.com/documentation/apps/ide-extension) to memos. That should make the life of devs easier while developing (extracting and inline annotations).

#### Extract Messages (translations)

Extract Messages (translations) via the `Inlang: Extract Message` code action.

![Extract Messages](https://cdn.jsdelivr.net/gh/inlang/inlang/assets/ide-extension/extract.gif)

#### Inline Annotations

See translations directly in your code. No more back-and-forth looking into the translation files themselves.

![Inline Annotations](https://cdn.jsdelivr.net/gh/inlang/inlang/assets/ide-extension/inline.gif)