### PR TITLE
chore: allow all 20x response status code in webhook

### DIFF
--- a/plugin/webhook/webhook.go
+++ b/plugin/webhook/webhook.go
@@ -95,7 +95,7 @@ func Post(payload WebhookPayload) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return errors.Errorf("failed to post webhook %s, status code: %d, response body: %s", payload.URL, resp.StatusCode, b)
 	}
 


### PR DESCRIPTION
Some website may return 201/204 to indicate a more detailed success