### PR TITLE
fix: validate username before create token

### DIFF
--- a/api/v2/user_service.go
+++ b/api/v2/user_service.go
@@ -220,7 +220,22 @@ func (s *UserService) CreateUserAccessToken(ctx context.Context, request *apiv2p
 	if request.ExpiresAt != nil {
 		expiresAt = request.ExpiresAt.AsTime()
 	}
-	accessToken, err := auth.GenerateAccessToken(user.Username, user.ID, expiresAt, []byte(s.Secret))
+
+	// Create access token for other users need to be verified.
+	if user.Username != request.Username {
+		// Normal users can only create access tokens for others.
+		if user.Role == store.RoleUser {
+			return nil, status.Errorf(codes.PermissionDenied, "permission denied")
+		}
+
+		// The request user must be exist.
+		requestUser, err := s.Store.GetUser(ctx, &store.FindUser{Username: &request.Username})
+		if requestUser == nil || err != nil {
+			return nil, status.Errorf(codes.NotFound, "fail to find user %s", request.Username)
+		}
+	}
+
+	accessToken, err := auth.GenerateAccessToken(request.Username, user.ID, expiresAt, []byte(s.Secret))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to generate access token: %v", err)
 	}


### PR DESCRIPTION
This PR add a new feature, that allow admin to create token for any exists user.

And it also fixed a bug that the *username* doesn't check before create token.