### PR TITLE
fix: telegram callback query handler dereferencing nil pointer if memo not found

### DIFF
--- a/server/integration/telegram.go
+++ b/server/integration/telegram.go
@@ -130,6 +130,20 @@ func (t *TelegramHandler) CallbackQueryHandle(ctx context.Context, bot *telegram
 		return bot.AnswerCallbackQuery(ctx, callbackQuery.ID, fmt.Sprintf("Failed to parse callbackQuery.Data %s", callbackQuery.Data))
 	}
 
+	memo, err := t.store.GetMemo(ctx, &store.FindMemo{
+		ID: &memoID,
+	})
+	if err != nil {
+		return bot.AnswerCallbackQuery(ctx, callbackQuery.ID, fmt.Sprintf("Failed to call FindMemo %s", err))
+	}
+	if memo == nil {
+		_, err = bot.EditMessage(ctx, callbackQuery.Message.Chat.ID, callbackQuery.Message.MessageID, fmt.Sprintf("Memo %d not found", memoID), nil)
+		if err != nil {
+			return bot.AnswerCallbackQuery(ctx, callbackQuery.ID, fmt.Sprintf("Failed to EditMessage %s", err))
+		}
+		return nil
+	}
+
 	update := store.UpdateMemo{
 		ID:         memoID,
 		Visibility: &visibility,

--- a/server/integration/telegram.go
+++ b/server/integration/telegram.go
@@ -141,7 +141,7 @@ func (t *TelegramHandler) CallbackQueryHandle(ctx context.Context, bot *telegram
 		if err != nil {
 			return bot.AnswerCallbackQuery(ctx, callbackQuery.ID, fmt.Sprintf("Failed to EditMessage %s", err))
 		}
-		return nil
+		return bot.AnswerCallbackQuery(ctx, callbackQuery.ID, fmt.Sprintf("Memo %d not found, possibly deleted elsewhere", memoID))
 	}
 
 	update := store.UpdateMemo{


### PR DESCRIPTION
If a memos added through telegram is deleted and we try to change the visibility in telegram, server will dereference a nil pointer in the handler when dispatching webhook.