### PR TITLE
fix:  parse inline latex as a inline element

### DIFF
--- a/web/src/labs/marked/parser/InlineLatex.tsx
+++ b/web/src/labs/marked/parser/InlineLatex.tsx
@@ -12,11 +12,7 @@ const inlineRenderer = (rawStr: string) => {
     } else if (matchResult[2]) {
       latexCode = matchResult[2];
     }
-    return (
-      <div className="w-full max-w-full overflow-x-auto">
-        <TeX key={latexCode}>{latexCode}</TeX>
-      </div>
-    );
+    return <TeX key={latexCode}>{latexCode}</TeX>;
   }
   return rawStr;
 };

--- a/web/src/labs/marked/parser/InlineLatex.tsx
+++ b/web/src/labs/marked/parser/InlineLatex.tsx
@@ -12,7 +12,9 @@ const inlineRenderer = (rawStr: string) => {
     } else if (matchResult[2]) {
       latexCode = matchResult[2];
     }
-    return <TeX key={latexCode}>{latexCode}</TeX>;
+    return <div className="max-w-full overflow-x-auto">
+        <TeX key={latexCode}>{latexCode}</TeX>
+      </div>
   }
   return rawStr;
 };


### PR DESCRIPTION
看了一下代码在下面这个commit里面给包了一层div , 不确定当时这个commit是为了解决什么问题提交的 ，感觉这里应该是不需要额外包一层div
https://github.com/usememos/memos/commit/20e5597104c4349df61c112899fab42227ad8c19

![commit](https://github.com/usememos/memos/assets/33889406/1d7a2d9d-905b-46f5-b9c8-e077ad0e5cc2)


fix #2523
fix #2468 
