### PR TITLE
fix: vite proxy setting

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -17,19 +17,19 @@ export default defineConfig({
     proxy: {
       "^/api": {
         target: devProxyServer,
-        changeOrigin: true,
+        xfwd: true,
       },
       "^/o/": {
         target: devProxyServer,
-        changeOrigin: true,
+        xfwd: true,
       },
       "^/u/.+/rss.xml": {
         target: devProxyServer,
-        changeOrigin: true,
+        xfwd: true,
       },
       "/explore/rss.xml": {
         target: devProxyServer,
-        changeOrigin: true,
+        xfwd: true,
       },
     },
   },


### PR DESCRIPTION
This PR fix some settings for vite proxy, so we can keep the origin HTTP Host header and add some XFF headers to the backend API server.