### PR TITLE
chore: optimize layout of image resources

### DIFF
--- a/web/src/components/MemoResourceListView.tsx
+++ b/web/src/components/MemoResourceListView.tsx
@@ -52,7 +52,12 @@ const MemoResourceListView: React.FC<Props> = (props: Props) => {
             />
           </div>
         ) : (
-          <div className={classNames("w-full mt-2 grid gap-2 grid-cols-2 sm:grid-cols-3")}>
+          <div
+            className={classNames(
+              "w-full mt-2 grid gap-2 grid-cols-2",
+              imageResourceList.length === 4 ? "sm:grid-cols-2" : "sm:grid-cols-3"
+            )}
+          >
             {imageResourceList.map((resource) => {
               const url = getResourceUrl(resource);
               return (


### PR DESCRIPTION
This PR just optimize image resources layout while the number of image is 4.

Before this PR, it'll be like this:

```
 | IMAGE1 | IMAGE2 | IMAGE3 |
 | IMAGE4 |
```

After this PR merged, it'll be like this:

```
 | IMAGE1 | IMAGE2 |
 | IMAGE3 | IMAGE4 |
```

This layout looks better, and come from *WeChat* *Moments*.