### PR TITLE
chore: update it.json translation

### DIFF
--- a/web/src/locales/it.json
+++ b/web/src/locales/it.json
@@ -100,7 +100,7 @@
     "archived-at": "Archiviato il",
     "search-placeholder": "Cerca memos",
     "visibility": {
-      "private": "Privao",
+      "private": "Privato",
       "protected": "Visibile ai membri",
       "public": "Pubblico",
       "disabled": "I memo pubblici sono disattivati"


### PR DESCRIPTION
Changed translation of "private" to "Privato" instead of "Privao" (missing the letter "t")