### PR TITLE
fix: invalid type convert in apiv2

### DIFF
--- a/api/v2/memo_service.go
+++ b/api/v2/memo_service.go
@@ -38,7 +38,7 @@ func (s *MemoService) CreateMemo(ctx context.Context, request *apiv2pb.CreateMem
 	create := &store.Memo{
 		CreatorID:  user.ID,
 		Content:    request.Content,
-		Visibility: store.Visibility(request.Visibility),
+		Visibility: store.Visibility(request.Visibility.String()),
 	}
 	memo, err := s.Store.CreateMemo(ctx, create)
 	if err != nil {


### PR DESCRIPTION
This PR just fix a bug in apiv2, which will cause `Visibility` param of `CreateMemo` has no effect in gRPC call.