### PR TITLE
fix: pnpm install failed in docker

### DIFF
--- a/scripts/docker-compose.dev.yaml
+++ b/scripts/docker-compose.dev.yaml
@@ -26,7 +26,8 @@ services:
     ports: ["3001:3001"]
     environment: ["DEV_PROXY_SERVER=http://api:8081/"]
     entrypoint: ["/bin/sh", "-c"]
-    command: ["corepack enable && pnpm install && pnpm dev"]
+    command: ["corepack enable && pnpm i --frozen-lockfile && pnpm dev"]
+    tmpfs: /work/node_modules/:exec # To avoid pnpm ERR_PNPM_LINKING_FAILED error
     volumes:
       - ./../web:/work
 


### PR DESCRIPTION
This PR resolved a problem, that the `pnpm install` may failed with `ERR_PNPM_LINKING_FAILED` in some case.

This is because *pnpm* is works by create hard link, which is not working well in docker container.

So we use `npm` to replace `pnpm`.