### PR TITLE
fix: detail page user-avatar size have unexpected height

### DIFF
--- a/web/src/pages/MemoDetail.tsx
+++ b/web/src/pages/MemoDetail.tsx
@@ -114,7 +114,7 @@ const MemoDetail = () => {
       <section className="relative top-0 w-full min-h-full overflow-x-hidden bg-zinc-100 dark:bg-zinc-900">
         <div className="relative w-full h-auto mx-auto flex flex-col justify-start items-center bg-white dark:bg-zinc-700">
           <div className="w-full flex flex-col justify-start items-center pt-16 pb-8">
-            <UserAvatar className="!w-20 h-20 mb-2 drop-shadow" avatarUrl={systemStatus.customizedProfile.logoUrl} />
+            <UserAvatar className="!w-20 !h-20 mb-2 drop-shadow" avatarUrl={systemStatus.customizedProfile.logoUrl} />
             <p className="text-3xl text-black opacity-80 dark:text-gray-200">{systemStatus.customizedProfile.name}</p>
           </div>
           <div className="relative flex-grow max-w-2xl w-full min-h-full flex flex-col justify-start items-start px-4 pb-6">

--- a/web/src/pages/UserProfile.tsx
+++ b/web/src/pages/UserProfile.tsx
@@ -45,7 +45,7 @@ const UserProfile = () => {
                   <div className="w-full flex flex-row justify-start items-start">
                     <div className="flex-grow shrink w-full">
                       <div className="w-full flex flex-col justify-start items-center py-8">
-                        <UserAvatar className="!w-20 h-20 mb-2 drop-shadow" avatarUrl={user?.avatarUrl} />
+                        <UserAvatar className="!w-20 !h-20 mb-2 drop-shadow" avatarUrl={user?.avatarUrl} />
                         <p className="text-3xl text-black opacity-80 dark:text-gray-200">{user?.nickname}</p>
                       </div>
                       <MemoList />


### PR DESCRIPTION
I've found an issue with the UserAvatar size display on the details page. 
The `h-20` className didn't take effect due to the lack of `!important`, resulting in the height remaining at `w-8`. 
This discrepancy in width and height is causing an inconsistency in the avatar dimensions.

before:
![image](https://github.com/usememos/memos/assets/102474041/2ad5f037-6ef5-409b-9fad-643a96f6ddaf)

After I changed `h-20` to `!h-20`, it look great now:
![image](https://github.com/usememos/memos/assets/102474041/1986d27e-d020-42fb-a1a0-dab0a4e7faed)
