### PR TITLE
fix: index page failed with 429

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -80,7 +80,7 @@ func NewServer(ctx context.Context, profile *profile.Profile, store *store.Store
 	e.Use(middleware.RateLimiterWithConfig(middleware.RateLimiterConfig{
 		Skipper: grpcRequestSkipper,
 		Store: middleware.NewRateLimiterMemoryStoreWithConfig(
-			middleware.RateLimiterMemoryStoreConfig{Rate: 30, Burst: 60, ExpiresIn: 3 * time.Minute},
+			middleware.RateLimiterMemoryStoreConfig{Rate: 30, Burst: 100, ExpiresIn: 3 * time.Minute},
 		),
 		IdentifierExtractor: func(ctx echo.Context) (string, error) {
 			id := ctx.RealIP()


### PR DESCRIPTION
This PR just change the burst rate limit from `60` to `100`.

Currently when we load the index page, there're many web resources ( about 88 uri ) to be load, the original burst limit `60` is too small, and will cause there server return `429` to refuse the browser to load.

PS, the resource number of the index page in my case:

- Document: 1
- CSS: 10
- Images: 1
- Javascript: 49
- XHR/Fetch: 27

Total: 88