### PR TITLE
fix: exclude all punctuation chars except underscore in tags

### DIFF
--- a/api/v1/tag.go
+++ b/api/v1/tag.go
@@ -176,7 +176,7 @@ func convertTagFromStore(tag *store.Tag) *Tag {
 	}
 }
 
-var tagRegexp = regexp.MustCompile(`#([^\s#,]+)`)
+var tagRegexp = regexp.MustCompile(`#((?:[^\s\p{P}]|_)+)`)
 
 func findTagListFromMemoContent(memoContent string) []string {
 	tagMapSet := make(map[string]bool)

--- a/api/v1/tag_test.go
+++ b/api/v1/tag_test.go
@@ -2,6 +2,8 @@ package v1
 
 import (
 	"testing"
+
+	"golang.org/x/exp/slices"
 )
 
 func TestFindTagListFromMemoContent(t *testing.T) {
@@ -37,10 +39,14 @@ func TestFindTagListFromMemoContent(t *testing.T) {
 			memoContent: "#tag1 http://123123.com?123123#tag2 \n#tag3  #tag4 http://123123.com?123123#tag2) ",
 			want:        []string{"tag1", "tag2", "tag3", "tag4"},
 		},
+		{
+			memoContent: "#tag1,#tag2! #tag3.. #tag_4",
+			want:        []string{"tag1", "tag2", "tag3", "tag_4"},
+		},
 	}
 	for _, test := range tests {
 		result := findTagListFromMemoContent(test.memoContent)
-		if len(result) != len(test.want) {
+		if !slices.Equal(result, test.want) {
 			t.Errorf("Find tag list %s: got result %v, want %v.", test.memoContent, result, test.want)
 		}
 	}

--- a/api/v1/tag_test.go
+++ b/api/v1/tag_test.go
@@ -35,7 +35,7 @@ func TestFindTagListFromMemoContent(t *testing.T) {
 		},
 		{
 			memoContent: "#tag1 http://123123.com?123123#tag2 \n#tag3  #tag4 http://123123.com?123123#tag2) ",
-			want:        []string{"tag1", "tag2", "tag2)", "tag3", "tag4"},
+			want:        []string{"tag1", "tag2", "tag3", "tag4"},
 		},
 	}
 	for _, test := range tests {

--- a/web/src/labs/marked/parser/Tag.tsx
+++ b/web/src/labs/marked/parser/Tag.tsx
@@ -1,6 +1,6 @@
 import { matcher } from "../matcher";
 
-export const TAG_REG = /#([^\s#,]+)/;
+export const TAG_REG = /#((?:[^\s\p{P}]|_)+)/u;
 
 const renderer = (rawStr: string) => {
   const matchResult = matcher(rawStr, TAG_REG);


### PR DESCRIPTION
The new regex uses the `u` modifier in the frontend regex which is only supported on es6 and above, but I think it's not a huge deal.

Related to #1957