### PR TITLE
fix: create memo without some attributes

### DIFF
--- a/store/db/mysql/memo.go
+++ b/store/db/mysql/memo.go
@@ -13,30 +13,30 @@ import (
 )
 
 func (d *DB) CreateMemo(ctx context.Context, create *store.Memo) (*store.Memo, error) {
-	fields := []string{"creator_id", "content", "visibility"}
+	fields := []string{"`creator_id`", "`content`", "`visibility`"}
 	placeholder := []string{"?", "?", "?"}
 	args := []any{create.CreatorID, create.Content, create.Visibility}
 
 	if create.ID != 0 {
-		fields = append(fields, "id")
+		fields = append(fields, "`id`")
 		placeholder = append(placeholder, "?")
 		args = append(args, create.ID)
 	}
 
 	if create.CreatedTs != 0 {
-		fields = append(fields, "created_ts")
+		fields = append(fields, "`created_ts`")
 		placeholder = append(placeholder, "FROM_UNIXTIME(?)")
 		args = append(args, create.CreatedTs)
 	}
 
 	if create.UpdatedTs != 0 {
-		fields = append(fields, "updated_ts")
+		fields = append(fields, "`updated_ts`")
 		placeholder = append(placeholder, "FROM_UNIXTIME(?)")
 		args = append(args, create.UpdatedTs)
 	}
 
 	if create.RowStatus != "" {
-		fields = append(fields, "row_status")
+		fields = append(fields, "`row_status`")
 		placeholder = append(placeholder, "?")
 		args = append(args, create.RowStatus)
 	}

--- a/store/db/mysql/memo.go
+++ b/store/db/mysql/memo.go
@@ -13,14 +13,36 @@ import (
 )
 
 func (d *DB) CreateMemo(ctx context.Context, create *store.Memo) (*store.Memo, error) {
-	stmt := "INSERT INTO `memo` (`creator_id`, `content`, `visibility`) VALUES (?, ?, ?)"
-	result, err := d.db.ExecContext(
-		ctx,
-		stmt,
-		create.CreatorID,
-		create.Content,
-		create.Visibility,
-	)
+	fields := []string{"creator_id", "content", "visibility"}
+	placeholder := []string{"?", "?", "?"}
+	args := []any{create.CreatorID, create.Content, create.Visibility}
+
+	if create.ID != 0 {
+		fields = append(fields, "id")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.ID)
+	}
+
+	if create.CreatedTs != 0 {
+		fields = append(fields, "created_ts")
+		placeholder = append(placeholder, "FROM_UNIXTIME(?)")
+		args = append(args, create.CreatedTs)
+	}
+
+	if create.UpdatedTs != 0 {
+		fields = append(fields, "updated_ts")
+		placeholder = append(placeholder, "FROM_UNIXTIME(?)")
+		args = append(args, create.UpdatedTs)
+	}
+
+	if create.RowStatus != "" {
+		fields = append(fields, "row_status")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.RowStatus)
+	}
+
+	stmt := "INSERT INTO memo (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ")"
+	result, err := d.db.ExecContext(ctx, stmt, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/store/db/sqlite/memo.go
+++ b/store/db/sqlite/memo.go
@@ -13,35 +13,35 @@ import (
 )
 
 func (d *DB) CreateMemo(ctx context.Context, create *store.Memo) (*store.Memo, error) {
-	fields := []string{"creator_id", "content", "visibility"}
+	fields := []string{"`creator_id`", "`content`", "`visibility`"}
 	placeholder := []string{"?", "?", "?"}
 	args := []any{create.CreatorID, create.Content, create.Visibility}
 
 	if create.ID != 0 {
-		fields = append(fields, "id")
+		fields = append(fields, "`id`")
 		placeholder = append(placeholder, "?")
 		args = append(args, create.ID)
 	}
 
 	if create.CreatedTs != 0 {
-		fields = append(fields, "created_ts")
+		fields = append(fields, "`created_ts`")
 		placeholder = append(placeholder, "?")
 		args = append(args, create.CreatedTs)
 	}
 
 	if create.UpdatedTs != 0 {
-		fields = append(fields, "updated_ts")
+		fields = append(fields, "`updated_ts`")
 		placeholder = append(placeholder, "?")
 		args = append(args, create.UpdatedTs)
 	}
 
 	if create.RowStatus != "" {
-		fields = append(fields, "row_status")
+		fields = append(fields, "`row_status`")
 		placeholder = append(placeholder, "?")
 		args = append(args, create.RowStatus)
 	}
 
-	stmt := "INSERT INTO memo (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ") RETURNING id, created_ts, updated_ts, row_status"
+	stmt := "INSERT INTO memo (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ") RETURNING `id`, `created_ts`, `updated_ts`, `row_status`"
 	if err := d.db.QueryRowContext(ctx, stmt, args...).Scan(
 		&create.ID,
 		&create.CreatedTs,

--- a/store/db/sqlite/memo.go
+++ b/store/db/sqlite/memo.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -14,28 +13,36 @@ import (
 )
 
 func (d *DB) CreateMemo(ctx context.Context, create *store.Memo) (*store.Memo, error) {
-	if create.CreatedTs == 0 {
-		create.CreatedTs = time.Now().Unix()
+	fields := []string{"creator_id", "content", "visibility"}
+	placeholder := []string{"?", "?", "?"}
+	args := []any{create.CreatorID, create.Content, create.Visibility}
+
+	if create.ID != 0 {
+		fields = append(fields, "id")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.ID)
 	}
 
-	stmt := `
-		INSERT INTO memo (
-			creator_id,
-			created_ts,
-			content,
-			visibility
-		)
-		VALUES (?, ?, ?, ?)
-		RETURNING id, created_ts, updated_ts, row_status
-	`
-	if err := d.db.QueryRowContext(
-		ctx,
-		stmt,
-		create.CreatorID,
-		create.CreatedTs,
-		create.Content,
-		create.Visibility,
-	).Scan(
+	if create.CreatedTs != 0 {
+		fields = append(fields, "created_ts")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.CreatedTs)
+	}
+
+	if create.UpdatedTs != 0 {
+		fields = append(fields, "updated_ts")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.UpdatedTs)
+	}
+
+	if create.RowStatus != "" {
+		fields = append(fields, "row_status")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.RowStatus)
+	}
+
+	stmt := "INSERT INTO memo (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ") RETURNING id, created_ts, updated_ts, row_status"
+	if err := d.db.QueryRowContext(ctx, stmt, args...).Scan(
 		&create.ID,
 		&create.CreatedTs,
 		&create.UpdatedTs,


### PR DESCRIPTION
This PR just fix a small bug ( maybe it's a new feature), that while we create `Memo`, the `Id`, `CreatedTs`,`UpdatedTs`,`RowStatus` attributes has no affect.