### PR TITLE
chore: extend height of setting page

### DIFF
--- a/web/src/components/Settings/MemberSection.tsx
+++ b/web/src/components/Settings/MemberSection.tsx
@@ -132,7 +132,7 @@ const PreferencesSection = () => {
       <div className="w-full flex flex-row justify-between items-center mt-6">
         <div className="title-text">{t("setting.member-list")}</div>
       </div>
-      <div className="w-full overflow-x-auto">
+      <div className="w-full overflow-x-auto max-h-[calc(100%-22rem)]">
         <div className="inline-block min-w-full align-middle">
           <table className="min-w-full divide-y divide-gray-300 dark:divide-gray-400">
             <thead>

--- a/web/src/layouts/Root.tsx
+++ b/web/src/layouts/Root.tsx
@@ -10,7 +10,7 @@ function Root() {
       </div>
       <div className="w-full max-w-6xl mx-auto flex flex-row justify-center items-start sm:px-4">
         <Header />
-        <main className="w-full sm:max-w-[calc(100%-14rem)] flex-grow shrink flex flex-col justify-start items-start">
+        <main className="w-full h-screen sm:max-w-[calc(100%-14rem)] flex-grow shrink flex flex-col justify-start items-start">
           <Outlet />
         </main>
       </div>


### PR DESCRIPTION
This PR makes a small optimization, that auto extend setting page's height to the whole screen.