### PR TITLE
fix: prevent copydb to create a fresh memos

### DIFF
--- a/cmd/copydb.go
+++ b/cmd/copydb.go
@@ -59,6 +59,13 @@ func copydb(fromProfile, toProfile *_profile.Profile) error {
 		return errors.Wrap(err, "fail to create `to` driver")
 	}
 
+	// Check if `to` driver has been created before
+	if history, err := toDriver.FindMigrationHistoryList(ctx, nil); err != nil {
+		return errors.New("fail to check migration history of `to` driver")
+	} else if len(history) == 0 {
+		return errors.New("migration history of `to` driver should not be empty")
+	}
+
 	if err := toDriver.Migrate(ctx); err != nil {
 		return errors.Wrap(err, "fail to migrate db")
 	}


### PR DESCRIPTION
This PR just fix a bug on `copydb`.

This command should only do db migrate on a exists *Memos* instance, and shouldn't initial a fresh one. That should only be done by run *Memos* directly.

This PR just prevent `copydb` to do that.