### PR TITLE
fix: auto expand height of setting page

### DIFF
--- a/web/src/less/setting.less
+++ b/web/src/less/setting.less
@@ -26,7 +26,7 @@
   }
 
   > .section-content-container {
-    @apply w-full sm:w-auto pl-2 grow flex flex-col justify-start items-start h-full sm:h-128 overflow-y-scroll hide-scrollbar;
+    @apply w-full sm:w-auto pl-2 grow flex flex-col justify-start items-start h-full;
 
     > .section-container {
       @apply flex flex-col justify-start items-start w-full;


### PR DESCRIPTION
Since we have split the *Setting* into a page instead of dialog, its height could expand to the whole screen instead of a fixed value.