### PR TITLE
chore: updating the default scopes of GitHub SSO

### DIFF
--- a/web/src/components/CreateIdentityProviderDialog.tsx
+++ b/web/src/components/CreateIdentityProviderDialog.tsx
@@ -21,7 +21,7 @@ const templateList: IdentityProvider[] = [
         authUrl: "https://github.com/login/oauth/authorize",
         tokenUrl: "https://github.com/login/oauth/access_token",
         userInfoUrl: "https://api.github.com/user",
-        scopes: ["user"],
+        scopes: ["read:user"],
         fieldMapping: {
           identifier: "login",
           displayName: "name",


### PR DESCRIPTION
The scope of "user" in GitHub OAuth includes permissions to update a user's profile.