### PR TITLE
fix: keep content and query param on save when access token is invalid

### DIFF
--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -326,6 +326,8 @@ const MemoEditor = (props: Props) => {
         });
         filterStore.clearFilter();
       }
+      editorRef.current?.setContent("");
+      clearContentQueryParam();
     } catch (error: any) {
       console.error(error);
       toast.error(error.response.data.message);
@@ -348,8 +350,6 @@ const MemoEditor = (props: Props) => {
       ...prevState,
       resourceList: [],
     }));
-    editorRef.current?.setContent("");
-    clearContentQueryParam();
     if (onConfirm) {
       onConfirm();
     }


### PR DESCRIPTION
keep content on save when access token is invalid

fix #2521 