### PR TITLE
fix: image upload failed with cloudflare R2

### DIFF
--- a/plugin/storage/s3/s3.go
+++ b/plugin/storage/s3/s3.go
@@ -49,6 +49,7 @@ func NewClient(ctx context.Context, config *Config) (*Client, error) {
 	awsConfig, err := s3config.LoadDefaultConfig(ctx,
 		s3config.WithEndpointResolverWithOptions(resolver),
 		s3config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(config.AccessKey, config.SecretKey, "")),
+		s3config.WithRegion(config.Region),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fix #2630

---

I noticed that aws-go-sdk was upgraded to v1.24.0 again, and saving resources to R2 failed. I tested Cloudflare R2 and it worked fine with the changes.