### PR TITLE
chore: added tooltip for vacuum button

### DIFF
--- a/web/src/components/Settings/SystemSection.tsx
+++ b/web/src/components/Settings/SystemSection.tsx
@@ -252,9 +252,14 @@ const SystemSection = () => {
         <Button onClick={handleUpdateCustomizedProfileButtonClick}>{t("common.edit")}</Button>
       </div>
       <div className="w-full flex flex-row justify-between items-center">
-        <span className="text-sm">
-          {t("setting.system-section.database-file-size")}: <span className="font-mono font-bold">{formatBytes(state.dbSize)}</span>
-        </span>
+        <div className="flex flex-row items-center">
+          <span className="text-sm">
+            {t("setting.system-section.database-file-size")}: <span className="font-mono font-bold">{formatBytes(state.dbSize)}</span>
+          </span>
+          <Tooltip title={t("setting.system-section.vacuum-hint")} placement="top">
+            <Icon.HelpCircle className="w-4 h-auto" />
+          </Tooltip>
+        </div>
         <Button onClick={handleVacuumBtnClick}>{t("common.vacuum")}</Button>
       </div>
       <p className="font-medium text-gray-700 dark:text-gray-500">{t("common.settings")}</p>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -256,6 +256,7 @@
       "disable-public-memos": "Disable public memos",
       "max-upload-size": "Maximum upload size (MiB)",
       "max-upload-size-hint": "Recommended value is 32 MiB.",
+      "vacuum-hint": "Cleans up unused or obsolete data.",
       "additional-style": "Additional style",
       "additional-script": "Additional script",
       "additional-style-placeholder": "Additional CSS code",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -256,7 +256,7 @@
       "disable-public-memos": "Disable public memos",
       "max-upload-size": "Maximum upload size (MiB)",
       "max-upload-size-hint": "Recommended value is 32 MiB.",
-      "vacuum-hint": "Cleans up unused or obsolete data.",
+      "vacuum-hint": "Cleans up unused data.",
       "additional-style": "Additional style",
       "additional-script": "Additional script",
       "additional-style-placeholder": "Additional CSS code",


### PR DESCRIPTION
A lot of users were confused about the use of 'Vacuum' button in the settings->system. Therefore I added a tooltip for this.

At the moment the tooltip text is only in English language.

From [issue #2724](https://github.com/usememos/memos/issues/2724)