### PR TITLE
removed sanitization logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/labstack/echo/v4 v4.11.4
 	github.com/lib/pq v1.10.9
 	github.com/lithammer/shortuuid/v4 v4.0.0
-	github.com/microcosm-cc/bluemonday v1.0.26
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2

--- a/plugin/http-getter/image.go
+++ b/plugin/http-getter/image.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/microcosm-cc/bluemonday"
 )
 
 type Image struct {
@@ -39,21 +38,9 @@ func GetImage(urlStr string) (*Image, error) {
 		return nil, err
 	}
 
-	bodyBytes, err = SanitizeContent(bodyBytes)
-	if err != nil {
-		return nil, err
-	}
-
 	image := &Image{
 		Blob:      bodyBytes,
 		Mediatype: mediatype,
 	}
 	return image, nil
-}
-
-func SanitizeContent(content []byte) ([]byte, error) {
-	bodyString := string(content)
-
-	bm := bluemonday.UGCPolicy()
-	return []byte(bm.Sanitize(bodyString)), nil
 }


### PR DESCRIPTION
Solving issue #3093 
I have removed the sanitization code currently being used for images.
Current logic uses an external html sanitization library i.e. bluemonday, however since we are passing the **binary image content and not html/markdown,** the _process damages the image bytes_ leading to a malformed image, since html sanitization only accepts a few standard html tags and filters out the rest of data.
Moreover, sanitizing image content does not make obvious sense since it would most obviously cause damage to the actual content.