### PR TITLE
chore: improve resource internal_path migrator

### DIFF
--- a/bin/memos/main.go
+++ b/bin/memos/main.go
@@ -59,11 +59,14 @@ var (
 			}
 
 			store := store.New(dbDriver, profile)
-			if err := store.MigrateResourceInternalPath(ctx); err != nil {
-				cancel()
-				log.Error("failed to migrate resource internal path", zap.Error(err))
-				return
-			}
+
+			go func() {
+				if err := store.MigrateResourceInternalPath(ctx); err != nil {
+					cancel()
+					log.Error("failed to migrate resource internal path", zap.Error(err))
+					return
+				}
+			}()
 
 			s, err := server.NewServer(ctx, profile, store)
 			if err != nil {

--- a/store/migrator.go
+++ b/store/migrator.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/usememos/memos/internal/log"
 )
 

--- a/store/migrator.go
+++ b/store/migrator.go
@@ -2,10 +2,14 @@ package store
 
 import (
 	"context"
-	"path/filepath"
+	"fmt"
+	"os"
+	"time"
+
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/usememos/memos/internal/log"
 )
 
 // MigrateResourceInternalPath migrates resource internal path from absolute path to relative path.
@@ -15,30 +19,37 @@ func (s *Store) MigrateResourceInternalPath(ctx context.Context) error {
 		return errors.Wrap(err, "failed to list resources")
 	}
 
+	dataPath := strings.ReplaceAll(s.Profile.Data, `\`, "/")
+	migrateStartTime := time.Now()
+	migratedCount := 0
 	for _, resource := range resources {
 		if resource.InternalPath == "" {
 			continue
 		}
 
-		internalPath := resource.InternalPath
-		if filepath.IsAbs(internalPath) {
-			if !strings.HasPrefix(internalPath, s.Profile.Data) {
-				// Invalid internal path, skip.
-				continue
-			}
-			internalPath = strings.TrimPrefix(internalPath, s.Profile.Data)
-			for strings.HasPrefix(internalPath, "/") {
-				internalPath = strings.TrimPrefix(internalPath, "/")
-			}
-			_, err := s.UpdateResource(ctx, &UpdateResource{
-				ID:           resource.ID,
-				InternalPath: &internalPath,
-			})
-			if err != nil {
-				return errors.Wrap(err, "failed to update resource")
-			}
+		internalPath := strings.ReplaceAll(resource.InternalPath, `\`, "/")
+		if !strings.HasPrefix(internalPath, dataPath) {
+			continue
 		}
+
+		internalPath = strings.TrimPrefix(internalPath, dataPath)
+
+		for os.IsPathSeparator(internalPath[0]) {
+			internalPath = internalPath[1:]
+		}
+
+		_, err := s.UpdateResource(ctx, &UpdateResource{
+			ID:           resource.ID,
+			InternalPath: &internalPath,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to update local resource path")
+		}
+		migratedCount++
 	}
 
+	if migratedCount > 0 {
+		log.Info(fmt.Sprintf("migrated %d local resource paths in %s", migratedCount, time.Since(migrateStartTime)))
+	}
 	return nil
 }

--- a/test/store/migrator_test.go
+++ b/test/store/migrator_test.go
@@ -1,0 +1,56 @@
+package teststore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/usememos/memos/store"
+)
+
+func TestMigrateResourceInternalPath(t *testing.T) {
+	ctx := context.Background()
+	ts := NewTestingStore(ctx, t)
+	user, err := createTestingHostUser(ctx, ts)
+	require.NoError(t, err)
+
+	testCases := []map[string]string{
+		{
+			ts.Profile.Data + "/assets/test.jpg": "assets/test.jpg",
+		},
+		{
+			ts.Profile.Data + `\assets\test.jpg`: "assets/test.jpg",
+		},
+		{
+			"/unhandled/path/test.jpg": "/unhandled/path/test.jpg",
+		},
+		{
+			`C:\unhandled\path\assets\test.jpg`: `C:\unhandled\path\assets\test.jpg`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		for input, expectedOutput := range testCase {
+			resourceCreate := &store.Resource{
+				CreatorID:    user.ID,
+				InternalPath: input,
+			}
+			createdResource, err := ts.CreateResource(ctx, resourceCreate)
+			require.NoError(t, err)
+
+			err = ts.MigrateResourceInternalPath(ctx)
+			require.NoError(t, err)
+
+			findResource := &store.FindResource{
+				ID: &createdResource.ID,
+			}
+			resource, err := ts.GetResource(ctx, findResource)
+			require.NoError(t, err)
+
+			require.Equal(t, expectedOutput, resource.InternalPath)
+		}
+	}
+
+	ts.Close()
+}


### PR DESCRIPTION
- handle mixed path styles
- handle Windows paths
- add tests
- run the migration in a separate goroutine, so server startup doesn't take too long on large databases and/or low-end hardware
- log basic post-migration stats like `INFO    store/migrator.go:52    migrated 34219 local resource paths in 42.8559848s`