### PR TITLE
chore: remote context.Context pointer

### DIFF
--- a/api/v1/resource.go
+++ b/api/v1/resource.go
@@ -187,7 +187,7 @@ func (s *APIV1Service) UploadResource(c echo.Context) error {
 	}
 
 	// This is the backend default max upload size limit.
-	maxUploadSetting := s.Store.GetSystemSettingValueWithDefault(&ctx, SystemSettingMaxUploadSizeMiBName.String(), "32")
+	maxUploadSetting := s.Store.GetSystemSettingValueWithDefault(ctx, SystemSettingMaxUploadSizeMiBName.String(), "32")
 	var settingMaxUploadSizeBytes int
 	if settingMaxUploadSizeMiB, err := strconv.Atoi(maxUploadSetting); err == nil {
 		settingMaxUploadSizeBytes = settingMaxUploadSizeMiB * MebiByte

--- a/server/integration/telegram.go
+++ b/server/integration/telegram.go
@@ -24,7 +24,7 @@ func NewTelegramHandler(store *store.Store) *TelegramHandler {
 }
 
 func (t *TelegramHandler) BotToken(ctx context.Context) string {
-	return t.store.GetSystemSettingValueWithDefault(&ctx, apiv1.SystemSettingTelegramBotTokenName.String(), "")
+	return t.store.GetSystemSettingValueWithDefault(ctx, apiv1.SystemSettingTelegramBotTokenName.String(), "")
 }
 
 const (

--- a/server/service/backup/backup.go
+++ b/server/service/backup/backup.go
@@ -25,7 +25,7 @@ func NewBackupRunner(store *store.Store) *BackupRunner {
 }
 
 func (r *BackupRunner) Run(ctx context.Context) {
-	intervalStr := r.Store.GetSystemSettingValueWithDefault(&ctx, apiv1.SystemSettingAutoBackupIntervalName.String(), "")
+	intervalStr := r.Store.GetSystemSettingValueWithDefault(ctx, apiv1.SystemSettingAutoBackupIntervalName.String(), "")
 	if intervalStr == "" {
 		log.Debug("no SystemSettingAutoBackupIntervalName setting, disable auto backup")
 		return

--- a/store/system_setting.go
+++ b/store/system_setting.go
@@ -51,8 +51,8 @@ func (s *Store) GetSystemSetting(ctx context.Context, find *FindSystemSetting) (
 	return systemSettingMessage, nil
 }
 
-func (s *Store) GetSystemSettingValueWithDefault(ctx *context.Context, settingName string, defaultValue string) string {
-	if setting, err := s.GetSystemSetting(*ctx, &FindSystemSetting{
+func (s *Store) GetSystemSettingValueWithDefault(ctx context.Context, settingName string, defaultValue string) string {
+	if setting, err := s.GetSystemSetting(ctx, &FindSystemSetting{
 		Name: settingName,
 	}); err == nil && setting != nil {
 		return setting.Value


### PR DESCRIPTION
This PR remove all pointer of `context.Context`.