### PR TITLE
fix: duplicate memo filter in user profile page

### DIFF
--- a/web/src/pages/UserProfile.tsx
+++ b/web/src/pages/UserProfile.tsx
@@ -49,9 +49,6 @@ const UserProfile = () => {
                         <UserAvatar className="!w-20 h-auto mb-2 drop-shadow" avatarUrl={user?.avatarUrl} />
                         <p className="text-3xl text-black opacity-80 dark:text-gray-200">{user?.nickname}</p>
                       </div>
-                      <div className="w-full h-auto flex flex-col justify-start items-start bg-zinc-100 dark:bg-zinc-800 rounded-lg">
-                        <MemoFilter />
-                      </div>
                       <MemoList />
                     </div>
                   </div>


### PR DESCRIPTION
If click memo tag in user profile page, it appears two memo filters component.