### PR TITLE
fix(tag_deletion): fix deleting tag from tag lists

### DIFF
--- a/server/router/api/v1/tag_service.go
+++ b/server/router/api/v1/tag_service.go
@@ -137,13 +137,7 @@ func (s *APIV1Service) RenameTag(ctx context.Context, request *v1pb.RenameTagReq
 }
 
 func (s *APIV1Service) DeleteTag(ctx context.Context, request *v1pb.DeleteTagRequest) (*emptypb.Empty, error) {
-	userID, err := ExtractUserIDFromName(request.Tag.Creator)
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid user name: %v", err)
-	}
-	user, err := s.Store.GetUser(ctx, &store.FindUser{
-		ID: &userID,
-	})
+	user, err := getCurrentUser(ctx, s.Store)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get user: %v", err)
 	}

--- a/web/src/components/HomeSidebar/TagsSection.tsx
+++ b/web/src/components/HomeSidebar/TagsSection.tsx
@@ -130,6 +130,7 @@ const TagItemContainer: React.FC<TagItemContainerProps> = (props: TagItemContain
       dialogName: "delete-tag-dialog",
       onConfirm: async () => {
         await tagStore.deleteTag(tag.text);
+        tagStore.fetchTags({ skipCache: true });
       },
     });
   };


### PR DESCRIPTION
Fix #3309 

What to know:
- Delete tag with or without children should be working after this fix, but the tag is still present in the memo
- the tag deletion still not working if the tag that wants to be deleted is a parent tag (need to discuss how is the expected behaviour if we delete the parent tag)
ex: tag is `#parent/sub1`. The tag is not deleted if the user hovers on #parent and deletes it. But if the user deletes #parent/sub1, it's working as expected. `#parent/sub1` will be deleted with `#parent` still exists.

https://github.com/usememos/memos/assets/67781184/e11432d3-2fba-480a-9e0c-e2c470c0a342
