### PR TITLE
feat: add visibility select in ShareMemoDialog

### DIFF
--- a/web/src/components/MemoActionMenu.tsx
+++ b/web/src/components/MemoActionMenu.tsx
@@ -101,7 +101,7 @@ const MemoActionMenu = (props: Props) => {
           <Icon.Edit3 className="w-4 h-auto" />
           {t("common.edit")}
         </MenuItem>
-        <MenuItem onClick={() => showShareMemoDialog(memo)}>
+        <MenuItem onClick={() => showShareMemoDialog(memo.id)}>
           <Icon.Share className="w-4 h-auto" />
           {t("common.share")}
         </MenuItem>

--- a/web/src/pages/MemoDetail.tsx
+++ b/web/src/pages/MemoDetail.tsx
@@ -176,7 +176,7 @@ const MemoDetail = () => {
                 </IconButton>
               </Tooltip>
               <Tooltip title={"Share"} placement="top">
-                <IconButton size="sm" onClick={() => showShareMemoDialog(memo)}>
+                <IconButton size="sm" onClick={() => showShareMemoDialog(memo.id)}>
                   <Icon.Share className="w-4 h-auto text-gray-600 dark:text-gray-400" />
                 </IconButton>
               </Tooltip>


### PR DESCRIPTION
I am not familiar with ts/react coding, so please make a double check before merge.

In ShareMemoDialog, user can change the visibility of the memo, so that the memo can be set to public to be viewed by anyone with the link.

related issue: #2868
related pr: #2931 
