### PR TITLE
chore: change dropdown's background color in dark mode

### DIFF
--- a/web/src/components/kit/Dropdown.tsx
+++ b/web/src/components/kit/Dropdown.tsx
@@ -43,7 +43,7 @@ const Dropdown: React.FC<Props> = (props: Props) => {
         </button>
       )}
       <div
-        className={`w-auto absolute flex flex-col justify-start items-start bg-white dark:bg-zinc-800 z-10 p-1 rounded-md shadow ${
+        className={`w-auto absolute flex flex-col justify-start items-start bg-white dark:bg-zinc-700 z-10 p-1 rounded-md shadow ${
           dropdownStatus ? "" : "!hidden"
         } ${actionsClassName ?? ""} ${positionClassName ?? "top-full right-0 mt-1"}`}
       >


### PR DESCRIPTION
#1919 

just change `dark:border-zinc-800` to `dark:border-zinc-700`

Preview:
![image](https://github.com/usememos/memos/assets/11350270/c8fe5075-2a16-47b7-baaa-7f3271f41eed)
