### PR TITLE
chore: change the timeout value of golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,5 @@
+run:
+  timeout: 10m
 linters:
   enable:
     - errcheck


### PR DESCRIPTION
The default timeout of *golangci-lint* is 1 minute, but the benchmark shows it always require 1~2 minutes to do this. So I changed the default timeout config of it.