### PR TITLE
fix: metric env not affect

### DIFF
--- a/cmd/memos.go
+++ b/cmd/memos.go
@@ -66,9 +66,12 @@ var (
 				return
 			}
 
-			if enableMetric {
+			if profile.Metric {
+				println("metric collection is enabled")
 				// nolint
 				metric.NewMetricClient(s.ID, *profile)
+			} else {
+				println("metric collection is disabled")
 			}
 
 			c := make(chan os.Signal, 1)
@@ -169,6 +172,7 @@ func initConfig() {
 	println("mode:", profile.Mode)
 	println("driver:", profile.Driver)
 	println("version:", profile.Version)
+	println("metric:", profile.Metric)
 	println("---")
 }
 

--- a/server/profile/profile.go
+++ b/server/profile/profile.go
@@ -30,6 +30,8 @@ type Profile struct {
 	Driver string `json:"-"`
 	// Version is the current version of server
 	Version string `json:"version"`
+	// Metric indicate the metric collection is enabled or not
+	Metric bool `json:"-"`
 }
 
 func (p *Profile) IsDev() bool {


### PR DESCRIPTION
This PR fix a bug, that the environment variable `MEMOS_METRIC` does not affect. #2433 #2447 