### PR TITLE
fix: OpenID was disappear sometimes

### DIFF
--- a/api/v1/system.go
+++ b/api/v1/system.go
@@ -74,10 +74,10 @@ func (s *APIV1Service) registerSystemRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to find host user").SetInternal(err)
 		}
 		if hostUser != nil {
-			// data desensitize
-			hostUser.OpenID = ""
-			hostUser.Email = ""
 			systemStatus.Host = converUserFromStore(hostUser)
+			// data desensitize
+			systemStatus.Host.OpenID = ""
+			systemStatus.Host.Email = ""
 		}
 
 		systemSettingList, err := s.Store.ListSystemSettings(ctx, &store.FindSystemSetting{})


### PR DESCRIPTION
While making a request to */v1/status*, the *User* cache will be modified unexpectedly. After that, if you request */user/me* again, the response *User* doesn't have *OpenID* and *Email* field.