### PR TITLE
fix: visibility param override the user auth state

### DIFF
--- a/api/v1/memo.go
+++ b/api/v1/memo.go
@@ -541,14 +541,6 @@ func (s *APIV1Service) registerMemoRoutes(g *echo.Group) {
 		}
 		findMemoMessage.ContentSearch = contentSearch
 
-		visibilityListStr := c.QueryParam("visibility")
-		if visibilityListStr != "" {
-			visibilityList := []store.Visibility{}
-			for _, visibility := range strings.Split(visibilityListStr, ",") {
-				visibilityList = append(visibilityList, store.Visibility(visibility))
-			}
-			findMemoMessage.VisibilityList = visibilityList
-		}
 		if limit, err := strconv.Atoi(c.QueryParam("limit")); err == nil {
 			findMemoMessage.Limit = &limit
 		}


### PR DESCRIPTION
In `/api/v1/memo/all`, the params `visibility` can be set as any values, which will cause anonymous request to fetch memos not `PUBLIC`.