### PR TITLE
cmd: use the built-in slices library

### DIFF
--- a/server/route/api/v1/tag.go
+++ b/server/route/api/v1/tag.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"slices"
 	"sort"
 
 	"github.com/labstack/echo/v4"
-	"golang.org/x/exp/slices"
 
 	"github.com/usememos/memos/store"
 )

--- a/server/route/api/v2/user_service.go
+++ b/server/route/api/v2/user_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
-	"golang.org/x/exp/slices"
 	expr "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"


### PR DESCRIPTION
In the current go 1.21 version used in the project, slices are no longer an experimental feature and have entered the standard library