### PR TITLE
fix(copydb): fix migration to Postgres

### DIFF
--- a/cmd/copydb.go
+++ b/cmd/copydb.go
@@ -95,6 +95,9 @@ func copydb(fromProfile, toProfile *_profile.Profile) error {
 	for table := range copyMap {
 		println("Checking " + table + "...")
 		var cnt int
+		if toProfile.Driver == "postgres" && table == "user" {
+			table = `"user"`
+		}
 		builder := squirrel.Select("COUNT(*)").From(table)
 		query, args, err := builder.ToSql()
 		if err != nil {

--- a/cmd/copydb.go
+++ b/cmd/copydb.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Masterminds/squirrel"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -94,8 +95,12 @@ func copydb(fromProfile, toProfile *_profile.Profile) error {
 	for table := range copyMap {
 		println("Checking " + table + "...")
 		var cnt int
-		err := toDb.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+table).Scan(&cnt)
+		builder := squirrel.Select("COUNT(*)").From(table)
+		query, args, err := builder.ToSql()
 		if err != nil {
+			return errors.Wrapf(err, "fail to build query '%s'", table)
+		}
+		if err := toDb.QueryRowContext(ctx, query, args...).Scan(&cnt); err != nil {
 			return errors.Wrapf(err, "fail to check '%s'", table)
 		}
 		if cnt > 0 && table != "system_setting" {


### PR DESCRIPTION
I just upgraded to v0.18.0 and am getting migration failures into a Postgres database. See #2600 for more context. This PR changes the `SELECT COUNT(*) ...` queries to use squirrel, and adds a hack to fix migration to Postgres. Not the prettiest but I have tested and it works for all database types without issue.

Fixes #2600

<details>
  <summary>Successful migration log</summary>

```
/usr/local/memos $ /tmp/memos copydb --from 'mysql://memos:***@tcp(memos)/memos'
---
Server profile
data: /var/opt/memos
dsn: postgresql://memos:***@postgresql/memos
addr:
port: 5230
mode: prod
driver: postgres
version: 0.18.0
metric: true
---
Checking activity...
Checking memo_relation...
Checking resource...
Checking tag...
Checking user...
Checking user_setting...
Checking idp...
Checking memo...
Checking memo_organizer...
Checking storage...
Checking system_setting...
Copying User...
	Total 1 records
	DONE
Copying Activity...
	Total 1 records
	DONE
Copying MemoRelation...
	Total 0 records
	DONE
Copying Resource...
	Total 0 records
	DONE
Copying Tag...
	Total 2 records
	DONE
Copying SystemSettings...
	Total 5 records
	DONE
Copying UserSettings...
	Total 3 records
	DONE
Copying IdentityProvider...
	Total 1 records
	DONE
Copying Memo...
	Total 15 records
	DONE
Copying MemoOrganizer...
	Total 0 records
	DONE
Copying Storage...
	Total 0 records
	DONE
done
```
</details>