### PR TITLE
fix: fail to update user's update_ts

### DIFF
--- a/store/db/mysql/user.go
+++ b/store/db/mysql/user.go
@@ -64,7 +64,7 @@ func (d *DB) CreateUser(ctx context.Context, create *store.User) (*store.User, e
 func (d *DB) UpdateUser(ctx context.Context, update *store.UpdateUser) (*store.User, error) {
 	set, args := []string{}, []any{}
 	if v := update.UpdatedTs; v != nil {
-		set, args = append(set, "`updated_ts` = ?"), append(args, *v)
+		set, args = append(set, "`updated_ts` = FROM_UNIXTIME(?)"), append(args, *v)
 	}
 	if v := update.RowStatus; v != nil {
 		set, args = append(set, "`row_status` = ?"), append(args, *v)

--- a/web/src/pages/Setting.tsx
+++ b/web/src/pages/Setting.tsx
@@ -43,7 +43,7 @@ const Setting = () => {
   };
 
   return (
-    <section className="@container w-full max-w-3xl min-h-full flex flex-col justify-start items-start px-4 sm:px-2 sm:pt-4 pb-8 bg-zinc-100 dark:bg-zinc-800">
+    <section className="@container w-full max-w-5xl min-h-full flex flex-col justify-start items-start px-4 sm:px-2 sm:pt-4 pb-8 bg-zinc-100 dark:bg-zinc-800">
       <MobileHeader showSearch={false} />
       <div className="setting-page-wrapper">
         <div className="section-selector-container">

--- a/web/src/pages/Setting.tsx
+++ b/web/src/pages/Setting.tsx
@@ -43,7 +43,7 @@ const Setting = () => {
   };
 
   return (
-    <section className="@container w-full max-w-5xl min-h-full flex flex-col justify-start items-start px-4 sm:px-2 sm:pt-4 pb-8 bg-zinc-100 dark:bg-zinc-800">
+    <section className="@container w-full max-w-3xl min-h-full flex flex-col justify-start items-start px-4 sm:px-2 sm:pt-4 pb-8 bg-zinc-100 dark:bg-zinc-800">
       <MobileHeader showSearch={false} />
       <div className="setting-page-wrapper">
         <div className="section-selector-container">


### PR DESCRIPTION
This PR fix a bug, which will cause user's update on `update_ts` failed when using *MySQL* as storage driver.