### PR TITLE
fix: visibility of memo editor is empty

### DIFF
--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -80,7 +80,7 @@ const MemoEditor = (props: Props) => {
   }, []);
 
   useEffect(() => {
-    let visibility = userSetting.memoVisibility;
+    let visibility = userSetting.memoVisibility || "PRIVATE";
     if (systemStatus.disablePublicMemos && visibility === "PUBLIC") {
       visibility = "PRIVATE";
     }


### PR DESCRIPTION
This PR fix a bug, while the default `visibility` of memo is empty, the memo editor will show an empty option instead of the default `PRIVATE`.