### PR TITLE
chore: added frontend functionality for the compact mode

### DIFF
--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@mui/joy";
+import { Chip, Tooltip } from "@mui/joy";
 import classNames from "classnames";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -86,6 +86,20 @@ const MemoView: React.FC<Props> = (props: Props) => {
     }
   }, []);
 
+  const [expand, setExpand] = useState(false);
+
+  const [showExpandButton, setShowExpandButton] = useState(false);
+
+  useEffect(() => {
+    if (userStore.userSetting?.compactView) {
+      setExpand(true);
+      setShowExpandButton(true);
+    } else {
+      setExpand(false);
+      setShowExpandButton(false);
+    }
+  }, [userStore.userSetting?.compactView]);
+
   return (
     <div
       className={classNames(
@@ -150,16 +164,32 @@ const MemoView: React.FC<Props> = (props: Props) => {
           {!readonly && <MemoActionMenu memo={memo} hiddenActions={props.showPinned ? [] : ["pin"]} />}
         </div>
       </div>
-      <MemoContent
-        key={`${memo.id}-${memo.updateTime}`}
-        memoId={memo.id}
-        content={memo.content}
-        readonly={readonly}
-        onClick={handleMemoContentClick}
-      />
-      <MemoResourceListView resources={memo.resources} />
-      <MemoRelationListView memo={memo} relations={referencedMemos} />
-      <MemoReactionistView memo={memo} reactions={memo.reactions} />
+      <div
+        className={`z-0 ${!expand ? "h-full" : "h-20 overflow-y-hidden rounded-b-xl bg-gradient-to-b from-transparent to-zinc-200 dark:to-zinc-700 w-full"}`}
+      >
+        <MemoContent
+          key={`${memo.id}-${memo.updateTime}`}
+          memoId={memo.id}
+          content={memo.content}
+          readonly={readonly}
+          onClick={handleMemoContentClick}
+          className={classNames(expand && "text-black/40 dark:text-white/50")}
+        />
+        <MemoResourceListView resources={memo.resources} />
+        <MemoRelationListView memo={memo} relations={referencedMemos} />
+        <MemoReactionistView memo={memo} reactions={memo.reactions} />
+      </div>
+      <div className="flex items-center justify-center w-full">
+        {showExpandButton && (
+          <div className="flex w-full items-center justify-center">
+            {expand && (
+              <Chip variant="solid" color="primary" size="sm" className="capitalize m-2 cursor-pointer">
+                <span onClick={handleGotoMemoDetailPage}>show more</span>
+              </Chip>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/web/src/components/Settings/PreferencesSection.tsx
+++ b/web/src/components/Settings/PreferencesSection.tsx
@@ -1,4 +1,4 @@
-import { Button, Divider, Input, Option, Select } from "@mui/joy";
+import { Button, Divider, Input, Option, Select, Switch } from "@mui/joy";
 import { useState } from "react";
 import { toast } from "react-hot-toast";
 import { Link } from "react-router-dom";
@@ -69,6 +69,15 @@ const PreferencesSection = () => {
     setTelegramUserId(value);
   };
 
+  const handleCompactViewChanged = async (value: boolean) => {
+    await userStore.updateUserSetting(
+      {
+        compactView: value,
+      },
+      ["compact_view"],
+    );
+  };
+
   return (
     <div className="w-full flex flex-col gap-2 pt-2 pb-4">
       <p className="font-medium text-gray-700 dark:text-gray-500">{t("common.basic")}</p>
@@ -102,7 +111,13 @@ const PreferencesSection = () => {
             ))}
         </Select>
       </div>
-
+      <div className="w-full flex flex-row justify-between items-center">
+        <span className="truncate">{t("setting.preference-section.compact-mode")}</span>
+        <Switch
+          checked={setting.compactView}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => handleCompactViewChanged(event.target.checked)}
+        />
+      </div>
       <Divider className="!my-3" />
 
       <div className="space-y-2 border rounded-md py-2 px-3 dark:border-zinc-700">

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -178,6 +178,7 @@
     "preference-section": {
       "theme": "Theme",
       "default-memo-visibility": "Default memo visibility",
+      "compact-mode": "Compact Mode",
       "default-resource-visibility": "Default resource visibility",
       "enable-folding-memo": "Enable folding memo",
       "enable-double-click": "Enable double-click to edit",


### PR DESCRIPTION
Previous PR was closed because of maintainability issues. New PR has one less file (tailwind.css). This PR shifted all the CSS used in the `MemoView.tsx` file, from `tailwind.css` to the `MemoView.tsx`. 