### PR TITLE
fix: exclude commas in tags

### DIFF
--- a/api/v1/tag.go
+++ b/api/v1/tag.go
@@ -176,7 +176,7 @@ func convertTagFromStore(tag *store.Tag) *Tag {
 	}
 }
 
-var tagRegexp = regexp.MustCompile(`#([^\s#]+)`)
+var tagRegexp = regexp.MustCompile(`#([^\s#,]+)`)
 
 func findTagListFromMemoContent(memoContent string) []string {
 	tagMapSet := make(map[string]bool)

--- a/web/src/labs/marked/parser/Tag.tsx
+++ b/web/src/labs/marked/parser/Tag.tsx
@@ -1,6 +1,6 @@
 import { matcher } from "../matcher";
 
-export const TAG_REG = /#([^\s#]+)/;
+export const TAG_REG = /#([^\s#,]+)/;
 
 const renderer = (rawStr: string) => {
   const matchResult = matcher(rawStr, TAG_REG);


### PR DESCRIPTION
Currently, if you try to write a tag and add a comma right after it, e.g. `I love using #Memos, it's great`, a tag named `#Memos,` will be created instead of `#Memos`, which is what I expected. This is solved by adding commas to the set of excluded characters in the tag regex in both the front end and back end, and this could be expanded by excluding all punctuation characters using `[[:punct:]]`.