### PR TITLE
feat(telegram): Support Telegram Channel

### DIFF
--- a/api/v1/system_setting.go
+++ b/api/v1/system_setting.go
@@ -36,7 +36,7 @@ const (
 	SystemSettingStorageServiceIDName SystemSettingName = "storage-service-id"
 	// SystemSettingLocalStoragePathName is the name of local storage path.
 	SystemSettingLocalStoragePathName SystemSettingName = "local-storage-path"
-	// SystemSettingTelegramBotToken is the name of Telegram Bot Token.
+	// SystemSettingTelegramBotTokenName is the name of Telegram Bot Token.
 	SystemSettingTelegramBotTokenName SystemSettingName = "telegram-bot-token"
 	// SystemSettingMemoDisplayWithUpdatedTsName is the name of memo display with updated ts.
 	SystemSettingMemoDisplayWithUpdatedTsName SystemSettingName = "memo-display-with-updated-ts"

--- a/api/v1/user_setting.go
+++ b/api/v1/user_setting.go
@@ -20,8 +20,10 @@ const (
 	UserSettingAppearanceKey UserSettingKey = "appearance"
 	// UserSettingMemoVisibilityKey is the key type for user preference memo default visibility.
 	UserSettingMemoVisibilityKey UserSettingKey = "memo-visibility"
-	// UserSettingTelegramUserID is the key type for telegram UserID of memos user.
+	// UserSettingTelegramUserIDKey is the key type for telegram UserID of memos user.
 	UserSettingTelegramUserIDKey UserSettingKey = "telegram-user-id"
+	// UserSettingTelegramChannelNameKey is the key type for telegram channel name user sent memo from.
+	UserSettingTelegramChannelNameKey UserSettingKey = "telegram-channel-name"
 )
 
 // String returns the string format of UserSettingKey type.
@@ -35,6 +37,8 @@ func (key UserSettingKey) String() string {
 		return "memo-visibility"
 	case UserSettingTelegramUserIDKey:
 		return "telegram-user-id"
+	case UserSettingTelegramChannelNameKey:
+		return "telegram-channel-name"
 	}
 	return ""
 }
