### PR TITLE
fix: firefox/safari to redirect to /explore in HomeLayout

### DIFF
--- a/web/src/layouts/HomeLayout.tsx
+++ b/web/src/layouts/HomeLayout.tsx
@@ -1,6 +1,6 @@
 import { Button, IconButton, Tooltip } from "@mui/joy";
 import classNames from "classnames";
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import useLocalStorage from "react-use/lib/useLocalStorage";
 import Icon from "@/components/Icon";
@@ -19,15 +19,16 @@ const HomeLayout = () => {
   const [collapsed, setCollapsed] = useLocalStorage<boolean>("navigation-collapsed", false);
 
   // Redirect to explore page if not logged in.
-  if (
-    !currentUser &&
-    ([Routes.HOME, Routes.TIMELINE, Routes.RESOURCES, Routes.INBOX, Routes.ARCHIVED, Routes.SETTING] as string[]).includes(
-      location.pathname,
-    )
-  ) {
-    navigateTo("/explore");
-    return;
-  }
+  useEffect(() => {
+    if (
+      !currentUser &&
+      ([Routes.HOME, Routes.TIMELINE, Routes.RESOURCES, Routes.INBOX, Routes.ARCHIVED, Routes.SETTING] as string[]).includes(
+        location.pathname,
+      )
+    ) {
+      navigateTo("/explore");
+    }
+  }, []);
 
   return (
     <div className="w-full min-h-full">


### PR DESCRIPTION
**Problem:**
For browsers not support <a href="https://caniuse.com/mdn-api_viewtransition">[ViewTransition API | Can I use... Support tables for HTML5, CSS3, etc](https://caniuse.com/mdn-api_viewtransition)</a>, majorly Firefox and Safari, `useNavigateTo`(useNavigateTo.ts) calls `useNavigate` immediately, and it works in most cases except in HomeLayout.tsx.

An error shows `You should call navigate() in a React.useEffect(), not when your component is first rendered.`

**Cause:**
Regressed by this PR: <a href="https://github.com/usememos/memos/commit/dfe29ec766290aec8dbb1769c09dccf2881f0ef4">[chore: tweak route layout · usememos/memos@dfe29ec](https://github.com/usememos/memos/commit/dfe29ec766290aec8dbb1769c09dccf2881f0ef4)</a>

**Fix:**
Follow the correct pattern to call `useNavigate` inside of an useEffect hook.