### PR TITLE
fix: body overflow styles

### DIFF
--- a/web/src/components/Dialog/BaseDialog.tsx
+++ b/web/src/components/Dialog/BaseDialog.tsx
@@ -73,6 +73,7 @@ export function generateDialog<T extends DialogProps>(
   const tempDiv = document.createElement("div");
   const dialog = createRoot(tempDiv);
   document.body.append(tempDiv);
+  document.body.style.overflow = "hidden";
 
   setTimeout(() => {
     tempDiv.firstElementChild?.classList.add("showup");
@@ -82,6 +83,7 @@ export function generateDialog<T extends DialogProps>(
     destroy: () => {
       tempDiv.firstElementChild?.classList.remove("showup");
       tempDiv.firstElementChild?.classList.add("showoff");
+      document.body.style.removeProperty("overflow");
       setTimeout(() => {
         dialog.unmount();
         tempDiv.remove();


### PR DESCRIPTION
fix #3049 

I reviewed the performance of the rc-image component during preview and found that the preview of this component is based on @rc-component/portal. I referred to the solution provided by that component.
https://github.com/react-component/portal/blob/815dc89dd74c4799b3604aefa73b94b05914ffb3/src/useScrollLocker.tsx#L23