### PR TITLE
fix: empty state display issue with resourceList style Grid

### DIFF
--- a/web/src/pages/ResourcesDashboard.tsx
+++ b/web/src/pages/ResourcesDashboard.tsx
@@ -286,7 +286,7 @@ const ResourcesDashboard = () => {
             ) : (
               <div
                 className={
-                  listStyle === "TABLE"
+                  listStyle === "TABLE" || resourceList.length === 0
                     ? "flex flex-col justify-start items-start w-full"
                     : "w-full h-auto grid grid-cols-2 md:grid-cols-4 md:px-6 gap-6"
                 }


### PR DESCRIPTION
This commit addresses a display issue with the empty state when the resourceList style is set to Grid. In the Grid style, the empty state was not being displayed correctly, leading to a layout inconsistency.

<img width="1158" alt="image" src="https://github.com/usememos/memos/assets/17526893/f5eb89b4-9993-445e-8050-a80cae660fc0">
