### PR TITLE
feat: add some dev tools in the docker compose

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -27,3 +27,53 @@ services:
     volumes:
       - ./web:/work
       - ./.air/node_modules/:/work/node_modules/ # Cache for Node Modules
+
+  # Services below are used for developers to run once
+  #
+  # You can just run `docker compose run --rm SERVICE_NAME` to use
+  # For example:
+  #   To regenerate typescript code of gRPC proto
+  #   Just run `docker compose run --rm buf`
+  #
+  # All of theses services belongs to profile 'tools'
+  # This will prevent to launch by normally `docker compose up` unexpectly
+
+  # Generate typescript code of gRPC proto
+  buf:
+    profiles: ["tools"]
+    image: bufbuild/buf
+    working_dir: /work/proto
+    command: generate
+    volumes:
+      - ./proto:/work/proto
+      - ./web/src/types/:/work/web/src/types/
+
+  # Do golang static code check before create PR
+  golangci-lint:
+    profiles: ["tools"]
+    image: golangci/golangci-lint:v1.54.2
+    working_dir: /work/
+    command: golangci-lint run -v
+    volumes:
+      - $HOME/go/pkg/:/go/pkg/ # Cache for go mod shared with the host
+      - .:/work/
+
+  # Do javascript lint before create PR
+  lint:
+    profiles: ["tools"]
+    image: node:18-alpine
+    working_dir: /work
+    command: npm run lint
+    volumes:
+      - ./web:/work
+      - ./.air/node_modules/:/work/node_modules/
+
+  # Compile typescripts before create PR
+  tsc:
+    profiles: ["tools"]
+    image: node:18-alpine
+    working_dir: /work
+    command: npm run tsc
+    volumes:
+      - ./web:/work
+      - ./.air/node_modules/:/work/node_modules/

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -67,13 +67,3 @@ services:
     volumes:
       - ./web:/work
       - ./.air/node_modules/:/work/node_modules/
-
-  # Compile typescripts before create PR
-  tsc:
-    profiles: ["tools"]
-    image: node:18-alpine
-    working_dir: /work
-    command: npm run tsc
-    volumes:
-      - ./web:/work
-      - ./.air/node_modules/:/work/node_modules/

--- a/web/package.json
+++ b/web/package.json
@@ -3,8 +3,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "tsc": "tsc",
-    "lint": "eslint --ext .js,.ts,.tsx, src",
+    "lint": "tsc && eslint --ext .js,.ts,.tsx, src",
     "lint-fix": "eslint --ext .js,.ts,.tsx, src --fix"
   },
   "packageManager": "pnpm@8.7.0",

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "tsc": "tsc",
     "lint": "eslint --ext .js,.ts,.tsx, src",
     "lint-fix": "eslint --ext .js,.ts,.tsx, src --fix"
   },


### PR DESCRIPTION
This PR just add some useful tools for developers into `docker-compose.dev.yaml`.

With the PR, developers can just run some tools simply with `docker compose`, such as:

To regenerate typescripts bind of gRPC protocol, you can just run:
```
docker compose run --rm buf
```

To lint the golang code before commit or push to the repo, just run:
```
docker compose run --rm golangci-lint
```

To lint the javascript code before commit or push to the repo, just run:
```
docker compose run --rm lint
```