@@ -111,6 +115,12 @@ func (upsert UpsertUserSettingRequest) Validate() error {
 		err := json.Unmarshal([]byte(upsert.Value), &key)
 		if err != nil {
 			return fmt.Errorf("invalid user setting telegram user id value")
+		}
+	} else if upsert.Key == UserSettingTelegramChannelNameKey {
+		var key string
+		err := json.Unmarshal([]byte(upsert.Value), &key)
+		if err != nil {
+			return fmt.Errorf("invalid user setting telegram channel name value")
 		}
 	} else {
 		return fmt.Errorf("invalid user setting key")

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,6 +1,6 @@
 # 1.Prepare your workspace by:
-#     docker compose run api go install github.com/cosmtrek/air@latest
-#     docker compose run web npm install
+#     docker compose -f docker-compose.dev.yaml run api go install github.com/cosmtrek/air@latest
+#     docker compose -f docker-compose.dev.yaml run web npm install
 #
 # 2. Start you work by:
 #     docker compose up -d

--- a/plugin/telegram/bot.go
+++ b/plugin/telegram/bot.go
@@ -29,13 +29,13 @@ func NewBotWithHandler(h Handler) *Bot {
 const noTokenWait = 30 * time.Second
 const errRetryWait = 10 * time.Second
 
-// Start start an infinity call of getUpdates from Telegram, call r.MessageHandle while get new message updates.
+// Start start a long polling using getUpdates to get Update, call r.MessageHandle while get new message updates.
 func (b *Bot) Start(ctx context.Context) {
 	var offset int
 
 	for {
 		updates, err := b.GetUpdates(ctx, offset)
-		if err == ErrInvalidToken {
+		if errors.Is(err, ErrInvalidToken) {
 			time.Sleep(noTokenWait)
 			continue
 		}
@@ -61,28 +61,32 @@ func (b *Bot) Start(ctx context.Context) {
 				continue
 			}
 
-			// handle Message update
+			var message Message
 			if update.Message != nil {
-				message := *update.Message
+				// handle private message
+				message = *update.Message
+			} else if update.ChannelPost != nil {
+				// handle channel message
+				message = *update.ChannelPost
+			}
 
-				// skip unsupported message
-				if !message.IsSupported() {
-					_, err := b.SendReplyMessage(ctx, message.Chat.ID, message.MessageID, "Supported messages: animation, audio, text, document, photo, video, video note, voice, other messages with caption")
-					if err != nil {
-						log.Error(fmt.Sprintf("fail to telegram.SendReplyMessage for messageID=%d", message.MessageID), zap.Error(err))
-					}
-					continue
+			// skip unsupported message
+			if !message.IsSupported() {
+				_, err := b.SendReplyMessage(ctx, message.Chat.ID, message.MessageID, "Supported messages: animation, audio, text, document, photo, video, video note, voice, other messages with caption")
+				if err != nil {
+					log.Error(fmt.Sprintf("fail to telegram.SendReplyMessage for messageID=%d", message.MessageID), zap.Error(err))
 				}
-
-				// Group message need do more
-				if message.MediaGroupID != nil {
-					groupMessages = append(groupMessages, message)
-					continue
-				}
-
-				singleMessages = append(singleMessages, message)
 				continue
 			}
+
+			// Group message need do more
+			if message.MediaGroupID != nil {
+				groupMessages = append(groupMessages, message)
+				continue
+			}
+
+			singleMessages = append(singleMessages, message)
+			continue
 		}
 
 		err = b.handleSingleMessages(ctx, singleMessages)

--- a/plugin/telegram/callback_query.go
+++ b/plugin/telegram/callback_query.go
@@ -1,5 +1,7 @@
 package telegram
 
+// CallbackQuery represents an incoming callback query from a callback button in
+// an inline keyboard (PUBLIC, PROTECTED, PRIVATE).
 type CallbackQuery struct {
 	ID              string   `json:"id"`
 	From            User     `json:"from"`

--- a/plugin/telegram/message.go
+++ b/plugin/telegram/message.go
@@ -14,13 +14,14 @@ type Message struct {
 	Photo                []PhotoSize     `json:"photo"`                   // Photo message is a photo, available sizes of the photo;
 	Caption              *string         `json:"caption"`                 // Caption for the animation, audio, document, photo, video or voice, 0-1024 characters;
 	Entities             []MessageEntity `json:"entities"`                // Entities are for text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text;
-	CaptionEntities      []MessageEntity `json:"caption_entities"`
-	Document             *Document       `json:"document"`   // Document message is a general file, information about the file;
-	Video                *Video          `json:"video"`      // Video message is a video, information about the video;
-	VideoNote            *VideoNote      `json:"video_note"` // VideoNote message is a video note, information about the video message;
-	Voice                *Voice          `json:"voice"`      // Voice message is a voice message, information about the file;
-	Audio                *Audio          `json:"audio"`      // Audio message is an audio file, information about the file;
-	Animation            *Animation      `json:"animation"`  // Animation message is an animation, information about the animation. For backward compatibility, when this field is set, the document field will also be set;
+	CaptionEntities      []MessageEntity `json:"caption_entities"`        // CaptionEntities are for messages with a caption, special entities like usernames, URLs, bot commands, etc. that appear in the caption;
+	Document             *Document       `json:"document"`                // Document message is a general file, information about the file;
+	Video                *Video          `json:"video"`                   // Video message is a video, information about the video;
+	VideoNote            *VideoNote      `json:"video_note"`              // VideoNote message is a video note, information about the video message;
+	Voice                *Voice          `json:"voice"`                   // Voice message is a voice message, information about the file;
+	Audio                *Audio          `json:"audio"`                   // Audio message is an audio file, information about the file;
+	Animation            *Animation      `json:"animation"`               // Animation message is an animation, information about the animation. For backward compatibility, when this field is set, the document field will also be set;
+	SenderChat           *Chat           `json:"sender_chat"`             // SenderChat is for messages sent through channels
 }
 
 func (m Message) GetMaxPhotoFileID() string {

--- a/plugin/telegram/update.go
+++ b/plugin/telegram/update.go
@@ -3,5 +3,6 @@ package telegram
 type Update struct {
 	UpdateID      int            `json:"update_id"`
 	Message       *Message       `json:"message"`
+	ChannelPost   *Message       `json:"channel_post"`
 	CallbackQuery *CallbackQuery `json:"callback_query"`
 }

--- a/store/user_setting.go
+++ b/store/user_setting.go
@@ -48,7 +48,7 @@ func (s *Store) ListUserSettings(ctx context.Context, find *FindUserSetting) ([]
 	query := `
 		SELECT
 			user_id,
-		  key,
+			key,
 			value
 		FROM user_setting
 		WHERE ` + strings.Join(where, " AND ")


### PR DESCRIPTION
Hi

This PR adds support for handling telegram channel message, I also formatted some code while developing.

To use it, simply add bot to your channel and add `telegram-channel-name` in `user_setting` table and it's done.

However, currently the bot will also reply a message under the channel name (as pic below), which may be annoying, can obviously can not be used in public channel. 
At first I thought it could be fixed by disabling the bot's `post_message` privilege in channel, but this cause an error since the bot first sends a "request pending message" then edit the message, if no message was sent in the first place, it won't be able to edit the message which cause errors.
This can be fixed by deleting the bot's message after the message was sent, or completely refactor the send message logic.

<img width="470" alt="image" src="https://github.com/usememos/memos/assets/29861494/f656efa3-8491-4473-9a23-bea9e28386fe">

Also, the channel name is not a unique identifier (you can have multiple channel with the same name), but the channel id can not be directly obtained from telegram app, it must go through the api. This is not intuitive so I tend to use the channel name as identifier :D