### PR TITLE
chore: fix typo in german localization

### DIFF
--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -237,7 +237,7 @@
         "title": "Server bearbeiten",
         "default": "Standard: memos",
         "icon-url": "Icon-URL",
-        "description": "Beschreibunb",
+        "description": "Beschreibung",
         "locale": "Sprache",
         "appearance": "Erscheinungsbild"
       },


### PR DESCRIPTION
TItle, basically. Just a typo fix.