### PR TITLE
fix: dark mode tag selection and suggestion

### DIFF
--- a/web/src/components/MemoEditor/Editor/TagSuggestions.tsx
+++ b/web/src/components/MemoEditor/Editor/TagSuggestions.tsx
@@ -106,7 +106,7 @@ const TagSuggestions = ({ editorRef, editorActions }: Props) => {
           onMouseDown={() => autocomplete(tag)}
           className={classNames(
             "rounded p-1 px-2 w-full truncate text-sm dark:text-gray-300 cursor-pointer hover:bg-zinc-200 dark:hover:bg-zinc-800",
-            i === selected ? "bg-zinc-300 dark:bg-zinc-700" : "",
+            i === selected ? "bg-zinc-300 dark:bg-zinc-600" : "",
           )}
         >
           <OverflowTip>#{tag}</OverflowTip>

--- a/web/src/components/MemoEditor/Editor/TagSuggestions.tsx
+++ b/web/src/components/MemoEditor/Editor/TagSuggestions.tsx
@@ -75,12 +75,16 @@ const TagSuggestions = ({ editorRef, editorActions }: Props) => {
   };
 
   const handleInput = () => {
-    if (!editorRef.current) return;
+    const editor = editorRef.current;
+    if (!editor) return;
+
     select(0);
     const [word, index] = getCurrentWord();
-    const isActive = word.startsWith("#") && !word.slice(1).includes("#");
-    const caretCordinates = getCaretCoordinates(editorRef.current, index);
-    caretCordinates.top -= editorRef.current.scrollTop;
+    const currentChar = editor.value[editor.selectionEnd];
+    const isActive = word.startsWith("#") && currentChar !== "#";
+
+    const caretCordinates = getCaretCoordinates(editor, index);
+    caretCordinates.top -= editor.scrollTop;
     isActive ? setPosition(caretCordinates) : hide();
   };
 

--- a/web/src/components/MemoEditor/Editor/TagSuggestions.tsx
+++ b/web/src/components/MemoEditor/Editor/TagSuggestions.tsx
@@ -79,7 +79,9 @@ const TagSuggestions = ({ editorRef, editorActions }: Props) => {
     select(0);
     const [word, index] = getCurrentWord();
     const isActive = word.startsWith("#") && !word.slice(1).includes("#");
-    isActive ? setPosition(getCaretCoordinates(editorRef.current, index)) : hide();
+    const caretCordinates = getCaretCoordinates(editorRef.current, index);
+    caretCordinates.top -= editorRef.current.scrollTop;
+    isActive ? setPosition(caretCordinates) : hide();
   };
 
   const listenersAreRegisteredRef = useRef(false);


### PR DESCRIPTION
Hello, I am really enjoying this app so far! This is my first self hosted app and first PR :)
This PR fixes three issues:

### 1. Correct dark mode highlight color of tag in tag suggestion

<img width="330" alt="Screenshot 2024-02-26 at 17 29 35" src="https://github.com/usememos/memos/assets/56483075/1d6043cb-3e1a-4e7d-b7b9-cf0702c5a014">

### 2. Fix incorrect position of tag suggestion when editing a memo and the memo is scrollable
| Before | After |
|--------|--------|
| <img width="300" alt="Screenshot 2024-02-26 at 17 34 10" src="https://github.com/usememos/memos/assets/56483075/68b28850-63a2-4c66-ba94-569d07d44bbd"> | <img width="300" alt="Screenshot 2024-02-26 at 17 35 30" src="https://github.com/usememos/memos/assets/56483075/48fa3554-82a9-40c7-8b64-8cf1215e2353"> |

### 3. Fix false trigger of tag suggestion

Fix scenario like the following:
```
1. Text #tag text
        ^ backspace here
2. Text#tag text
       ^ space
3. Text #tag text
        ^ tag suggestion opens
```