### PR TITLE
chore: add a flag to change metric switch

### DIFF
--- a/cmd/memos.go
+++ b/cmd/memos.go
@@ -32,13 +32,14 @@ const (
 )
 
 var (
-	profile *_profile.Profile
-	mode    string
-	addr    string
-	port    int
-	data    string
-	driver  string
-	dsn     string
+	profile      *_profile.Profile
+	mode         string
+	addr         string
+	port         int
+	data         string
+	driver       string
+	dsn          string
+	enableMetric bool
 
 	rootCmd = &cobra.Command{
 		Use:   "memos",
@@ -65,8 +66,10 @@ var (
 				return
 			}
 
-			// nolint
-			metric.NewMetricClient(s.ID, *profile)
+			if enableMetric {
+				// nolint
+				metric.NewMetricClient(s.ID, *profile)
+			}
 
 			c := make(chan os.Signal, 1)
 			// Trigger graceful shutdown on SIGINT or SIGTERM.
@@ -109,6 +112,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&data, "data", "d", "", "data directory")
 	rootCmd.PersistentFlags().StringVarP(&driver, "driver", "", "", "database driver")
 	rootCmd.PersistentFlags().StringVarP(&dsn, "dsn", "", "", "database source name(aka. DSN)")
+	rootCmd.PersistentFlags().BoolVarP(&enableMetric, "metric", "", false, "allow metric collection")
 
 	err := viper.BindPFlag("mode", rootCmd.PersistentFlags().Lookup("mode"))
 	if err != nil {
@@ -134,11 +138,16 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+	err = viper.BindPFlag("metric", rootCmd.PersistentFlags().Lookup("metric"))
+	if err != nil {
+		panic(err)
+	}
 
 	viper.SetDefault("mode", "demo")
 	viper.SetDefault("driver", "sqlite")
 	viper.SetDefault("addr", "")
 	viper.SetDefault("port", 8081)
+	viper.SetDefault("metric", "false")
 	viper.SetEnvPrefix("memos")
 }
 

--- a/cmd/memos.go
+++ b/cmd/memos.go
@@ -112,7 +112,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&data, "data", "d", "", "data directory")
 	rootCmd.PersistentFlags().StringVarP(&driver, "driver", "", "", "database driver")
 	rootCmd.PersistentFlags().StringVarP(&dsn, "dsn", "", "", "database source name(aka. DSN)")
-	rootCmd.PersistentFlags().BoolVarP(&enableMetric, "metric", "", false, "allow metric collection")
+	rootCmd.PersistentFlags().BoolVarP(&enableMetric, "metric", "", true, "allow metric collection")
 
 	err := viper.BindPFlag("mode", rootCmd.PersistentFlags().Lookup("mode"))
 	if err != nil {
@@ -147,7 +147,7 @@ func init() {
 	viper.SetDefault("driver", "sqlite")
 	viper.SetDefault("addr", "")
 	viper.SetDefault("port", 8081)
-	viper.SetDefault("metric", "false")
+	viper.SetDefault("metric", "true")
 	viper.SetEnvPrefix("memos")
 }
 


### PR DESCRIPTION
This PR add a switch to disable the metric collector start from `v0.16.1`, which is mentioned on #2433 .