### PR TITLE
fix: apiv2 failed in container

### DIFF
--- a/web/src/grpcweb.ts
+++ b/web/src/grpcweb.ts
@@ -5,7 +5,10 @@ import { SystemServiceDefinition } from "./types/proto/api/v2/system_service";
 import { TagServiceDefinition } from "./types/proto/api/v2/tag_service";
 import { UserServiceDefinition } from "./types/proto/api/v2/user_service";
 
-const address = import.meta.env.MODE === "development" ? "http://localhost:8081" : window.location.origin;
+let address = window.location.origin;
+if (window.location.host == "localhost") {
+  address = "http://localhost:8081";
+}
 
 const channel = createChannel(
   address,

--- a/web/src/grpcweb.ts
+++ b/web/src/grpcweb.ts
@@ -5,13 +5,8 @@ import { SystemServiceDefinition } from "./types/proto/api/v2/system_service";
 import { TagServiceDefinition } from "./types/proto/api/v2/tag_service";
 import { UserServiceDefinition } from "./types/proto/api/v2/user_service";
 
-let address = window.location.origin;
-if (window.location.host == "localhost") {
-  address = "http://localhost:8081";
-}
-
 const channel = createChannel(
-  address,
+  window.location.origin,
   FetchTransport({
     credentials: "include",
   })

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
         target: devProxyServer,
         xfwd: true,
       },
+      "^/memos.api.v2": {
+        target: devProxyServer,
+        xfwd: true,
+      },
       "^/o/": {
         target: devProxyServer,
         xfwd: true,


### PR DESCRIPTION
While calling api v2 in container or any other dev environment which is not on `localhost`, all the v2 API will failed. This PR just fixed this bug.