### PR TITLE
chore: add latency in log

### DIFF
--- a/cmd/memos.go
+++ b/cmd/memos.go
@@ -149,6 +149,7 @@ func initConfig() {
 
 	println("---")
 	println("Server profile")
+	println("data:", profile.Data)
 	println("dsn:", profile.DSN)
 	println("addr:", profile.Addr)
 	println("port:", profile.Port)

--- a/server/server.go
+++ b/server/server.go
@@ -59,7 +59,7 @@ func NewServer(ctx context.Context, profile *profile.Profile, store *store.Store
 	}
 
 	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
-		Format: `{"time":"${time_rfc3339}",` +
+		Format: `{"time":"${time_rfc3339}","latency":"${latency_human}",` +
 			`"method":"${method}","uri":"${uri}",` +
 			`"status":${status},"error":"${error}"}` + "\n",
 	}))


### PR DESCRIPTION
This PR just add *latency* in the request log, which is helpful while debug the performance of Memos