### PR TITLE
feat: Enable iframe rendering in markdown code block

### DIFF
--- a/web/src/components/MemoContent/CodeBlock.tsx
+++ b/web/src/components/MemoContent/CodeBlock.tsx
@@ -15,14 +15,14 @@ const CodeBlock: React.FC<Props> = ({ language, content }: Props) => {
   const formatedLanguage = language.toLowerCase() || "plaintext";
   let highlightedCode = hljs.highlightAuto(content).value;
 
-  // Users can set Markdown code blocks as 'iframe' 
+  // Users can set Markdown code blocks as 'iframe'
   // to embed videos or external audio links from services like Apple Music or Spotify.
   if (formatedLanguage === "iframe") {
     const renderHTML = () => {
       return { __html: content };
     };
-  
-    return <div className="mx-auto w-11/12 !my-4"dangerouslySetInnerHTML={renderHTML()} />;
+
+    return <div className="mx-auto w-11/12 !my-4" dangerouslySetInnerHTML={renderHTML()} />;
   }
 
   try {

--- a/web/src/components/MemoContent/CodeBlock.tsx
+++ b/web/src/components/MemoContent/CodeBlock.tsx
@@ -15,6 +15,16 @@ const CodeBlock: React.FC<Props> = ({ language, content }: Props) => {
   const formatedLanguage = language.toLowerCase() || "plaintext";
   let highlightedCode = hljs.highlightAuto(content).value;
 
+  // Users can set Markdown code blocks as 'iframe' 
+  // to embed videos or external audio links from services like Apple Music or Spotify.
+  if (formatedLanguage === "iframe") {
+    const renderHTML = () => {
+      return { __html: content };
+    };
+  
+    return <div className="mx-auto w-11/12 !my-4"dangerouslySetInnerHTML={renderHTML()} />;
+  }
+
   try {
     const temp = hljs.highlight(content, {
       language: formatedLanguage,


### PR DESCRIPTION
This PR allows users to set Markdown code blocks as 'iframe' to embed videos or external music links from services like Apple Music or Spotify.

<img width="768" alt="image" src="https://github.com/usememos/memos/assets/57408875/55c41ffa-45fd-46b8-92f8-6a9e3997930e">
<img width="609" alt="image" src="https://github.com/usememos/memos/assets/57408875/164b5b77-ffd7-4a34-bcbd-f13b72a75c35">
