### PR TITLE
fix: persist jwt expires by cookie

### DIFF
--- a/api/v1/auth.go
+++ b/api/v1/auth.go
@@ -106,8 +106,11 @@ func (s *APIV1Service) SignIn(c echo.Context) error {
 	}
 
 	var expireAt time.Time
+	// Set cookie expiration to 100 years to make it persistent.
+	cookieExp := time.Now().AddDate(100, 0, 0)
 	if !signin.Remember {
 		expireAt = time.Now().Add(auth.AccessTokenDuration)
+		cookieExp = time.Now().Add(auth.CookieExpDuration)
 	}
 
 	accessToken, err := auth.GenerateAccessToken(user.Username, user.ID, expireAt, []byte(s.Secret))
@@ -117,7 +120,6 @@ func (s *APIV1Service) SignIn(c echo.Context) error {
 	if err := s.UpsertAccessTokenToStore(ctx, user, accessToken); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Sprintf("failed to upsert access token, err: %s", err)).SetInternal(err)
 	}
-	cookieExp := time.Now().Add(auth.CookieExpDuration)
 	setTokenCookie(c, auth.AccessTokenCookieName, accessToken, cookieExp)
 	userMessage := convertUserFromStore(user)
 	return c.JSON(http.StatusOK, userMessage)


### PR DESCRIPTION
We have add a feature in #2402 to support persist the authorized status, but it still break on the cookie's expire. This PR just fixed that.

Because of cookie is not support to set as never expire, we set a 100 years duration as a walk around for that.