### PR TITLE
feat: handle restore memo when is in archived memo detail page

### DIFF
--- a/web/src/components/MemoActionMenu.tsx
+++ b/web/src/components/MemoActionMenu.tsx
@@ -24,7 +24,7 @@ const MemoActionMenu = (props: Props) => {
   const location = useLocation();
   const navigateTo = useNavigateTo();
   const memoStore = useMemoStore();
-  const isInMemoDetailPage = location.pathname.startsWith(`/m/${memo.name}`);
+  const isInMemoDetailPage = location.pathname.startsWith(`/m/${memo.uid}`);
 
   const handleTogglePinMemoBtnClick = async () => {
     try {
@@ -57,24 +57,35 @@ const MemoActionMenu = (props: Props) => {
     });
   };
 
-  const handleArchiveMemoClick = async () => {
+  const handleToggleMemoStatusClick = async () => {
     try {
-      await memoStore.updateMemo(
-        {
-          name: memo.name,
-          rowStatus: RowStatus.ARCHIVED,
-        },
-        ["row_status"],
-      );
+      if (memo.rowStatus === RowStatus.ARCHIVED) {
+        await memoStore.updateMemo(
+          {
+            name: memo.name,
+            rowStatus: RowStatus.ACTIVE,
+          },
+          ["row_status"],
+        );
+        toast(t("message.restored-successfully"));
+      } else {
+        await memoStore.updateMemo(
+          {
+            name: memo.name,
+            rowStatus: RowStatus.ARCHIVED,
+          },
+          ["row_status"],
+        );
+        toast.success(t("message.archived-successfully"));
+      }
     } catch (error: any) {
       console.error(error);
       toast.error(error.response.data.message);
       return;
     }
 
-    toast.success("Archived successfully");
     if (isInMemoDetailPage) {
-      navigateTo("/archived");
+      memo.rowStatus === RowStatus.ARCHIVED ? navigateTo("/") : navigateTo("/archived");
     }
   };
 
@@ -120,9 +131,9 @@ const MemoActionMenu = (props: Props) => {
             {t("common.share")}
           </MenuItem>
         )}
-        <MenuItem color="warning" onClick={handleArchiveMemoClick}>
-          <Icon.Archive className="w-4 h-auto" />
-          {t("common.archive")}
+        <MenuItem color="warning" onClick={handleToggleMemoStatusClick}>
+          {memo.rowStatus === RowStatus.ARCHIVED ? <Icon.ArchiveRestore className="w-4 h-auto" /> : <Icon.Archive className="w-4 h-auto" />}
+          {memo.rowStatus === RowStatus.ARCHIVED ? t("common.restore") : t("common.archive")}
         </MenuItem>
         <MenuItem color="danger" onClick={handleDeleteMemoClick}>
           <Icon.Trash className="w-4 h-auto" />

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -312,6 +312,7 @@
     "no-data": "No data found.",
     "memos-ready": "all memos are ready",
     "resource-ready": "all resource are ready",
+    "archived-successfully": "Archived successfully",
     "restored-successfully": "Restored successfully",
     "memo-updated-datetime": "Memo created datetime changed.",
     "invalid-created-datetime": "Invalid created datetime.",

--- a/web/src/locales/vi.json
+++ b/web/src/locales/vi.json
@@ -126,6 +126,7 @@
     "private-only": "Bản ghi chú này là riêng tư",
     "resource-filename-updated": "Tên tệp tài nguyên đã được cập nhật.",
     "resource-ready": "tất cả tài nguyên đã sẵn sàng",
+    "archived-successfully": "Lưu trữ thành công",
     "restored-successfully": "Khôi phục thành công",
     "signup-failed": "Đăng ký thất bại",
     "succeed-copy-code": "Mã đã được sao chép thành công.",


### PR DESCRIPTION
Currently, when going to the link of an archived memo, the action still shows Archive instead of Restore