### PR TITLE
fix: clear localStorage while draft is empty

### DIFF
--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -45,7 +45,8 @@ const MemoEditor = (props: Props) => {
   const { className, editorClassName, cacheKey, memoId, onConfirm } = props;
   const { i18n } = useTranslation();
   const t = useTranslate();
-  const [contentCache, setContentCache] = useLocalStorage<string>(`memo-editor-${cacheKey}`, "");
+  const contentCacheKey = `memo-editor-${cacheKey}`;
+  const [contentCache, setContentCache] = useLocalStorage<string>(contentCacheKey, "");
   const {
     state: { systemStatus },
   } = useGlobalStore();
@@ -283,7 +284,11 @@ const MemoEditor = (props: Props) => {
 
   const handleContentChange = (content: string) => {
     setHasContent(content !== "");
-    setContentCache(content);
+    if (content == "") {
+      localStorage.removeItem(contentCacheKey);
+    } else {
+      setContentCache(content);
+    }
   };
 
   const handleSaveBtnClick = async () => {

--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -284,10 +284,10 @@ const MemoEditor = (props: Props) => {
 
   const handleContentChange = (content: string) => {
     setHasContent(content !== "");
-    if (content == "") {
-      localStorage.removeItem(contentCacheKey);
-    } else {
+    if (content !== "") {
       setContentCache(content);
+    } else {
+      localStorage.removeItem(contentCacheKey);
     }
   };
 


### PR DESCRIPTION
This PR just fixed a bug, while the draft of memo is clean, the localStorage should be clear instead of keep a empty string there.