### PR TITLE
chore: fix misuse of package path instead of filepath.path

### DIFF
--- a/plugin/telegram/attachment.go
+++ b/plugin/telegram/attachment.go
@@ -1,7 +1,7 @@
 package telegram
 
 import (
-	"path"
+	"path/filepath"
 
 	"go.uber.org/zap"
 
@@ -27,7 +27,7 @@ func (b Attachment) GetMimeType() string {
 		return b.MimeType
 	}
 
-	mime, ok := mimeTypes[path.Ext(b.FileName)]
+	mime, ok := mimeTypes[filepath.Ext(b.FileName)]
 	if !ok {
 		// Handle unknown file extension
 		log.Warn("Unknown file type for ", zap.String("filename", b.FileName))

--- a/server/integration/telegram.go
+++ b/server/integration/telegram.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"path"
+	"path/filepath"
 	"strconv"
 	"unicode/utf16"
 
@@ -85,7 +85,7 @@ func (t *TelegramHandler) MessageHandle(ctx context.Context, bot *telegram.Bot, 
 		// Fill the common field of create
 		create := store.Resource{
 			CreatorID: creatorID,
-			Filename:  path.Base(attachment.FileName),
+			Filename:  filepath.Base(attachment.FileName),
 			Type:      attachment.GetMimeType(),
 			Size:      attachment.FileSize,
 			MemoID:    &memoMessage.ID,


### PR DESCRIPTION
As stated by https://pkg.go.dev/path, "path" is mainly for URLs, "path.filepath" for file systems