### PR TITLE
WIP: feat(telegram): Support Telegram Channel

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,6 +1,6 @@
 # 1.Prepare your workspace by:
-#     docker compose run api go install github.com/cosmtrek/air@latest
-#     docker compose run web npm install
+#     docker compose -f docker-compose.dev.yaml run api go install github.com/cosmtrek/air@latest
+#     docker compose -f docker-compose.dev.yaml run web npm install
 #
 # 2. Start you work by:
 #     docker compose up -d

--- a/plugin/telegram/callback_query.go
+++ b/plugin/telegram/callback_query.go
@@ -1,5 +1,7 @@
 package telegram
 
+// CallbackQuery represents an incoming callback query from a callback button in
+// an inline keyboard (PUBLIC, PROTECTED, PRIVATE).
 type CallbackQuery struct {
 	ID              string   `json:"id"`
 	From            User     `json:"from"`

--- a/plugin/telegram/message.go
+++ b/plugin/telegram/message.go
@@ -14,13 +14,14 @@ type Message struct {
 	Photo                []PhotoSize     `json:"photo"`                   // Photo message is a photo, available sizes of the photo;
 	Caption              *string         `json:"caption"`                 // Caption for the animation, audio, document, photo, video or voice, 0-1024 characters;
 	Entities             []MessageEntity `json:"entities"`                // Entities are for text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text;
-	CaptionEntities      []MessageEntity `json:"caption_entities"`
-	Document             *Document       `json:"document"`   // Document message is a general file, information about the file;
-	Video                *Video          `json:"video"`      // Video message is a video, information about the video;
-	VideoNote            *VideoNote      `json:"video_note"` // VideoNote message is a video note, information about the video message;
-	Voice                *Voice          `json:"voice"`      // Voice message is a voice message, information about the file;
-	Audio                *Audio          `json:"audio"`      // Audio message is an audio file, information about the file;
-	Animation            *Animation      `json:"animation"`  // Animation message is an animation, information about the animation. For backward compatibility, when this field is set, the document field will also be set;
+	CaptionEntities      []MessageEntity `json:"caption_entities"`        // CaptionEntities are for messages with a caption, special entities like usernames, URLs, bot commands, etc. that appear in the caption;
+	Document             *Document       `json:"document"`                // Document message is a general file, information about the file;
+	Video                *Video          `json:"video"`                   // Video message is a video, information about the video;
+	VideoNote            *VideoNote      `json:"video_note"`              // VideoNote message is a video note, information about the video message;
+	Voice                *Voice          `json:"voice"`                   // Voice message is a voice message, information about the file;
+	Audio                *Audio          `json:"audio"`                   // Audio message is an audio file, information about the file;
+	Animation            *Animation      `json:"animation"`               // Animation message is an animation, information about the animation. For backward compatibility, when this field is set, the document field will also be set;
+	SenderChat           *Chat           `json:"sender_chat"`             // SenderChat is for messages sent through channels
 }
 
 func (m Message) GetMaxPhotoFileID() string {

--- a/plugin/telegram/update.go
+++ b/plugin/telegram/update.go
@@ -3,5 +3,6 @@ package telegram
 type Update struct {
 	UpdateID      int            `json:"update_id"`
 	Message       *Message       `json:"message"`
+	ChannelPost   *Message       `json:"channel_post"`
 	CallbackQuery *CallbackQuery `json:"callback_query"`
 }

--- a/server/telegram.go
+++ b/server/telegram.go
@@ -37,6 +37,14 @@ func (t *telegramHandler) MessageHandle(ctx context.Context, bot *telegram.Bot, 
 		return fmt.Errorf("fail to SendReplyMessage: %s", err)
 	}
 
+	// TODO: handle channel
+	// Message from channel
+	//if message.SenderChat != nil {
+	//
+	//} else {
+	//
+	//}
+	// validate telegram userid
 	var creatorID int32
 	userSettingList, err := t.store.ListUserSettings(ctx, &store.FindUserSetting{
 		Key: apiv1.UserSettingTelegramUserIDKey.String(),
@@ -52,6 +60,9 @@ func (t *telegramHandler) MessageHandle(ctx context.Context, bot *telegram.Bot, 
 
 		if value == strconv.Itoa(message.From.ID) {
 			creatorID = userSetting.UserID
+			//} else if va {
+			//
+			// TODO: handle channel
 		}
 	}
 


### PR DESCRIPTION
> Update:
> 
> I managed to support channel post, however, there is not such userid in channel, the only identifier will be the channel name, which leads to another kv pair (key: telegram-channel-name) in table user_setting
> 
> And TBH, I don't really know how to do that, I guess I'll make a draft PR first 🤣

ref: https://github.com/usememos/memos/issues/2070

I'm not sure if adding a user setting is a good move, let me know if there's a better way to do it