### PR TITLE
feat: add support for convert HEIC on Apple devices

### DIFF
--- a/web/src/components/CreateResourceDialog.tsx
+++ b/web/src/components/CreateResourceDialog.tsx
@@ -11,6 +11,7 @@ const fileTypeAutocompleteOptions = ["image/*", "text/*", "audio/*", "video/*", 
 
 interface Props extends DialogProps {
   onCancel?: () => void;
+  imageOnly?: boolean;
   onConfirm?: (resourceList: Resource[]) => void;
 }
 
@@ -23,7 +24,7 @@ interface State {
 
 const CreateResourceDialog: React.FC<Props> = (props: Props) => {
   const t = useTranslate();
-  const { destroy, onCancel, onConfirm } = props;
+  const { destroy, onCancel, onConfirm, imageOnly } = props;
   const resourceStore = useResourceStore();
   const [state, setState] = useState<State>({
     selectedMode: "local-file",
@@ -211,7 +212,7 @@ const CreateResourceDialog: React.FC<Props> = (props: Props) => {
                 type="file"
                 id="files"
                 multiple={true}
-                accept="*"
+                accept={imageOnly ? ".png, .jpg, .jpeg, .bmp, .gif" : "*"}
               />
             </div>
             <List size="sm" sx={{ width: "100%" }}>

--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -177,8 +177,9 @@ const MemoEditor = (props: Props) => {
     }));
   };
 
-  const handleUploadFileBtnClick = () => {
+  const handleUploadFileBtnClick = (imageOnly: boolean) => {
     showCreateResourceDialog({
+      imageOnly: imageOnly,
       onConfirm: (resourceList) => {
         setState((prevState) => ({
           ...prevState,
@@ -443,9 +444,15 @@ const MemoEditor = (props: Props) => {
           <TagSelector onTagSelectorClick={(tag) => handleTagSelectorClick(tag)} />
           <IconButton
             className="flex flex-row justify-center items-center p-1 w-auto h-auto mr-1 select-none rounded cursor-pointer text-gray-600 dark:text-gray-400 hover:bg-gray-300 dark:hover:bg-zinc-800 hover:shadow"
-            onClick={handleUploadFileBtnClick}
+            onClick={() => handleUploadFileBtnClick(true)}
           >
             <Icon.Image className="w-5 h-5 mx-auto" />
+          </IconButton>
+          <IconButton
+            className="flex flex-row justify-center items-center p-1 w-auto h-auto mr-1 select-none rounded cursor-pointer text-gray-600 dark:text-gray-400 hover:bg-gray-300 dark:hover:bg-zinc-800 hover:shadow"
+            onClick={() => handleUploadFileBtnClick(false)}
+          >
+            <Icon.Paperclip className="w-5 h-5 mx-auto" />
           </IconButton>
           <IconButton
             className="flex flex-row justify-center items-center p-1 w-auto h-auto mr-1 select-none rounded cursor-pointer text-gray-600 dark:text-gray-400 hover:bg-gray-300 dark:hover:bg-zinc-800 hover:shadow"


### PR DESCRIPTION
HEIC is a common image format on iOS devices, but most browsers cannot preview it directly. Instead, all Apple OS has a built-in function that converts HEIC to a more common image format when uploading on the WEB.

However, there require the `accept` attribute of `<input>` must be set, and the value should be a `image/*` type, `*` is not worked. And, due to the limitations of the HTML standard, `accept` does not support excluding some types through the blacklist mechanism.

In the end, I duplicated the upload resource button, and now there're two buttons for upload :
1. First one still use the old `image` icon, and can only upload images with auto convert HEIC.
2. The new one with a paper clip icon for uploading any type of file, but without HEIC convert.

This PR will resolved #2164, #625, #70 .