### PR TITLE
fix: incorrect localization key for sign-up failure message

### DIFF
--- a/web/src/pages/Auth.tsx
+++ b/web/src/pages/Auth.tsx
@@ -104,11 +104,11 @@ const Auth = () => {
       if (user) {
         window.location.href = "/";
       } else {
-        toast.error(t("common.signup-failed"));
+        toast.error(t("message.signup-failed"));
       }
     } catch (error: any) {
       console.error(error);
-      toast.error(error.response.data.message || error.message || t("common.signup-failed"));
+      toast.error(error.response.data.message || error.message || t("message.signup-failed"));
     }
     actionBtnLoadingState.setFinish();
   };


### PR DESCRIPTION
- Updated the localization key used for the sign-up failure message in the `handleSignUpButtonClick` function of `Auth.tsx`.
- Replaced `common.signup-failed` with the correct localization key `message.signup-failed` to ensure proper localization.
- This fix ensures that the correct localization key is used for the sign-up failure message, providing accurate translations and a better user experience.