### PR TITLE
Update frontend.go to disallow crawling by default

### DIFF
--- a/server/frontend/frontend.go
+++ b/server/frontend/frontend.go
@@ -80,7 +80,7 @@ func (s *FrontendService) registerRoutes(e *echo.Echo) {
 		}
 		instanceURL := instanceURLSetting.Value
 		robotsTxt := fmt.Sprintf(`User-agent: *
-Allow: /
+Disallow: /
 Host: %s
 Sitemap: %s/sitemap.xml`, instanceURL, instanceURL)
 		return c.String(http.StatusOK, robotsTxt)


### PR DESCRIPTION
Setting robots.txt to disallow web crawlers by default would help Memos continue to be a privacy-first solution