### PR TITLE
fix: create resource without some attributes

### DIFF
--- a/store/db/mysql/resource.go
+++ b/store/db/mysql/resource.go
@@ -12,18 +12,36 @@ import (
 )
 
 func (d *DB) CreateResource(ctx context.Context, create *store.Resource) (*store.Resource, error) {
-	stmt := "INSERT INTO `resource` (`filename`, `blob`, `external_link`, `type`, `size`, `creator_id`, `internal_path`) VALUES (?, ?, ?, ?, ?, ?, ?)"
-	result, err := d.db.ExecContext(
-		ctx,
-		stmt,
-		create.Filename,
-		create.Blob,
-		create.ExternalLink,
-		create.Type,
-		create.Size,
-		create.CreatorID,
-		create.InternalPath,
-	)
+	fields := []string{"`filename`", "`blob`", "`external_link`", "`type`", "`size`", "`creator_id`", "`internal_path`"}
+	placeholder := []string{"?", "?", "?", "?", "?", "?", "?"}
+	args := []any{create.Filename, create.Blob, create.ExternalLink, create.Type, create.Size, create.CreatorID, create.InternalPath}
+
+	if create.ID != 0 {
+		fields = append(fields, "`id`")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.ID)
+	}
+
+	if create.CreatedTs != 0 {
+		fields = append(fields, "`created_ts`")
+		placeholder = append(placeholder, "FROM_UNIXTIME(?)")
+		args = append(args, create.CreatedTs)
+	}
+
+	if create.UpdatedTs != 0 {
+		fields = append(fields, "`updated_ts`")
+		placeholder = append(placeholder, "FROM_UNIXTIME(?)")
+		args = append(args, create.UpdatedTs)
+	}
+
+	if create.MemoID != nil {
+		fields = append(fields, "`memo_id`")
+		placeholder = append(placeholder, "?")
+		args = append(args, *create.MemoID)
+	}
+
+	stmt := "INSERT INTO `resource` (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ")"
+	result, err := d.db.ExecContext(ctx, stmt, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/store/db/sqlite/resource.go
+++ b/store/db/sqlite/resource.go
@@ -10,30 +10,36 @@ import (
 )
 
 func (d *DB) CreateResource(ctx context.Context, create *store.Resource) (*store.Resource, error) {
-	stmt := `
-		INSERT INTO resource (
-			filename,
-			blob,
-			external_link,
-			type,
-			size,
-			creator_id,
-			internal_path
-		)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
-		RETURNING id, created_ts, updated_ts
-	`
-	if err := d.db.QueryRowContext(
-		ctx,
-		stmt,
-		create.Filename,
-		create.Blob,
-		create.ExternalLink,
-		create.Type,
-		create.Size,
-		create.CreatorID,
-		create.InternalPath,
-	).Scan(&create.ID, &create.CreatedTs, &create.UpdatedTs); err != nil {
+	fields := []string{"`filename`", "`blob`", "`external_link`", "`type`", "`size`", "`creator_id`", "`internal_path`"}
+	placeholder := []string{"?", "?", "?", "?", "?", "?", "?"}
+	args := []any{create.Filename, create.Blob, create.ExternalLink, create.Type, create.Size, create.CreatorID, create.InternalPath}
+
+	if create.ID != 0 {
+		fields = append(fields, "`id`")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.ID)
+	}
+
+	if create.CreatedTs != 0 {
+		fields = append(fields, "`created_ts`")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.CreatedTs)
+	}
+
+	if create.UpdatedTs != 0 {
+		fields = append(fields, "`updated_ts`")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.UpdatedTs)
+	}
+
+	if create.MemoID != nil {
+		fields = append(fields, "`memo_id`")
+		placeholder = append(placeholder, "?")
+		args = append(args, *create.MemoID)
+	}
+
+	stmt := "INSERT INTO `resource` (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ") RETURNING id, created_ts, updated_ts"
+	if err := d.db.QueryRowContext(ctx, stmt, args...).Scan(&create.ID, &create.CreatedTs, &create.UpdatedTs); err != nil {
 		return nil, err
 	}
 

--- a/store/db/sqlite/resource.go
+++ b/store/db/sqlite/resource.go
@@ -38,7 +38,7 @@ func (d *DB) CreateResource(ctx context.Context, create *store.Resource) (*store
 		args = append(args, *create.MemoID)
 	}
 
-	stmt := "INSERT INTO `resource` (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ") RETURNING id, created_ts, updated_ts"
+	stmt := "INSERT INTO `resource` (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ") RETURNING `id`, `created_ts`, `updated_ts`"
 	if err := d.db.QueryRowContext(ctx, stmt, args...).Scan(&create.ID, &create.CreatedTs, &create.UpdatedTs); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR just fix a small bug ( maybe it's a new feature), that while we create `Resource`, the `Id`, `CreatedTs`,`UpdatedTs`,`MemoID` attributes has no affect.