### PR TITLE
fix: multiple inline latex parsing

### DIFF
--- a/web/src/labs/marked/parser/InlineLatex.tsx
+++ b/web/src/labs/marked/parser/InlineLatex.tsx
@@ -1,24 +1,20 @@
 import TeX from "@matejmazur/react-katex";
 import "katex/dist/katex.min.css";
 
-export const LATEX_INLINE_REG = /\$(.+?)\$|\\\(([^\\]+)\\\)/g;
+export const LATEX_INLINE_REG = /\$(.+?)\$|\\\((.+?)\\\)/;
 
 const inlineRenderer = (rawStr: string) => {
   const matchResult = LATEX_INLINE_REG.exec(rawStr);
-  if (!matchResult) {
-    return rawStr;
+  if (matchResult) {
+    let latexCode = "";
+    if (matchResult[1]) {
+      latexCode = matchResult[1];
+    } else if (matchResult[2]) {
+      latexCode = matchResult[2];
+    }
+    return <TeX key={latexCode}>{latexCode}</TeX>;
   }
-
-  let latexCode = "";
-
-  if (matchResult[1]) {
-    // $
-    latexCode = matchResult[1];
-  } else if (matchResult[2]) {
-    // \( and \)
-    latexCode = matchResult[2];
-  }
-  return <TeX>{latexCode}</TeX>;
+  return rawStr;
 };
 
 export default {


### PR DESCRIPTION
Fix parsing and rendering of multiple inline LaTeX code within a single line.


pre fix:
<img width="672" alt="CleanShot 2023-09-13 at 17 07 17@2x" src="https://github.com/usememos/memos/assets/7401626/516da7a8-f789-4278-88da-94d297de222b">

fixed:
<img width="725" alt="CleanShot 2023-09-13 at 17 02 26@2x" src="https://github.com/usememos/memos/assets/7401626/62094861-dd2d-43b7-a6b9-ccb18977f0cd">
