### PR TITLE
fix: avoid making memos public when disabled

### DIFF
--- a/api/v2/memo_service.go
+++ b/api/v2/memo_service.go
@@ -325,6 +325,14 @@ func (s *APIV2Service) UpdateMemo(ctx context.Context, request *apiv2pb.UpdateMe
 			}
 		} else if path == "visibility" {
 			visibility := convertVisibilityToStore(request.Memo.Visibility)
+			// Find disable public memos system setting.
+			disablePublicMemosSystem, err := s.getDisablePublicMemosSystemSettingValue(ctx)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to get system setting")
+			}
+			if disablePublicMemosSystem && visibility == store.Public {
+				return nil, status.Errorf(codes.PermissionDenied, "disable public memos system setting is enabled")
+			}
 			update.Visibility = &visibility
 		} else if path == "row_status" {
 			rowStatus := convertRowStatusToStore(request.Memo.RowStatus)


### PR DESCRIPTION
fix #2814

I am not familiar with golang coding, so please make a double check before merge, especially api v1 version.

After this change, changes to the existing public memos would also be banned in api v2. I don't know if it is in line with the original intent of the public memos (I think the target to disable public memos is to prevent users from causually adding/modifying the content displayed on the public pages).

For api v1, enforce normal user to save as private memo if public memos are disabled, just like CreateMemo.

Besides, I wonder whether the api v1 is deprecated and whether it need updating.