### PR TITLE
chore: fix store tests on Windows

### DIFF
--- a/test/store/activity_test.go
+++ b/test/store/activity_test.go
@@ -30,4 +30,5 @@ func TestActivityStore(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(activities))
 	require.Equal(t, activity, activities[0])
+	ts.Close()
 }

--- a/test/store/idp_test.go
+++ b/test/store/idp_test.go
@@ -53,4 +53,5 @@ func TestIdentityProviderStore(t *testing.T) {
 	idpList, err := ts.ListIdentityProviders(ctx, &store.FindIdentityProvider{})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(idpList))
+	ts.Close()
 }

--- a/test/store/inbox_test.go
+++ b/test/store/inbox_test.go
@@ -50,4 +50,5 @@ func TestInboxStore(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(inboxes))
+	ts.Close()
 }

--- a/test/store/memo_organizer_test.go
+++ b/test/store/memo_organizer_test.go
@@ -59,4 +59,5 @@ func TestMemoOrganizerStore(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(memoOrganizers))
+	ts.Close()
 }

--- a/test/store/memo_relation_test.go
+++ b/test/store/memo_relation_test.go
@@ -55,4 +55,5 @@ func TestMemoRelationStore(t *testing.T) {
 	}
 	_, err = ts.UpsertMemoRelation(ctx, commentRelation)
 	require.NoError(t, err)
+	ts.Close()
 }

--- a/test/store/memo_test.go
+++ b/test/store/memo_test.go
@@ -58,6 +58,7 @@ func TestMemoStore(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(memoList))
+	ts.Close()
 }
 
 func TestDeleteMemoStore(t *testing.T) {
@@ -77,4 +78,5 @@ func TestDeleteMemoStore(t *testing.T) {
 		ID: memo.ID,
 	})
 	require.NoError(t, err)
+	ts.Close()
 }

--- a/test/store/resource_test.go
+++ b/test/store/resource_test.go
@@ -59,4 +59,5 @@ func TestResourceStore(t *testing.T) {
 		ID: 2,
 	})
 	require.NoError(t, err)
+	ts.Close()
 }

--- a/test/store/storage_test.go
+++ b/test/store/storage_test.go
@@ -36,4 +36,5 @@ func TestStorageStore(t *testing.T) {
 	storageList, err = ts.ListStorages(ctx, &store.FindStorage{})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(storageList))
+	ts.Close()
 }

--- a/test/store/system_setting_test.go
+++ b/test/store/system_setting_test.go
@@ -36,4 +36,5 @@ func TestSystemSettingStore(t *testing.T) {
 	list, err := ts.ListSystemSettings(ctx, &store.FindSystemSetting{})
 	require.NoError(t, err)
 	require.Equal(t, 4, len(list))
+	ts.Close()
 }

--- a/test/store/tag_test.go
+++ b/test/store/tag_test.go
@@ -35,4 +35,5 @@ func TestTagStore(t *testing.T) {
 	tags, err = ts.ListTags(ctx, &store.FindTag{})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(tags))
+	ts.Close()
 }

--- a/test/store/user_setting_test.go
+++ b/test/store/user_setting_test.go
@@ -24,4 +24,5 @@ func TestUserSettingStore(t *testing.T) {
 	list, err := ts.ListUserSettings(ctx, &store.FindUserSetting{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(list))
+	ts.Close()
 }

--- a/test/store/user_test.go
+++ b/test/store/user_test.go
@@ -35,6 +35,7 @@ func TestUserStore(t *testing.T) {
 	users, err = ts.ListUsers(ctx, &store.FindUser{})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(users))
+	ts.Close()
 }
 
 func createTestingHostUser(ctx context.Context, ts *store.Store) (*store.User, error) {

--- a/test/store/webhook_test.go
+++ b/test/store/webhook_test.go
@@ -47,4 +47,5 @@ func TestWebhookStore(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(webhooks))
+	ts.Close()
 }


### PR DESCRIPTION
It's just a matter of explicitly closing the database, so that TempDir.removeAll doesn't fail. This doesn't affect other systems.

![Screenshot_1](https://github.com/usememos/memos/assets/7476810/67dccacb-a2e9-43be-88bf-9a674ac8e937) => ![Screenshot_2](https://github.com/usememos/memos/assets/7476810/f7f7900c-d575-4640-bec3-0349764d1bdb)
