### PR TITLE
fix: visibility of user preference is empty

### DIFF
--- a/web/src/components/Settings/PreferencesSection.tsx
+++ b/web/src/components/Settings/PreferencesSection.tsx
@@ -85,7 +85,7 @@ const PreferencesSection = () => {
         <span className="text-sm break-keep text-ellipsis overflow-hidden">{t("setting.preference-section.default-memo-visibility")}</span>
         <Select
           className="!min-w-fit"
-          value={setting.memoVisibility}
+          value={setting.memoVisibility || "PRIVATE"}
           startDecorator={<VisibilityIcon visibility={setting.memoVisibility as Visibility} />}
           onChange={(_, visibility) => {
             if (visibility) {


### PR DESCRIPTION
This PR fix a bug, while the default `visibility` of memo is empty, the visibility row in user preference will show an empty option instead of the default `PRIVATE`.