### PR TITLE
fix: create storage without some attributes 

### DIFF
--- a/store/db/mysql/storage.go
+++ b/store/db/mysql/storage.go
@@ -8,8 +8,18 @@ import (
 )
 
 func (d *DB) CreateStorage(ctx context.Context, create *store.Storage) (*store.Storage, error) {
-	stmt := "INSERT INTO `storage` (`name`, `type`, `config`) VALUES (?, ?, ?)"
-	result, err := d.db.ExecContext(ctx, stmt, create.Name, create.Type, create.Config)
+	fields := []string{"`name`", "`type`", "`config`"}
+	placeholder := []string{"?", "?", "?"}
+	args := []any{create.Name, create.Type, create.Config}
+
+	if create.ID != 0 {
+		fields = append(fields, "`id`")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.ID)
+	}
+
+	stmt := "INSERT INTO `storage` (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ")"
+	result, err := d.db.ExecContext(ctx, stmt, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/store/db/sqlite/storage.go
+++ b/store/db/sqlite/storage.go
@@ -8,16 +8,18 @@ import (
 )
 
 func (d *DB) CreateStorage(ctx context.Context, create *store.Storage) (*store.Storage, error) {
-	stmt := `
-		INSERT INTO storage (
-			name,
-			type,
-			config
-		)
-		VALUES (?, ?, ?)
-		RETURNING id
-	`
-	if err := d.db.QueryRowContext(ctx, stmt, create.Name, create.Type, create.Config).Scan(
+	fields := []string{"`name`", "`type`", "`config`"}
+	placeholder := []string{"?", "?", "?"}
+	args := []any{create.Name, create.Type, create.Config}
+
+	if create.ID != 0 {
+		fields = append(fields, "`id`")
+		placeholder = append(placeholder, "?")
+		args = append(args, create.ID)
+	}
+
+	stmt := "INSERT INTO `storage` (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ") RETURNING id"
+	if err := d.db.QueryRowContext(ctx, stmt, args...).Scan(
 		&create.ID,
 	); err != nil {
 		return nil, err

--- a/store/db/sqlite/storage.go
+++ b/store/db/sqlite/storage.go
@@ -18,7 +18,7 @@ func (d *DB) CreateStorage(ctx context.Context, create *store.Storage) (*store.S
 		args = append(args, create.ID)
 	}
 
-	stmt := "INSERT INTO `storage` (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ") RETURNING id"
+	stmt := "INSERT INTO `storage` (" + strings.Join(fields, ", ") + ") VALUES (" + strings.Join(placeholder, ", ") + ") RETURNING `id`"
 	if err := d.db.QueryRowContext(ctx, stmt, args...).Scan(
 		&create.ID,
 	); err != nil {


### PR DESCRIPTION
This PR just fix a small bug ( maybe it's a new feature), that while we create `Storage`, the `Id` attribute has no affect.