### PR TITLE
chore: expand page width to avoid scroll on AccessTokens

### DIFF
--- a/web/src/pages/Setting.tsx
+++ b/web/src/pages/Setting.tsx
@@ -43,7 +43,7 @@ const Setting = () => {
   };
 
   return (
-    <section className="@container w-full max-w-3xl min-h-full flex flex-col justify-start items-start px-4 sm:px-2 sm:pt-4 pb-8 bg-zinc-100 dark:bg-zinc-800">
+    <section className="@container w-full max-w-5xl min-h-full flex flex-col justify-start items-start px-4 sm:px-2 sm:pt-4 pb-8 bg-zinc-100 dark:bg-zinc-800">
       <MobileHeader showSearch={false} />
       <div className="setting-page-wrapper">
         <div className="section-selector-container">


### PR DESCRIPTION
Before:
<img width="744" alt="before" src="https://github.com/usememos/memos/assets/126313/1edbb3ba-43a2-4648-8fae-b55cec49d9a1">

After:
<img width="878" alt="after" src="https://github.com/usememos/memos/assets/126313/2c3de03a-0a1e-455f-ada7-73a39450a4db">
