### PR TITLE
chore: fix typo in build script's if statement

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -73,7 +73,7 @@ if (!$?) {
     Write-Host "Frontend built!" -f green
 }
 
-f (!$?) {
+if (!$?) {
     Write-Host -BackgroundColor red -ForegroundColor white "Could not generate buf types. See above."
     Exit 1
 } else {


### PR DESCRIPTION
missing 'i' in 'if' statement