### PR TITLE
chore: remove the max height limit for single media

### DIFF
--- a/web/src/components/MemoResourceListView.tsx
+++ b/web/src/components/MemoResourceListView.tsx
@@ -62,7 +62,7 @@ const MemoResourceListView = ({ resourceList = [] }: { resourceList: Resource[] 
 
     if (resources.length === 1) {
       return (
-        <div className="mt-2 max-w-full max-h-72 flex justify-center items-center border dark:border-zinc-800 rounded overflow-hidden hide-scrollbar hover:shadow-md">
+        <div className="mt-2 max-w-full flex justify-center items-center border dark:border-zinc-800 rounded overflow-hidden hide-scrollbar hover:shadow-md">
           <MediaCard resource={mediaResources[0]} />
         </div>
       );


### PR DESCRIPTION
For a single media (such as image), there's a max height class ( `max-h-72` ) to limit its height. This cause the image be crop and looks bad. So I think it could be removed.