### PR TITLE
chore: split Go binary and src for dev

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -14,8 +14,9 @@ services:
     working_dir: /work
     command: air -c ./scripts/.air.toml
     volumes:
+      - $HOME/go/pkg/:/go/pkg/ # Cache for go mod shared with the host
+      - ./.air/bin/:/go/bin/   # Cache for binary used only in container, such as *air*
       - .:/work/
-      - ./.air/go/:/go/ # Cache for go mod database
   web:
     image: node:18.12.1-alpine3.16
     working_dir: /work


### PR DESCRIPTION
This is just a optimization for developers.

While we have already cached the *GOPATH* of container into the host before.

But the Golang's mod (which contains only source code) could be shared with the common *GOPATH* in the host, instead of a separated directory only this project, this will save a lot of disk spaces.

The binary in *GOPATH* should still cached in our project's path, because the container OS may different with the host.