### PR TITLE
fix: all ID from int to int64 to avoid 32bits machine break

### DIFF
--- a/plugin/telegram/api_edit_message.go
+++ b/plugin/telegram/api_edit_message.go
@@ -9,10 +9,10 @@ import (
 )
 
 // EditMessage make an editMessageText api request.
-func (b *Bot) EditMessage(ctx context.Context, chatID, messageID int, text string, inlineKeyboards [][]InlineKeyboardButton) (*Message, error) {
+func (b *Bot) EditMessage(ctx context.Context, chatID, messageID int64, text string, inlineKeyboards [][]InlineKeyboardButton) (*Message, error) {
 	formData := url.Values{
-		"message_id": {strconv.Itoa(messageID)},
-		"chat_id":    {strconv.Itoa(chatID)},
+		"message_id": {strconv.FormatInt(messageID, 10)},
+		"chat_id":    {strconv.FormatInt(chatID, 10)},
 		"text":       {text},
 	}
 

--- a/plugin/telegram/api_get_updates.go
+++ b/plugin/telegram/api_get_updates.go
@@ -7,10 +7,10 @@ import (
 )
 
 // GetUpdates make a getUpdates api request.
-func (b *Bot) GetUpdates(ctx context.Context, offset int) ([]Update, error) {
+func (b *Bot) GetUpdates(ctx context.Context, offset int64) ([]Update, error) {
 	formData := url.Values{
 		"timeout": {"60"},
-		"offset":  {strconv.Itoa(offset)},
+		"offset":  {strconv.FormatInt(offset, 10)},
 	}
 
 	var result []Update

--- a/plugin/telegram/api_send_message.go
+++ b/plugin/telegram/api_send_message.go
@@ -7,10 +7,10 @@ import (
 )
 
 // SendReplyMessage make a sendMessage api request.
-func (b *Bot) SendReplyMessage(ctx context.Context, chatID, replyID int, text string) (*Message, error) {
+func (b *Bot) SendReplyMessage(ctx context.Context, chatID, replyID int64, text string) (*Message, error) {
 	formData := url.Values{
-		"reply_to_message_id": {strconv.Itoa(replyID)},
-		"chat_id":             {strconv.Itoa(chatID)},
+		"reply_to_message_id": {strconv.FormatInt(replyID, 10)},
+		"chat_id":             {strconv.FormatInt(chatID, 10)},
 		"text":                {text},
 	}
 

--- a/plugin/telegram/bot.go
+++ b/plugin/telegram/bot.go
@@ -31,7 +31,7 @@ const errRetryWait = 10 * time.Second
 
 // Start start a long polling using getUpdates to get Update, call r.MessageHandle while get new message updates.
 func (b *Bot) Start(ctx context.Context) {
-	var offset int
+	var offset int64
 
 	for {
 		updates, err := b.GetUpdates(ctx, offset)

--- a/plugin/telegram/chat.go
+++ b/plugin/telegram/chat.go
@@ -10,7 +10,7 @@ const (
 )
 
 type Chat struct {
-	ID        int      `json:"id"`
+	ID        int64    `json:"id"`
 	Title     string   `json:"title"`      // Title for supergroups, channels and group chats
 	Type      ChatType `json:"type"`       // Type of chat, can be either “private”, “group”, “supergroup” or “channel”
 	FirstName string   `json:"first_name"` // FirstName of the other party in a private chat

--- a/plugin/telegram/message.go
+++ b/plugin/telegram/message.go
@@ -3,13 +3,13 @@ package telegram
 import "fmt"
 
 type Message struct {
-	MessageID            int             `json:"message_id"`              // MessageID is a unique message identifier inside this chat
+	MessageID            int64           `json:"message_id"`              // MessageID is a unique message identifier inside this chat
 	From                 User            `json:"from"`                    // From is a sender, empty for messages sent to channels;
 	Date                 int             `json:"date"`                    // Date of the message was sent in Unix time
 	Text                 *string         `json:"text"`                    // Text is for text messages, the actual UTF-8 text of the message, 0-4096 characters;
 	Chat                 *Chat           `json:"chat"`                    // Chat is the conversation the message belongs to
 	ForwardFromChat      *Chat           `json:"forward_from_chat"`       // ForwardFromChat for messages forwarded from channels, information about the original channel;
-	ForwardFromMessageID int             `json:"forward_from_message_id"` // ForwardFromMessageID for messages forwarded from channels, identifier of the original message in the channel;
+	ForwardFromMessageID int64           `json:"forward_from_message_id"` // ForwardFromMessageID for messages forwarded from channels, identifier of the original message in the channel;
 	MediaGroupID         *string         `json:"media_group_id"`          // MediaGroupID is the unique identifier of a media message group this message belongs to;
 	Photo                []PhotoSize     `json:"photo"`                   // Photo message is a photo, available sizes of the photo;
 	Caption              *string         `json:"caption"`                 // Caption for the animation, audio, document, photo, video or voice, 0-1024 characters;

--- a/plugin/telegram/update.go
+++ b/plugin/telegram/update.go
@@ -1,7 +1,7 @@
 package telegram
 
 type Update struct {
-	UpdateID      int            `json:"update_id"`
+	UpdateID      int64          `json:"update_id"`
 	Message       *Message       `json:"message"`
 	CallbackQuery *CallbackQuery `json:"callback_query"`
 }

--- a/plugin/telegram/user.go
+++ b/plugin/telegram/user.go
@@ -1,5 +1,5 @@
 package telegram
 
 type User struct {
-	ID int `json:"id"`
+	ID int64 `json:"id"`
 }

--- a/server/telegram.go
+++ b/server/telegram.go
@@ -50,7 +50,7 @@ func (t *telegramHandler) MessageHandle(ctx context.Context, bot *telegram.Bot, 
 			continue
 		}
 
-		if value == strconv.Itoa(message.From.ID) {
+		if value == strconv.FormatInt(message.From.ID, 10) {
 			creatorID = userSetting.UserID
 		}
 	}


### PR DESCRIPTION
This PR fix all `ID` fields's type from `int` to `int64`, to avoid break on 32bit machines.