### PR TITLE
fix: CreateIdentityProvider without id

### DIFF
--- a/store/db/sqlite/idp.go
+++ b/store/db/sqlite/idp.go
@@ -23,26 +23,16 @@ func (d *DB) CreateIdentityProvider(ctx context.Context, create *store.IdentityP
 		return nil, errors.Errorf("unsupported idp type %s", string(create.Type))
 	}
 
-	stmt := `
-		INSERT INTO idp (
-			name,
-			type,
-			identifier_filter,
-			config
-		)
-		VALUES (?, ?, ?, ?)
-		RETURNING id
-	`
-	if err := d.db.QueryRowContext(
-		ctx,
-		stmt,
-		create.Name,
-		create.Type,
-		create.IdentifierFilter,
-		string(configBytes),
-	).Scan(
-		&create.ID,
-	); err != nil {
+	placeholders := []string{"?", "?", "?", "?"}
+	fields := []string{"`name`", "`type`", "`identifier_filter`", "`config`"}
+	args := []any{create.Name, create.Type, create.IdentifierFilter, string(configBytes)}
+
+	if create.ID != 0 {
+		fields, placeholders, args = append(fields, "`id`"), append(placeholders, "?"), append(args, create.ID)
+	}
+
+	stmt := "INSERT INTO `idp` (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholders, ", ") + ") RETURNING id"
+	if err := d.db.QueryRowContext(ctx, stmt, args...).Scan(&create.ID); err != nil {
 		return nil, err
 	}
 

--- a/store/db/sqlite/idp.go
+++ b/store/db/sqlite/idp.go
@@ -31,7 +31,7 @@ func (d *DB) CreateIdentityProvider(ctx context.Context, create *store.IdentityP
 		fields, placeholders, args = append(fields, "`id`"), append(placeholders, "?"), append(args, create.ID)
 	}
 
-	stmt := "INSERT INTO `idp` (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholders, ", ") + ") RETURNING id"
+	stmt := "INSERT INTO `idp` (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholders, ", ") + ") RETURNING `id`"
 	if err := d.db.QueryRowContext(ctx, stmt, args...).Scan(&create.ID); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR just fix a small bug ( maybe it's a new feature), that while we create IdentityProvider, the `Id` attributes has no affect.