### PR TITLE
chore: persist selected date of DailyReview page

### DIFF
--- a/web/src/pages/DailyReview.tsx
+++ b/web/src/pages/DailyReview.tsx
@@ -2,7 +2,7 @@ import classNames from "classnames";
 import { last } from "lodash-es";
 import { useEffect, useRef } from "react";
 import toast from "react-hot-toast";
-import { useLocalStorage } from "react-use";
+import useLocalStorage from "react-use/lib/useLocalStorage";
 import useToggle from "react-use/lib/useToggle";
 import DailyMemo from "@/components/DailyMemo";
 import Empty from "@/components/Empty";

--- a/web/src/pages/DailyReview.tsx
+++ b/web/src/pages/DailyReview.tsx
@@ -18,12 +18,16 @@ import { useMemoStore, useUserStore } from "@/store/module";
 import { findNearestLanguageMatch, useTranslate } from "@/utils/i18n";
 
 const DailyReview = () => {
+  let initCurrentDateStamp = Number(window.sessionStorage.getItem("daily-review-datestamp"));
+  if (initCurrentDateStamp == 0) {
+    initCurrentDateStamp = getDateStampByDate(getNormalizedDateString());
+  }
   const t = useTranslate();
   const memoStore = useMemoStore();
   const userStore = useUserStore();
   const user = useCurrentUser();
   const { localSetting } = userStore.state.user as User;
-  const [currentDateStamp, setCurrentDateStamp] = useState(getDateStampByDate(getNormalizedDateString()));
+  const [currentDateStamp, setCurrentDateStamp] = useState(initCurrentDateStamp);
   const [showDatePicker, toggleShowDatePicker] = useToggle(false);
   const memosElRef = useRef<HTMLDivElement>(null);
   const currentDate = new Date(currentDateStamp);
@@ -85,8 +89,13 @@ const DailyReview = () => {
   };
 
   const handleDataPickerChange = (datestamp: number): void => {
-    setCurrentDateStamp(datestamp);
+    updateCurrentDateStamp(datestamp);
     toggleShowDatePicker(false);
+  };
+
+  const updateCurrentDateStamp = (datestamp: number): void => {
+    setCurrentDateStamp(datestamp);
+    window.sessionStorage.setItem("daily-review-datestamp", datestamp.toString());
   };
 
   const locale = findNearestLanguageMatch(i18n.language);
@@ -108,7 +117,7 @@ const DailyReview = () => {
           <div className="flex flex-row justify-end items-center">
             <button
               className="w-7 h-7 mr-2 flex justify-center items-center rounded cursor-pointer select-none last:mr-0 hover:bg-gray-200 dark:hover:bg-zinc-700 p-0.5"
-              onClick={() => setCurrentDateStamp(currentDateStamp - DAILY_TIMESTAMP)}
+              onClick={() => updateCurrentDateStamp(currentDateStamp - DAILY_TIMESTAMP)}
             >
               <Icon.ChevronLeft className="w-full h-auto" />
             </button>
@@ -117,7 +126,7 @@ const DailyReview = () => {
                 "w-7 h-7 mr-2 flex justify-center items-center rounded select-none last:mr-0 hover:bg-gray-200 dark:hover:bg-zinc-700 p-0.5",
                 isFutureDateDisabled ? "cursor-not-allowed" : "cursor-pointer"
               )}
-              onClick={() => setCurrentDateStamp(currentDateStamp + DAILY_TIMESTAMP)}
+              onClick={() => updateCurrentDateStamp(currentDateStamp + DAILY_TIMESTAMP)}
               disabled={isFutureDateDisabled}
             >
               <Icon.ChevronRight className="w-full h-auto" />

--- a/web/src/pages/DailyReview.tsx
+++ b/web/src/pages/DailyReview.tsx
@@ -1,7 +1,8 @@
 import classNames from "classnames";
 import { last } from "lodash-es";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import toast from "react-hot-toast";
+import { useLocalStorage } from "react-use";
 import useToggle from "react-use/lib/useToggle";
 import DailyMemo from "@/components/DailyMemo";
 import Empty from "@/components/Empty";
@@ -18,16 +19,16 @@ import { useMemoStore, useUserStore } from "@/store/module";
 import { findNearestLanguageMatch, useTranslate } from "@/utils/i18n";
 
 const DailyReview = () => {
-  let initCurrentDateStamp = Number(window.sessionStorage.getItem("daily-review-datestamp"));
-  if (initCurrentDateStamp == 0) {
-    initCurrentDateStamp = getDateStampByDate(getNormalizedDateString());
-  }
   const t = useTranslate();
   const memoStore = useMemoStore();
   const userStore = useUserStore();
   const user = useCurrentUser();
   const { localSetting } = userStore.state.user as User;
-  const [currentDateStamp, setCurrentDateStamp] = useState(initCurrentDateStamp);
+  const [currentDateStampRaw, setCurrentDateStamp] = useLocalStorage<number>(
+    "daily-review-datestamp",
+    getDateStampByDate(getNormalizedDateString())
+  );
+  const currentDateStamp = currentDateStampRaw as number;
   const [showDatePicker, toggleShowDatePicker] = useToggle(false);
   const memosElRef = useRef<HTMLDivElement>(null);
   const currentDate = new Date(currentDateStamp);
@@ -89,13 +90,8 @@ const DailyReview = () => {
   };
 
   const handleDataPickerChange = (datestamp: number): void => {
-    updateCurrentDateStamp(datestamp);
-    toggleShowDatePicker(false);
-  };
-
-  const updateCurrentDateStamp = (datestamp: number): void => {
     setCurrentDateStamp(datestamp);
-    window.sessionStorage.setItem("daily-review-datestamp", datestamp.toString());
+    toggleShowDatePicker(false);
   };
 
   const locale = findNearestLanguageMatch(i18n.language);
@@ -117,7 +113,7 @@ const DailyReview = () => {
           <div className="flex flex-row justify-end items-center">
             <button
               className="w-7 h-7 mr-2 flex justify-center items-center rounded cursor-pointer select-none last:mr-0 hover:bg-gray-200 dark:hover:bg-zinc-700 p-0.5"
-              onClick={() => updateCurrentDateStamp(currentDateStamp - DAILY_TIMESTAMP)}
+              onClick={() => setCurrentDateStamp(currentDateStamp - DAILY_TIMESTAMP)}
             >
               <Icon.ChevronLeft className="w-full h-auto" />
             </button>
@@ -126,7 +122,7 @@ const DailyReview = () => {
                 "w-7 h-7 mr-2 flex justify-center items-center rounded select-none last:mr-0 hover:bg-gray-200 dark:hover:bg-zinc-700 p-0.5",
                 isFutureDateDisabled ? "cursor-not-allowed" : "cursor-pointer"
               )}
-              onClick={() => updateCurrentDateStamp(currentDateStamp + DAILY_TIMESTAMP)}
+              onClick={() => setCurrentDateStamp(currentDateStamp + DAILY_TIMESTAMP)}
               disabled={isFutureDateDisabled}
             >
               <Icon.ChevronRight className="w-full h-auto" />


### PR DESCRIPTION
This PR add a small feature, to persist current selected date of DailyReview page. With the feature, while we refresh the DailyReview page, we needn't to select date again.