### PR TITLE
chore: set image loading to lazy

### DIFF
--- a/web/src/components/ResourceIcon.tsx
+++ b/web/src/components/ResourceIcon.tsx
@@ -27,6 +27,7 @@ const ResourceIcon = (props: Props) => {
     return (
       <SquareDiv className={classNames(className, "flex items-center justify-center overflow-clip")}>
         <img
+          loading="lazy"
           className="min-w-full min-h-full object-cover border rounded dark:border-none"
           src={resource.externalLink ? resourceUrl : resourceUrl + "?thumbnail=1"}
           onClick={() => showPreviewImageDialog(resourceUrl)}


### PR DESCRIPTION
This PR change the resource's `img` to be lazy loading, which could decrease the concurrent request to the server, especially in the `Resource` page or other pages with a lot of images.