### PR TITLE
fix: avoid content flash on auto collapse

### DIFF
--- a/web/src/components/MemoContent.tsx
+++ b/web/src/components/MemoContent.tsx
@@ -30,22 +30,22 @@ const MemoContent: React.FC<Props> = (props: Props) => {
   });
   const memoContentContainerRef = useRef<HTMLDivElement>(null);
   const isVisitorMode = userStore.isVisitorMode();
-  const autoCollapse: boolean = isVisitorMode ? true : (userStore.state.user as User).localSetting.enableAutoCollapse;
+  const autoCollapse: boolean = !showFull && (isVisitorMode ? true : (userStore.state.user as User).localSetting.enableAutoCollapse);
 
   useEffect(() => {
-    if (showFull) {
+    if (!autoCollapse) {
       return;
     }
 
     if (memoContentContainerRef.current) {
-      const height = memoContentContainerRef.current.clientHeight;
+      const height = memoContentContainerRef.current.scrollHeight;
       if (height > MAX_EXPAND_HEIGHT) {
         setState({
           expandButtonStatus: 0,
         });
       }
     }
-  }, []);
+  }, [autoCollapse]);
 
   const handleMemoContentClick = async (e: React.MouseEvent) => {
     if (onMemoContentClick) {
@@ -70,7 +70,7 @@ const MemoContent: React.FC<Props> = (props: Props) => {
     <div className={`memo-content-wrapper ${className || ""}`}>
       <div
         ref={memoContentContainerRef}
-        className={`memo-content-text ${autoCollapse && state.expandButtonStatus === 0 ? "max-h-64 overflow-y-hidden" : ""}`}
+        className={`memo-content-text ${autoCollapse && state.expandButtonStatus < 1 ? "max-h-64 overflow-y-hidden" : ""}`}
         onClick={handleMemoContentClick}
         onDoubleClick={handleMemoContentDoubleClick}
       >


### PR DESCRIPTION
**Background:** Currently if auto-collapse is on, long posts will be fully shown first and then collapsed, leading to significant content flash.

This PR will render all posts with a max height to avoid the content flash, then check `scrollHeight` instead of `clientHeight`.