### PR TITLE
fix: invalid orientation of image thumbnail in Apple devices

### DIFF
--- a/server/resource.go
+++ b/server/resource.go
@@ -598,7 +598,7 @@ func getOrGenerateThumbnailImage(srcBlob []byte, dstPath string) ([]byte, error)
 		}()
 
 		reader := bytes.NewReader(srcBlob)
-		src, err := imaging.Decode(reader)
+		src, err := imaging.Decode(reader, imaging.AutoOrientation(true))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to decode thumbnail image")
 		}


### PR DESCRIPTION
Some images generated in Apple devices will get an invalid orientation while generate the thumbnail. This PR just fix it.