### PR TITLE
chore: replace util.Min helper with built-in min

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -41,13 +41,6 @@ func GenUUID() string {
 	return uuid.New().String()
 }
 
-func Min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 var letters = []rune("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 // RandomString returns a random string with length n.

--- a/server/route/rss/rss.go
+++ b/server/route/rss/rss.go
@@ -13,7 +13,6 @@ import (
 	"github.com/yourselfhosted/gomark/ast"
 	"github.com/yourselfhosted/gomark/renderer"
 
-	"github.com/usememos/memos/internal/util"
 	"github.com/usememos/memos/server/profile"
 	"github.com/usememos/memos/store"
 )
@@ -102,7 +101,7 @@ func (s *RSSService) generateRSSFromMemoList(ctx context.Context, memoList []*st
 		Created:     time.Now(),
 	}
 
-	var itemCountLimit = util.Min(len(memoList), maxRSSItemCount)
+	var itemCountLimit = min(len(memoList), maxRSSItemCount)
 	feed.Items = make([]*feeds.Item, itemCountLimit)
 	for i := 0; i < itemCountLimit; i++ {
 		memo := memoList[i]
@@ -152,7 +151,7 @@ func getRSSItemTitle(content string) string {
 	}
 
 	title := strings.Split(content, "\n")[0]
-	var titleLengthLimit = util.Min(len(title), maxRSSItemTitleLength)
+	var titleLengthLimit = min(len(title), maxRSSItemTitleLength)
 	if titleLengthLimit < len(title) {
 		title = title[:titleLengthLimit] + "..."
 	}


### PR DESCRIPTION
We can use the built-in `min` function since Go 1.21.

Reference: https://go.dev/ref/spec#Min_and_max