### PR TITLE
feat: add {uuid} in path template when using local storage or S3

### DIFF
--- a/api/v1/resource.go
+++ b/api/v1/resource.go
@@ -354,6 +354,8 @@ func replacePathTemplate(path, filename string) string {
 			return fmt.Sprintf("%02d", t.Minute())
 		case "{second}":
 			return fmt.Sprintf("%02d", t.Second())
+		case "{uuid}":
+			return util.GenUUID()
 		}
 		return s
 	})


### PR DESCRIPTION
Add an addition tag `{uuid}` to the `replacePathTemplate`.

It is a workaround to leak the public links of a resource when using S3-based object storage. Currently, all resource blobs stored in S3 (R2, OSS) are set to be public. It is insecure as the resources for the private memos are also accessible on the Internet. It happens in many situations. For example, the adversary might gauss the private resources' URLs based on the public memos' URLs even using a timestamp. Also, the resource's accessibility will not be modified when the memo's accessibility is changed.


Using an additional {uuid} might reduce this risk.  Actually, it is better to use a signed URL, but it might bring a large range refaction. As a result, using an additional UUID might help with little modification to the current structure. (related issues #1191 )

Meanwhile, it is also possible to avoid filename conflict using local storage.