### PR TITLE
/api/v1/auth/signup json format 

### DIFF
--- a/api/v1/auth.go
+++ b/api/v1/auth.go
@@ -65,7 +65,8 @@ func (s *APIV1Service) registerAuthRoutes(g *echo.Group) {
 		if err := s.createAuthSignInActivity(c, user); err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create activity").SetInternal(err)
 		}
-		return c.JSON(http.StatusOK, user)
+		userMessage := convertUserFromStore(user)
+		return c.JSON(http.StatusOK, userMessage)
 	})
 
 	// POST /auth/signin/sso - Sign in with SSO
@@ -152,7 +153,8 @@ func (s *APIV1Service) registerAuthRoutes(g *echo.Group) {
 		if err := s.createAuthSignInActivity(c, user); err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create activity").SetInternal(err)
 		}
-		return c.JSON(http.StatusOK, user)
+		userMessage := convertUserFromStore(user)
+		return c.JSON(http.StatusOK, userMessage)
 	})
 
 	// POST /auth/signup - Sign up a new user.
@@ -218,7 +220,8 @@ func (s *APIV1Service) registerAuthRoutes(g *echo.Group) {
 			return echo.NewHTTPError(http.StatusInternalServerError, "Failed to create activity").SetInternal(err)
 		}
 
-		return c.JSON(http.StatusOK, user)
+		userMessage := convertUserFromStore(user)
+		return c.JSON(http.StatusOK, userMessage)
 	})
 
 	// POST /auth/signout - Sign out.


### PR DESCRIPTION
api/v1/auth/相关接口未应用convertUserFromStore方法，会导致User对象获得类型存在问题，导致User定义的`json:`相关的字段转化失效。 导致输出json未被正确格式化

The related interfaces in api/v1/auth/ are not utilizing the convertUserFromStore method, which can result in issues with the type of the User object. This can cause the json:-related fields defined in the User struct to be ineffective, leading to incorrect formatting of the output JSON.

*/api/v1/auth/signin* error example:
```
{
    "ID": 11,
    "RowStatus": "NORMAL",
    "CreatedTs": 1690099547,
    "UpdatedTs": 1690099547,
    "Username": "***",
    "Role": "USER",
    "Email": "",
    "Nickname": "***",
    "PasswordHash": "***",
    "OpenID": "01901a30-cbc5-403b-a428-***",
    "AvatarURL": ""
}
```
