### PR TITLE
fix: escape on resource filename

### DIFF
--- a/web/src/utils/resource.ts
+++ b/web/src/utils/resource.ts
@@ -3,5 +3,5 @@ export const getResourceUrl = (resource: Resource, withOrigin = true) => {
     return resource.externalLink;
   }
 
-  return `${withOrigin ? window.location.origin : ""}/o/r/${resource.id}/${resource.publicId}/${resource.filename}`;
+  return `${withOrigin ? window.location.origin : ""}/o/r/${resource.id}/${resource.publicId}/${encodeURIComponent(resource.filename)}`;
 };


### PR DESCRIPTION
Some resource's filename contains special characters, such as *+*, so we need to escape the filename before generate a link.