### PR TITLE
feat: add command to move blob from local to db

### DIFF
--- a/cmd/memos.go
+++ b/cmd/memos.go
@@ -114,6 +114,77 @@ var (
 			}
 		},
 	}
+
+	mvrssCmd = &cobra.Command{
+		Use:   "mvrss",
+		Short: "Move resource between storage",
+		Run: func(cmd *cobra.Command, _ []string) {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			from, err := cmd.Flags().GetString(mvrssCmdFlagFrom)
+			if err != nil {
+				fmt.Printf("failed to get from storage, error: %+v\n", err)
+				return
+			}
+
+			to, err := cmd.Flags().GetString(mvrssCmdFlagTo)
+			if err != nil {
+				fmt.Printf("failed to get to storage, error: %+v\n", err)
+				return
+			}
+
+			if from != "local" || to != "db" {
+				fmt.Printf("only local=>db be supported currently\n")
+				return
+			}
+
+			db := db.NewDB(profile)
+			if err := db.Open(ctx); err != nil {
+				fmt.Printf("failed to open db, error: %+v\n", err)
+				return
+			}
+
+			s := store.New(db.DBInstance, profile)
+			resources, err := s.ListResources(ctx, &store.FindResource{})
+			if err != nil {
+				fmt.Printf("failed to list resources, error: %+v\n", err)
+				return
+			}
+
+			var emptyString string
+			for _, res := range resources {
+				if res.InternalPath == "" {
+					continue
+				}
+
+				buf, err := os.ReadFile(res.InternalPath)
+				if err != nil {
+					fmt.Printf("Resource %5d failed to read file: %s\n", res.ID, err)
+					continue
+				}
+
+				if len(buf) != int(res.Size) {
+					fmt.Printf("Resource %5d size of file %d != %d\n", res.ID, len(buf), res.Size)
+					continue
+				}
+
+				update := store.UpdateResource{
+					ID:           res.ID,
+					Blob:         buf,
+					InternalPath: &emptyString,
+				}
+				_, err = s.UpdateResource(ctx, &update)
+				if err != nil {
+					fmt.Printf("Resource %5d failed to update: %s\n", res.ID, err)
+					continue
+				}
+
+				fmt.Printf("Resource %5d copy %12d bytes from %s\n", res.ID, len(buf), res.InternalPath)
+			}
+			fmt.Println("done")
+		},
+	}
 )
 
 func Execute() error {
@@ -148,6 +219,11 @@ func init() {
 	setupCmd.Flags().String(setupCmdFlagHostPassword, "", "Owner password")
 
 	rootCmd.AddCommand(setupCmd)
+
+	mvrssCmd.Flags().String(mvrssCmdFlagFrom, "local", "From storage")
+	mvrssCmd.Flags().String(mvrssCmdFlagTo, "db", "To Storage")
+
+	rootCmd.AddCommand(mvrssCmd)
 }
 
 func initConfig() {
@@ -171,4 +247,6 @@ func initConfig() {
 const (
 	setupCmdFlagHostUsername = "host-username"
 	setupCmdFlagHostPassword = "host-password"
+	mvrssCmdFlagFrom         = "from"
+	mvrssCmdFlagTo           = "to"
 )

--- a/cmd/memos.go
+++ b/cmd/memos.go
@@ -116,7 +116,7 @@ var (
 	}
 
 	mvrssCmd = &cobra.Command{
-		Use:   "mvrss",
+		Use:   "mvrss", // `mvrss` is a shortened for 'means move resource'
 		Short: "Move resource between storage",
 		Run: func(cmd *cobra.Command, _ []string) {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/store/resource.go
+++ b/store/resource.go
@@ -36,9 +36,11 @@ type FindResource struct {
 }
 
 type UpdateResource struct {
-	ID        int
-	UpdatedTs *int64
-	Filename  *string
+	ID           int
+	UpdatedTs    *int64
+	Filename     *string
+	InternalPath *string
+	Blob         []byte
 }
 
 type DeleteResource struct {
@@ -173,6 +175,12 @@ func (s *Store) UpdateResource(ctx context.Context, update *UpdateResource) (*Re
 	}
 	if v := update.Filename; v != nil {
 		set, args = append(set, "filename = ?"), append(args, *v)
+	}
+	if v := update.InternalPath; v != nil {
+		set, args = append(set, "internal_path = ?"), append(args, *v)
+	}
+	if v := update.Blob; v != nil {
+		set, args = append(set, "blob = ?"), append(args, v)
 	}
 
 	args = append(args, update.ID)


### PR DESCRIPTION
With this PR, we can move resource blob from local file back to database, the only thing you need is run a sub command of *Memos*.

First of all , **STOP Your Container** and **Backup anything**.
Second of all, **STOP Your Container** and **Backup anything**.
AGAIN and AGAIN and AGAIN, **STOP Your Container** and **Backup anything**.


If you have finish all above, just run a cmd:
```
docker run -it -v ~/.memos/:/var/opt/memos ghcr.io/usememos/memos:latest mvrss
```



PS: Next version, we'll add support to move resource between more storages.