### PR TITLE
fix: double click to edit memo

### DIFF
--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -84,9 +84,13 @@ const MemoView: React.FC<Props> = (props: Props) => {
       }
     }
 
-    if (e.detail === 2) {
-      handleEditMemoClick();
-    }
+    // Use setTimeout for double-click recognition, as pointed out by @daveclinton on GitHub.
+    setTimeout(() => {
+      if (e.detail === 2) {
+        e.preventDefault();
+        handleEditMemoClick();
+      }
+    }, 500);
   }, []);
 
   return (

--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -83,6 +83,10 @@ const MemoView: React.FC<Props> = (props: Props) => {
         showPreviewImageDialog([imgUrl], 0);
       }
     }
+
+    if (e.detail === 2) {
+      handleEditMemoClick();
+    }
   }, []);
 
   return (

--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -15,6 +15,7 @@ import showChangeMemoCreatedTsDialog from "./ChangeMemoCreatedTsDialog";
 import Icon from "./Icon";
 import MemoActionMenu from "./MemoActionMenu";
 import MemoContent from "./MemoContent";
+import showMemoEditorDialog from "./MemoEditor/MemoEditorDialog";
 import MemoReactionistView from "./MemoReactionListView";
 import MemoRelationListView from "./MemoRelationListView";
 import MemoResourceListView from "./MemoResourceListView";
@@ -72,6 +73,13 @@ const MemoView: React.FC<Props> = (props: Props) => {
     } else {
       navigateTo(`/m/${memo.name}`);
     }
+  };
+
+  const handleEditMemoClick = () => {
+    showMemoEditorDialog({
+      memoId: memo.id,
+      cacheKey: `${memo.id}-${memo.updateTime}`,
+    });
   };
 
   const handleMemoContentClick = useCallback(async (e: React.MouseEvent) => {


### PR DESCRIPTION
The user was not able to edit the memo by double-clicking in v18.0.2, however, this was available in previous versions.

Hence this PR aims to fix this bug.

Note: You are only able to edit the memo (by double click) on the homepage, as the UI is more convenient in the Memo Detail page.