### PR TITLE
feat: add a webhook action for deleted memos

### DIFF
--- a/api/v1/memo.go
+++ b/api/v1/memo.go
@@ -632,7 +632,6 @@ func (s *APIV1Service) DeleteMemo(c echo.Context) error {
 		}
 	}
 
-
 	if err := s.Store.DeleteMemo(ctx, &store.DeleteMemo{
 		ID: memoID,
 	}); err != nil {

--- a/api/v1/memo.go
+++ b/api/v1/memo.go
@@ -625,6 +625,14 @@ func (s *APIV1Service) DeleteMemo(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusUnauthorized, "Unauthorized")
 	}
 
+	if memoMessage, err := s.convertMemoFromStore(ctx, memo); err == nil {
+		// Try to dispatch webhook when memo is deleted.
+		if err := s.DispatchMemoDeletedWebhook(ctx, memoMessage); err != nil {
+			log.Warn("Failed to dispatch memo deleted webhook", zap.Error(err))
+		}
+	}
+
+
 	if err := s.Store.DeleteMemo(ctx, &store.DeleteMemo{
 		ID: memoID,
 	}); err != nil {
@@ -956,6 +964,11 @@ func (s *APIV1Service) DispatchMemoCreatedWebhook(ctx context.Context, memo *Mem
 // DispatchMemoUpdatedWebhook dispatches webhook when memo is updated.
 func (s *APIV1Service) DispatchMemoUpdatedWebhook(ctx context.Context, memo *Memo) error {
 	return s.dispatchMemoRelatedWebhook(ctx, memo, "memos.memo.updated")
+}
+
+// DispatchMemoDeletedWebhook dispatches webhook when memo is deletedd.
+func (s *APIV1Service) DispatchMemoDeletedWebhook(ctx context.Context, memo *Memo) error {
+	return s.dispatchMemoRelatedWebhook(ctx, memo, "memos.memo.deleted")
 }
 
 func (s *APIV1Service) dispatchMemoRelatedWebhook(ctx context.Context, memo *Memo, activityType string) error {

--- a/api/v2/memo_service.go
+++ b/api/v2/memo_service.go
@@ -353,7 +353,6 @@ func (s *APIV2Service) DeleteMemo(ctx context.Context, request *apiv2pb.DeleteMe
 		}
 	}
 
-
 	if err = s.Store.DeleteMemo(ctx, &store.DeleteMemo{
 		ID: request.Id,
 	}); err != nil {

--- a/api/v2/memo_service.go
+++ b/api/v2/memo_service.go
@@ -346,6 +346,14 @@ func (s *APIV2Service) DeleteMemo(ctx context.Context, request *apiv2pb.DeleteMe
 		return nil, status.Errorf(codes.PermissionDenied, "permission denied")
 	}
 
+	if memoMessage, err := s.convertMemoFromStore(ctx, memo); err == nil {
+		// Try to dispatch webhook when memo is deleted.
+		if err := s.DispatchMemoDeletedWebhook(ctx, memoMessage); err != nil {
+			log.Warn("Failed to dispatch memo deleted webhook", zap.Error(err))
+		}
+	}
+
+
 	if err = s.Store.DeleteMemo(ctx, &store.DeleteMemo{
 		ID: request.Id,
 	}); err != nil {
@@ -738,6 +746,11 @@ func (s *APIV2Service) DispatchMemoCreatedWebhook(ctx context.Context, memo *api
 // DispatchMemoUpdatedWebhook dispatches webhook when memo is updated.
 func (s *APIV2Service) DispatchMemoUpdatedWebhook(ctx context.Context, memo *apiv2pb.Memo) error {
 	return s.dispatchMemoRelatedWebhook(ctx, memo, "memos.memo.updated")
+}
+
+// DispatchMemoDeletedWebhook dispatches webhook when memo is deleted.
+func (s *APIV2Service) DispatchMemoDeletedWebhook(ctx context.Context, memo *apiv2pb.Memo) error {
+	return s.dispatchMemoRelatedWebhook(ctx, memo, "memos.memo.deleted")
 }
 
 func (s *APIV2Service) dispatchMemoRelatedWebhook(ctx context.Context, memo *apiv2pb.Memo, activityType string) error {


### PR DESCRIPTION
Add a webhook when the memos are deleted. Currently, the webhooks are only triggered when the memos are created (C) or updated (U). But the webhook for deleting (D) is missing. I think it is better for the webhook to activate for the entire CURD procedures.

I love memos, and use it heavily. However, I need it to send me a notice as a reminder, like issue #858. I realize that this function is in the roadmap, but I cannot wait to have it. As a result, I recently worked on my community tool [memos-reminder](https://github.com/ertuil/memos-reminder) as a temporary solution. It reads memos using the webhook API, and reads some date/time tags in it, and then sends me reminder emails.

However, I find that the current webhook is not completed, as it will not notify my memos-reminder to delete the related timers when the memos are deleted.