### PR TITLE
fix: add resource.clear to en.json

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -126,6 +126,7 @@
     "upload-successfully": "Upload successfully",
     "file-drag-drop-prompt": "Drag and drop your file here to upload file",
     "search-bar-placeholder": "Search resource",
+    "clear": "Clear",
     "create-dialog": {
       "title": "Create Resource",
       "upload-method": "Upload method",


### PR DESCRIPTION
fix build error: Argument of type '"resource.clear"' is not assignable to parameter of type 'Translations'.