### PR TITLE
fix: create user without some attributes 

### DIFF
--- a/store/db/mysql/user.go
+++ b/store/db/mysql/user.go
@@ -10,30 +10,30 @@ import (
 )
 
 func (d *DB) CreateUser(ctx context.Context, create *store.User) (*store.User, error) {
-	fields := []string{"username", "role", "email", "nickname", "password_hash", "avatar_url"}
+	fields := []string{"`username`", "`role`", "`email`", "`nickname`", "`password_hash`", "`avatar_url`"}
 	placeholder := []string{"?", "?", "?", "?", "?", "?"}
 	args := []any{create.Username, create.Role, create.Email, create.Nickname, create.PasswordHash, create.AvatarURL}
 
 	if create.RowStatus != "" {
-		fields = append(fields, "row_status")
+		fields = append(fields, "`row_status`")
 		placeholder = append(placeholder, "?")
 		args = append(args, create.RowStatus)
 	}
 
 	if create.CreatedTs != 0 {
-		fields = append(fields, "created_ts")
+		fields = append(fields, "`created_ts`")
 		placeholder = append(placeholder, "FROM_UNIXTIME(?)")
 		args = append(args, create.CreatedTs)
 	}
 
 	if create.UpdatedTs != 0 {
-		fields = append(fields, "updated_ts")
+		fields = append(fields, "`updated_ts`")
 		placeholder = append(placeholder, "FROM_UNIXTIME(?)")
 		args = append(args, create.UpdatedTs)
 	}
 
 	if create.ID != 0 {
-		fields = append(fields, "id")
+		fields = append(fields, "`id`")
 		placeholder = append(placeholder, "?")
 		args = append(args, create.ID)
 	}

--- a/store/db/mysql/user.go
+++ b/store/db/mysql/user.go
@@ -10,15 +10,36 @@ import (
 )
 
 func (d *DB) CreateUser(ctx context.Context, create *store.User) (*store.User, error) {
-	stmt := "INSERT INTO `user` (`username`, `role`, `email`, `nickname`, `password_hash`, `avatar_url`) VALUES (?, ?, ?, ?, ?, ?)"
-	result, err := d.db.ExecContext(ctx, stmt,
-		create.Username,
-		create.Role,
-		create.Email,
-		create.Nickname,
-		create.PasswordHash,
-		create.AvatarURL,
-	)
+	fields := []string{"username", "role", "email", "nickname", "password_hash", "avatar_url"}
+	placeholder := []string{"?", "?", "?", "?", "?", "?"}
+	args := []any{create.Username, create.Role, create.Email, create.Nickname, create.PasswordHash, create.AvatarURL}
+
+	if create.RowStatus != "" {
+		fields = append(fields, "row_status")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.RowStatus)
+	}
+
+	if create.CreatedTs != 0 {
+		fields = append(fields, "created_ts")
+		placeholder = append(placeholder, "FROM_UNIXTIME(?)")
+		args = append(args, create.CreatedTs)
+	}
+
+	if create.UpdatedTs != 0 {
+		fields = append(fields, "updated_ts")
+		placeholder = append(placeholder, "FROM_UNIXTIME(?)")
+		args = append(args, create.UpdatedTs)
+	}
+
+	if create.ID != 0 {
+		fields = append(fields, "id")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.ID)
+	}
+
+	stmt := "INSERT INTO user (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ")"
+	result, err := d.db.ExecContext(ctx, stmt, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/store/db/sqlite/user.go
+++ b/store/db/sqlite/user.go
@@ -8,36 +8,36 @@ import (
 )
 
 func (d *DB) CreateUser(ctx context.Context, create *store.User) (*store.User, error) {
-	fields := []string{"username", "role", "email", "nickname", "password_hash"}
+	fields := []string{"`username`", "`role`", "`email`", "`nickname`", "`password_hash`"}
 	placeholder := []string{"?", "?", "?", "?", "?"}
 	args := []any{create.Username, create.Role, create.Email, create.Nickname, create.PasswordHash}
 
 	if create.AvatarURL != "" {
-		fields = append(fields, "avatar_url")
+		fields = append(fields, "`avatar_url`")
 		placeholder = append(placeholder, "?")
 		args = append(args, create.AvatarURL)
 	}
 
 	if create.RowStatus != "" {
-		fields = append(fields, "row_status")
+		fields = append(fields, "`row_status`")
 		placeholder = append(placeholder, "?")
 		args = append(args, create.RowStatus)
 	}
 
 	if create.CreatedTs != 0 {
-		fields = append(fields, "created_ts")
+		fields = append(fields, "`created_ts`")
 		placeholder = append(placeholder, "?")
 		args = append(args, create.CreatedTs)
 	}
 
 	if create.UpdatedTs != 0 {
-		fields = append(fields, "updated_ts")
+		fields = append(fields, "`updated_ts`")
 		placeholder = append(placeholder, "?")
 		args = append(args, create.UpdatedTs)
 	}
 
 	if create.ID != 0 {
-		fields = append(fields, "id")
+		fields = append(fields, "`id`")
 		placeholder = append(placeholder, "?")
 		args = append(args, create.ID)
 	}

--- a/store/db/sqlite/user.go
+++ b/store/db/sqlite/user.go
@@ -8,26 +8,42 @@ import (
 )
 
 func (d *DB) CreateUser(ctx context.Context, create *store.User) (*store.User, error) {
-	stmt := `
-		INSERT INTO user (
-			username,
-			role,
-			email,
-			nickname,
-			password_hash
-		)
-		VALUES (?, ?, ?, ?, ?)
-		RETURNING id, avatar_url, created_ts, updated_ts, row_status
-	`
-	if err := d.db.QueryRowContext(
-		ctx,
-		stmt,
-		create.Username,
-		create.Role,
-		create.Email,
-		create.Nickname,
-		create.PasswordHash,
-	).Scan(
+	fields := []string{"username", "role", "email", "nickname", "password_hash"}
+	placeholder := []string{"?", "?", "?", "?", "?"}
+	args := []any{create.Username, create.Role, create.Email, create.Nickname, create.PasswordHash}
+
+	if create.AvatarURL != "" {
+		fields = append(fields, "avatar_url")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.AvatarURL)
+	}
+
+	if create.RowStatus != "" {
+		fields = append(fields, "row_status")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.RowStatus)
+	}
+
+	if create.CreatedTs != 0 {
+		fields = append(fields, "created_ts")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.CreatedTs)
+	}
+
+	if create.UpdatedTs != 0 {
+		fields = append(fields, "updated_ts")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.UpdatedTs)
+	}
+
+	if create.ID != 0 {
+		fields = append(fields, "id")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.ID)
+	}
+
+	stmt := "INSERT INTO user (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ") RETURNING id, avatar_url, created_ts, updated_ts, row_status"
+	if err := d.db.QueryRowContext(ctx, stmt, args...).Scan(
 		&create.ID,
 		&create.AvatarURL,
 		&create.CreatedTs,


### PR DESCRIPTION
This PR just fix a small bug ( maybe it's a new feature), that while we create `User`, the `Id`, `CreatedTs`,`UpdatedTs`,`RowStatus` attributes has no affect.