### PR TITLE
feat: add user role external

### DIFF
--- a/.github/workflows/build-and-push-release-image.yml
+++ b/.github/workflows/build-and-push-release-image.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           context: ./
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/store/db/sqlite/migration/dev/LATEST__SCHEMA.sql
+++ b/store/db/sqlite/migration/dev/LATEST__SCHEMA.sql
@@ -33,7 +33,7 @@ CREATE TABLE user (
   updated_ts BIGINT NOT NULL DEFAULT (strftime('%s', 'now')),
   row_status TEXT NOT NULL CHECK (row_status IN ('NORMAL', 'ARCHIVED')) DEFAULT 'NORMAL',
   username TEXT NOT NULL UNIQUE,
-  role TEXT NOT NULL CHECK (role IN ('HOST', 'ADMIN', 'USER')) DEFAULT 'USER',
+  role TEXT NOT NULL CHECK (role IN ('HOST', 'ADMIN', 'USER', 'EXTERNAL')) DEFAULT 'USER',
   email TEXT NOT NULL DEFAULT '',
   nickname TEXT NOT NULL DEFAULT '',
   password_hash TEXT NOT NULL,

--- a/store/db/sqlite/migration/prod/LATEST__SCHEMA.sql
+++ b/store/db/sqlite/migration/prod/LATEST__SCHEMA.sql
@@ -33,7 +33,7 @@ CREATE TABLE user (
   updated_ts BIGINT NOT NULL DEFAULT (strftime('%s', 'now')),
   row_status TEXT NOT NULL CHECK (row_status IN ('NORMAL', 'ARCHIVED')) DEFAULT 'NORMAL',
   username TEXT NOT NULL UNIQUE,
-  role TEXT NOT NULL CHECK (role IN ('HOST', 'ADMIN', 'USER')) DEFAULT 'USER',
+  role TEXT NOT NULL CHECK (role IN ('HOST', 'ADMIN', 'USER', 'EXTERNAL')) DEFAULT 'USER',
   email TEXT NOT NULL DEFAULT '',
   nickname TEXT NOT NULL DEFAULT '',
   password_hash TEXT NOT NULL,

--- a/store/user.go
+++ b/store/user.go
@@ -14,6 +14,8 @@ const (
 	RoleAdmin Role = "ADMIN"
 	// RoleUser is the USER role.
 	RoleUser Role = "USER"
+	// RoleExternal is the EXTERNAL role.
+	RoleExternal Role = "EXTERNAL"
 )
 
 func (e Role) String() string {
@@ -24,6 +26,8 @@ func (e Role) String() string {
 		return "ADMIN"
 	case RoleUser:
 		return "USER"
+	case RoleExternal:
+		return "EXTERNAL"
 	}
 	return "USER"
 }

--- a/web/src/components/Settings/MemberSection.tsx
+++ b/web/src/components/Settings/MemberSection.tsx
@@ -1,4 +1,4 @@
-import { Button, Dropdown, Input, Menu, MenuButton } from "@mui/joy";
+import { Button, Dropdown, Input, Menu, MenuButton, Select, Option } from "@mui/joy";
 import React, { useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
 import * as api from "@/helpers/api";
@@ -11,6 +11,7 @@ import Icon from "../Icon";
 interface State {
   createUserUsername: string;
   createUserPassword: string;
+  createUserRole: UserRole;
 }
 
 const MemberSection = () => {
@@ -20,6 +21,7 @@ const MemberSection = () => {
   const [state, setState] = useState<State>({
     createUserUsername: "",
     createUserPassword: "",
+    createUserRole: "EXTERNAL",
   });
   const [userList, setUserList] = useState<User[]>([]);
 
@@ -30,6 +32,13 @@ const MemberSection = () => {
   const fetchUserList = async () => {
     const { data } = await api.getUserList();
     setUserList(data.sort((a, b) => a.id - b.id));
+  };
+
+  const handleRoleInputChange = (_, value: string) => {
+    setState({
+      ...state,
+      createUserRole: value,
+    });
   };
 
   const handleUsernameInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -47,7 +56,12 @@ const MemberSection = () => {
   };
 
   const handleCreateUserBtnClick = async () => {
-    if (state.createUserUsername === "" || state.createUserPassword === "") {
+    if (state.createUserUsername === "") {
+      toast.error(t("message.fill-form"));
+      return;
+    }
+
+    if (state.createUserRole !== "EXTERNAL" && state.createUserPassword === "") {
       toast.error(t("message.fill-form"));
       return;
     }
@@ -55,7 +69,7 @@ const MemberSection = () => {
     const userCreate: UserCreate = {
       username: state.createUserUsername,
       password: state.createUserPassword,
-      role: "USER",
+      role: state.createUserRole,
     };
 
     try {
@@ -67,6 +81,7 @@ const MemberSection = () => {
     setState({
       createUserUsername: "",
       createUserPassword: "",
+      createUserRole: state.createUserRole,
     });
   };
 
@@ -115,16 +130,36 @@ const MemberSection = () => {
 
   return (
     <div className="section-container member-section-container">
-      <p className="title-text">{t("setting.member-section.create-a-member")}</p>
+      <p className="title-text">{t("setting.member-section.create-a-user")}</p>
       <div className="w-full flex flex-col justify-start items-start gap-2">
         <div className="flex flex-col justify-start items-start gap-1">
-          <span className="text-sm">{t("common.username")}</span>
-          <Input type="text" placeholder={t("common.username")} value={state.createUserUsername} onChange={handleUsernameInputChange} />
+          <Select className="text-sm" value={state.createUserRole} onChange={handleRoleInputChange}>
+            <Option value="USER">用户</Option>
+            <Option value="EXTERNAL">外部用户</Option>
+          </Select>
         </div>
         <div className="flex flex-col justify-start items-start gap-1">
-          <span className="text-sm">{t("common.password")}</span>
-          <Input type="password" placeholder={t("common.password")} value={state.createUserPassword} onChange={handlePasswordInputChange} />
+          <span className="text-sm">
+            {t(state.createUserRole !== "EXTERNAL" ? "common.username" : "setting.member-section.user-home-address")}
+          </span>
+          <Input
+            type="text"
+            placeholder={t(state.createUserRole !== "EXTERNAL" ? "common.username" : "setting.member-section.user-home-address")}
+            value={state.createUserUsername}
+            onChange={handleUsernameInputChange}
+          />
         </div>
+        {state.createUserRole !== "EXTERNAL" && (
+          <div className="flex flex-col justify-start items-start gap-1">
+            <span className="text-sm">{t("common.password")}</span>
+            <Input
+              type="password"
+              placeholder={t("common.password")}
+              value={state.createUserPassword}
+              onChange={handlePasswordInputChange}
+            />
+          </div>
+        )}
         <div className="btns-container">
           <Button onClick={handleCreateUserBtnClick}>{t("common.create")}</Button>
         </div>

--- a/web/src/components/Settings/MemberSection.tsx
+++ b/web/src/components/Settings/MemberSection.tsx
@@ -137,8 +137,8 @@ const MemberSection = () => {
             className="text-sm"
             value={state.createUserRole}
             onChange={(_, value) => {
-              if (value==="USER" || value ==="EXTERNAL") {
-               handleRoleInputChange(value);
+              if (value === "USER" || value === "EXTERNAL") {
+                handleRoleInputChange(value);
               }
             }}
           >

--- a/web/src/components/Settings/MemberSection.tsx
+++ b/web/src/components/Settings/MemberSection.tsx
@@ -34,7 +34,7 @@ const MemberSection = () => {
     setUserList(data.sort((a, b) => a.id - b.id));
   };
 
-  const handleRoleInputChange = (_, value: string) => {
+  const handleRoleInputChange = (value: UserRole) => {
     setState({
       ...state,
       createUserRole: value,
@@ -133,7 +133,15 @@ const MemberSection = () => {
       <p className="title-text">{t("setting.member-section.create-a-user")}</p>
       <div className="w-full flex flex-col justify-start items-start gap-2">
         <div className="flex flex-col justify-start items-start gap-1">
-          <Select className="text-sm" value={state.createUserRole} onChange={handleRoleInputChange}>
+          <Select
+            className="text-sm"
+            value={state.createUserRole}
+            onChange={(_, value) => {
+              if (value==="USER" || value ==="EXTERNAL") {
+               handleRoleInputChange(value);
+              }
+            }}
+          >
             <Option value="USER">用户</Option>
             <Option value="EXTERNAL">外部用户</Option>
           </Select>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -229,6 +229,8 @@
     },
     "member-section": {
       "create-a-member": "Create a member",
+      "create-a-user": "Create a user",
+      "user-home-address": "User home address",
       "archive-member": "Archive member",
       "archive-warning": "Are you sure to archive {{username}}?",
       "delete-member": "Delete Member",

--- a/web/src/types/modules/user.d.ts
+++ b/web/src/types/modules/user.d.ts
@@ -1,5 +1,5 @@
 type UserId = number;
-type UserRole = "HOST" | "USER";
+type UserRole = "HOST" | "USER" | "EXTERNAL";
 
 interface User {
   id: UserId;


### PR DESCRIPTION
This PR is add a new user role `EXTERNAL` (external), which will be used in *Explore Memos* features.

While you add a `EXTERNAL` user, it will fetch the user's info from the home address provided by you, and then save it as the user's username.