### PR TITLE
chore: update Shortcuts link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Contributions are what make the open-source community such an amazing place to l
 - [eallion/memos.top](https://github.com/eallion/memos.top) - Static page rendered with the Memos API
 - [eindex/logseq-memos-sync](https://github.com/EINDEX/logseq-memos-sync) - Logseq plugin
 - [JakeLaoyu/memos-import-from-flomo](https://github.com/JakeLaoyu/memos-import-from-flomo) - Import data. Support from flomo, wechat reading
-- [Send to memos](https://www.icloud.com/shortcuts/bb804bdd8af840d1b9f71d5df250654d) - Shortcuts (iOS, iPadOS or macOS)
+- [Quick Memo](https://www.icloud.com/shortcuts/bb804bdd8af840d1b9f71d5df250654d) - Shortcuts (iOS, iPadOS or macOS)
 - [Memos Raycast Extension](https://www.raycast.com/JakeYu/memos) - Raycast extension
 - [Memos Desktop](https://github.com/xudaolong/memos-desktop) - Third party client for MacOS and Windows
 - [MemosGallery](https://github.com/BarryYangi/MemosGallery) - A static Gallery rendered with the Memos API

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Contributions are what make the open-source community such an amazing place to l
 - [eallion/memos.top](https://github.com/eallion/memos.top) - Static page rendered with the Memos API
 - [eindex/logseq-memos-sync](https://github.com/EINDEX/logseq-memos-sync) - Logseq plugin
 - [JakeLaoyu/memos-import-from-flomo](https://github.com/JakeLaoyu/memos-import-from-flomo) - Import data. Support from flomo, wechat reading
-- [Quick Memo](https://www.icloud.com/shortcuts/bb804bdd8af840d1b9f71d5df250654d) - Shortcuts (iOS, iPadOS or macOS)
+- [Quick Memo](https://www.icloud.com/shortcuts/1eaef307112843ed9f91d256f5ee7ad9) - Shortcuts (iOS, iPadOS or macOS)
 - [Memos Raycast Extension](https://www.raycast.com/JakeYu/memos) - Raycast extension
 - [Memos Desktop](https://github.com/xudaolong/memos-desktop) - Third party client for MacOS and Windows
 - [MemosGallery](https://github.com/BarryYangi/MemosGallery) - A static Gallery rendered with the Memos API

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Contributions are what make the open-source community such an amazing place to l
 - [eallion/memos.top](https://github.com/eallion/memos.top) - Static page rendered with the Memos API
 - [eindex/logseq-memos-sync](https://github.com/EINDEX/logseq-memos-sync) - Logseq plugin
 - [JakeLaoyu/memos-import-from-flomo](https://github.com/JakeLaoyu/memos-import-from-flomo) - Import data. Support from flomo, wechat reading
-- [Send to memos](https://sharecuts.cn/shortcut/13098) - A shortcut for iOS
+- [Send to memos](https://www.icloud.com/shortcuts/bb804bdd8af840d1b9f71d5df250654d) - Shortcuts (iOS, iPadOS or macOS)
 - [Memos Raycast Extension](https://www.raycast.com/JakeYu/memos) - Raycast extension
 - [Memos Desktop](https://github.com/xudaolong/memos-desktop) - Third party client for MacOS and Windows
 - [MemosGallery](https://github.com/BarryYangi/MemosGallery) - A static Gallery rendered with the Memos API


### PR DESCRIPTION
Hello! I have done a few minor changes to the shortcut:
- The description in the README. `A shortcut for iOS` -> `Shortcuts (iOS, iPadOS or macOS)`, more consistent with others.
- Shortcut
  - A more specific **error message** (like `Error: No API Endpoint`)
  - If failed to save, prompt for copying the memo **text to the clipboard**, so that the user can save it manually (rather than losing it).
  - Prompt for confirmation after tags being appended. User can either confirm or **modify the text**. This helps when quick saving quotes from an article using share sheet and want to make comments.