### PR TITLE
chore: make metric collect configurable

### DIFF
--- a/api/v1/system.go
+++ b/api/v1/system.go
@@ -20,6 +20,8 @@ type SystemStatus struct {
 	// System settings
 	// Allow sign up.
 	AllowSignUp bool `json:"allowSignUp"`
+	// Allow metric.
+	AllowMetric bool `json:"allowMetric"`
 	// Disable password login.
 	DisablePasswordLogin bool `json:"disablePasswordLogin"`
 	// Disable public memos.
@@ -78,6 +80,7 @@ func (s *APIV1Service) GetSystemStatus(c echo.Context) error {
 		},
 		// Allow sign up by default.
 		AllowSignUp:      true,
+		AllowMetric:      false,
 		MaxUploadSizeMiB: 32,
 		CustomizedProfile: CustomizedProfile{
 			Name:       "memos",
@@ -118,6 +121,8 @@ func (s *APIV1Service) GetSystemStatus(c echo.Context) error {
 		switch systemSetting.Name {
 		case SystemSettingAllowSignUpName.String():
 			systemStatus.AllowSignUp = baseValue.(bool)
+		case SystemSettingAllowMetricName.String():
+			systemStatus.AllowMetric = baseValue.(bool)
 		case SystemSettingDisablePasswordLoginName.String():
 			systemStatus.DisablePasswordLogin = baseValue.(bool)
 		case SystemSettingDisablePublicMemosName.String():

--- a/api/v1/system_setting.go
+++ b/api/v1/system_setting.go
@@ -42,6 +42,8 @@ const (
 	SystemSettingMemoDisplayWithUpdatedTsName SystemSettingName = "memo-display-with-updated-ts"
 	// SystemSettingAutoBackupIntervalName is the name of auto backup interval as seconds.
 	SystemSettingAutoBackupIntervalName SystemSettingName = "auto-backup-interval"
+	// SystemSettingEnableMetric is the name of enable metric switch.
+	SystemSettingEnableMetric SystemSettingName = "enable-metric"
 )
 const systemSettingUnmarshalError = `failed to unmarshal value from system setting "%v"`
 

--- a/api/v1/system_setting.go
+++ b/api/v1/system_setting.go
@@ -20,6 +20,8 @@ const (
 	SystemSettingSecretSessionName SystemSettingName = "secret-session"
 	// SystemSettingAllowSignUpName is the name of allow signup setting.
 	SystemSettingAllowSignUpName SystemSettingName = "allow-signup"
+	// SystemSettingAllowMetricName is the name of allow metric setting.
+	SystemSettingAllowMetricName SystemSettingName = "allow-metric"
 	// SystemSettingDisablePasswordLoginName is the name of disable password login setting.
 	SystemSettingDisablePasswordLoginName SystemSettingName = "disable-password-login"
 	// SystemSettingDisablePublicMemosName is the name of disable public memos setting.
@@ -42,8 +44,6 @@ const (
 	SystemSettingMemoDisplayWithUpdatedTsName SystemSettingName = "memo-display-with-updated-ts"
 	// SystemSettingAutoBackupIntervalName is the name of auto backup interval as seconds.
 	SystemSettingAutoBackupIntervalName SystemSettingName = "auto-backup-interval"
-	// SystemSettingEnableMetric is the name of enable metric switch.
-	SystemSettingEnableMetric SystemSettingName = "enable-metric"
 )
 const systemSettingUnmarshalError = `failed to unmarshal value from system setting "%v"`
 
@@ -191,6 +191,11 @@ func (upsert UpsertSystemSettingRequest) Validate() error {
 	case SystemSettingServerIDName:
 		return errors.Errorf("updating %v is not allowed", settingName)
 	case SystemSettingAllowSignUpName:
+		var value bool
+		if err := json.Unmarshal([]byte(upsert.Value), &value); err != nil {
+			return errors.Errorf(systemSettingUnmarshalError, settingName)
+		}
+	case SystemSettingAllowMetricName:
 		var value bool
 		if err := json.Unmarshal([]byte(upsert.Value), &value); err != nil {
 			return errors.Errorf(systemSettingUnmarshalError, settingName)

--- a/cmd/memos.go
+++ b/cmd/memos.go
@@ -68,7 +68,7 @@ var (
 
 			enableMetricSettingVal := store.GetSystemSettingValueWithDefault(&ctx, string(apiv1.SystemSettingEnableMetric), "false")
 			if "true" == enableMetricSettingVal {
-				metric.NewMetricClient(s.ID, *profile)
+				_, _ = metric.NewMetricClient(s.ID, *profile)
 			}
 
 			c := make(chan os.Signal, 1)

--- a/cmd/memos.go
+++ b/cmd/memos.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
+	apiv1 "github.com/usememos/memos/api/v1"
 	"github.com/usememos/memos/internal/log"
 	"github.com/usememos/memos/server"
 	_profile "github.com/usememos/memos/server/profile"
@@ -65,8 +66,10 @@ var (
 				return
 			}
 
-			// nolint
-			metric.NewMetricClient(s.ID, *profile)
+			enableMetricSettingVal := store.GetSystemSettingValueWithDefault(&ctx, string(apiv1.SystemSettingEnableMetric), "false")
+			if "true" == enableMetricSettingVal {
+				metric.NewMetricClient(s.ID, *profile)
+			}
 
 			c := make(chan os.Signal, 1)
 			// Trigger graceful shutdown on SIGINT or SIGTERM.

--- a/cmd/memos.go
+++ b/cmd/memos.go
@@ -66,7 +66,7 @@ var (
 				return
 			}
 
-			enableMetricSettingVal := store.GetSystemSettingValueWithDefault(&ctx, string(apiv1.SystemSettingEnableMetric), "false")
+			enableMetricSettingVal := store.GetSystemSettingValueWithDefault(&ctx, string(apiv1.SystemSettingAllowMetricName), "false")
 			if "true" == enableMetricSettingVal {
 				_, _ = metric.NewMetricClient(s.ID, *profile)
 			}

--- a/web/src/components/Settings/SystemSection.tsx
+++ b/web/src/components/Settings/SystemSection.tsx
@@ -15,6 +15,7 @@ import "@/less/settings/system-section.less";
 interface State {
   dbSize: number;
   allowSignUp: boolean;
+  allowMetric: boolean;
   disablePasswordLogin: boolean;
   disablePublicMemos: boolean;
   additionalStyle: string;
@@ -31,6 +32,7 @@ const SystemSection = () => {
   const [state, setState] = useState<State>({
     dbSize: systemStatus.dbSize,
     allowSignUp: systemStatus.allowSignUp,
+    allowMetric: systemStatus.allowMetric,
     disablePasswordLogin: systemStatus.disablePasswordLogin,
     additionalStyle: systemStatus.additionalStyle,
     additionalScript: systemStatus.additionalScript,
@@ -59,6 +61,7 @@ const SystemSection = () => {
       ...state,
       dbSize: systemStatus.dbSize,
       allowSignUp: systemStatus.allowSignUp,
+      allowMetric: systemStatus.allowMetric,
       disablePasswordLogin: systemStatus.disablePasswordLogin,
       additionalStyle: systemStatus.additionalStyle,
       additionalScript: systemStatus.additionalScript,
@@ -77,6 +80,18 @@ const SystemSection = () => {
     globalStore.setSystemStatus({ allowSignUp: value });
     await api.upsertSystemSetting({
       name: "allow-signup",
+      value: JSON.stringify(value),
+    });
+  };
+
+  const handleAllowMetricChanged = async (value: boolean) => {
+    setState({
+      ...state,
+      allowMetric: value,
+    });
+    globalStore.setSystemStatus({ allowMetric: value });
+    await api.upsertSystemSetting({
+      name: "allow-metric",
       value: JSON.stringify(value),
     });
   };
@@ -266,6 +281,15 @@ const SystemSection = () => {
       <div className="form-label">
         <span className="normal-text">{t("setting.system-section.allow-user-signup")}</span>
         <Switch checked={state.allowSignUp} onChange={(event) => handleAllowSignUpChanged(event.target.checked)} />
+      </div>
+      <div className="form-label">
+        <div className="flex flex-row items-center">
+          <div className="w-auto flex items-center">
+            <span className="normal-text">{t("setting.system-section.allow-metric")}</span>
+            <LearnMore url="https://www.usememos.com/legal/privacy-policy" />
+          </div>
+        </div>
+        <Switch checked={state.allowMetric} onChange={(event) => handleAllowMetricChanged(event.target.checked)} />
       </div>
       <div className="form-label">
         <span className="normal-text">{t("setting.system-section.disable-password-login")}</span>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -246,6 +246,7 @@
       },
       "database-file-size": "Database File Size",
       "allow-user-signup": "Allow user signup",
+      "allow-metric": "Allow Memos to collect metric",
       "disable-password-login": "Disable password login",
       "disable-password-login-warning": "This will disable password login for all users. It is not possible to log in without reverting this setting in the database if your configured identity providers fail. You’ll also have to be extra carefull when removing an identity provider",
       "disable-password-login-final-warning": "Please type \"CONFIRM\" if you know what you are doing.",

--- a/web/src/locales/zh-Hans.json
+++ b/web/src/locales/zh-Hans.json
@@ -331,6 +331,7 @@
       "additional-style": "自定义样式",
       "additional-style-placeholder": "自定义 CSS 代码",
       "allow-user-signup": "允许用户注册",
+      "allow-metric": "允许Memos搜集匿名统计数据",
       "auto-backup-interval": "自动备份间隔（单位：秒）",
       "auto-backup-interval-hint": "设置为 0 禁止自动备份，重启后生效。",
       "customize-server": {

--- a/web/src/types/modules/system.d.ts
+++ b/web/src/types/modules/system.d.ts
@@ -18,6 +18,7 @@ interface SystemStatus {
   dbSize: number;
   // System settings
   allowSignUp: boolean;
+  allowMetric: boolean;
   disablePasswordLogin: boolean;
   disablePublicMemos: boolean;
   maxUploadSizeMiB: number;


### PR DESCRIPTION
This PR add a switch to disable the metric collector start from `v0.16.1`, which is mentioned on #2433 .