### PR TITLE
chore: print profile.Data in boot log

### DIFF
--- a/cmd/memos.go
+++ b/cmd/memos.go
@@ -149,6 +149,7 @@ func initConfig() {
 
 	println("---")
 	println("Server profile")
+	println("data:", profile.Data)
 	println("dsn:", profile.DSN)
 	println("addr:", profile.Addr)
 	println("port:", profile.Port)


### PR DESCRIPTION
This PR just add `profile.Data` in the booting log.