### PR TITLE
fix: hashtag filter for Unicode characters

### DIFF
--- a/web/src/components/MemoList.tsx
+++ b/web/src/components/MemoList.tsx
@@ -43,7 +43,7 @@ const MemoList: React.FC<Props> = (props: Props) => {
           }
           if (tagQuery) {
             const tagsSet = new Set<string>();
-            for (const t of Array.from(memo.content.match(new RegExp(TAG_REG, "g")) ?? [])) {
+            for (const t of Array.from(memo.content.match(new RegExp(TAG_REG, "gu")) ?? [])) {
               const tag = t.replace(TAG_REG, "$1").trim();
               const items = tag.split("/");
               let temp = "";


### PR DESCRIPTION
This commit addresses an issue #2016  with the hashtag filter, which was not working correctly for hashtags containing Unicode characters. The filter was only capturing single-letter hashtags instead of complete hashtags.