### PR TITLE
chore: update iOS shortcut link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ Contributions are what make the open-source community such an amazing place to l
 - [eallion/memos.top](https://github.com/eallion/memos.top) - Static page rendered with the Memos API
 - [eindex/logseq-memos-sync](https://github.com/EINDEX/logseq-memos-sync) - Logseq plugin
 - [JakeLaoyu/memos-import-from-flomo](https://github.com/JakeLaoyu/memos-import-from-flomo) - Import data. Support from flomo, wechat reading
-- [Send to memos](https://sharecuts.cn/shortcut/12640) - A shortcut for iOS
-- [Send to memos (>=0.15.0)](https://sharecuts.cn/shortcut/13098) - A shortcut for iOS (memos >=0.15.0)
+- [Send to memos](https://sharecuts.cn/shortcut/13098) - A shortcut for iOS
 - [Memos Raycast Extension](https://www.raycast.com/JakeYu/memos) - Raycast extension
 - [Memos Desktop](https://github.com/xudaolong/memos-desktop) - Third party client for MacOS and Windows
 - [MemosGallery](https://github.com/BarryYangi/MemosGallery) - A static Gallery rendered with the Memos API

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Contributions are what make the open-source community such an amazing place to l
 - [eindex/logseq-memos-sync](https://github.com/EINDEX/logseq-memos-sync) - Logseq plugin
 - [JakeLaoyu/memos-import-from-flomo](https://github.com/JakeLaoyu/memos-import-from-flomo) - Import data. Support from flomo, wechat reading
 - [Send to memos](https://sharecuts.cn/shortcut/12640) - A shortcut for iOS
+- [Send to memos (>=0.15.0)](https://sharecuts.cn/shortcut/13098) - A shortcut for iOS (memos >=0.15.0)
 - [Memos Raycast Extension](https://www.raycast.com/JakeYu/memos) - Raycast extension
 - [Memos Desktop](https://github.com/xudaolong/memos-desktop) - Third party client for MacOS and Windows
 - [MemosGallery](https://github.com/BarryYangi/MemosGallery) - A static Gallery rendered with the Memos API


### PR DESCRIPTION
New shortcut for memos version 0.15.0 and above on IOS