### PR TITLE
Fix panic in GetUserMemosStats when memo is deleted" -m "The GetUserM…

### DIFF
--- a/server/route/api/v2/memo_service.go
+++ b/server/route/api/v2/memo_service.go
@@ -450,6 +450,11 @@ func (s *APIV2Service) GetUserMemosStats(ctx context.Context, request *apiv2pb.G
 	}
 	stats := make(map[string]int32)
 	for _, memo := range memos {
+		// Check if the memo exists before processing it
+		if memo == nil {
+			continue
+		}
+
 		displayTs := memo.CreatedTs
 		if displayWithUpdatedTs {
 			displayTs = memo.UpdatedTs


### PR DESCRIPTION
## Description
The `GetUserMemosStats` function panics with a nil pointer dereference error when a memo is deleted and the Telegram bot tries to update the user's memo stats. This happens because the function assumes that all memos in the `memos` slice are non-nil.

## Solution
To fix this issue, a check is added to skip processing nil memos. If a memo is nil (indicating it has been deleted), the function continues with the next memo without causing a panic.

This fix prevents the panic error and ensures that the `GetUserMemosStats` function handles deleted memos gracefully when called by the Telegram bot or any other client.

## Additional Info
The panic error occurs specifically when the Telegram bot tries to update the user's memo stats after a memo is deleted. This fix addresses that particular scenario and prevents the bot from crashing.
