### PR TITLE
chore: disable NPM update notice while running lint

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -60,7 +60,7 @@ services:
     profiles: ["tools"]
     image: node:18-alpine
     working_dir: /work
-    command: npm run lint
+    command: npm --no-update-notifier run lint
     volumes:
       - ./web:/work
       - ./.air/node_modules/:/work/node_modules/


### PR DESCRIPTION
This PR disable the notice message like below while running `npm` to lint code:

```
npm notice 
npm notice New major version of npm available! 9.8.1 -> 10.2.1
npm notice Changelog: https://github.com/npm/cli/releases/tag/v10.2.1
npm notice Run npm install -g npm@10.2.1 to update!
npm notice 
```