### PR TITLE
fix: header archived id

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -108,7 +108,7 @@ const Header = () => {
             <>
               <NavLink
                 to="/archived"
-                id="header-setting"
+                id="header-archived"
                 className={({ isActive }) =>
                   `${
                     isActive && "bg-white dark:bg-zinc-700 shadow"


### PR DESCRIPTION
The ID of the header archived is the same as the ID of the header settings.