### PR TITLE
fix: skip system_setting check while copydb

### DIFF
--- a/cmd/copydb.go
+++ b/cmd/copydb.go
@@ -98,7 +98,7 @@ func copydb(fromProfile, toProfile *_profile.Profile) error {
 		if err != nil {
 			return errors.Wrapf(err, "fail to check '%s'", table)
 		}
-		if cnt > 0 {
+		if cnt > 0 && table != "system_setting" {
 			return errors.Errorf("table '%s' is not empty", table)
 		}
 	}


### PR DESCRIPTION
The *Memos* instance initial by install will feed some records in `system_setting` table, and the `copydb` cmd will also check and require it empty.

This PR just skip that check.