### PR TITLE
Fix: Set max height to 50vh for better viewing for larger screens.

### DIFF
--- a/web/src/components/MemoEditor/Editor/index.tsx
+++ b/web/src/components/MemoEditor/Editor/index.tsx
@@ -185,7 +185,7 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
   return (
     <div
       className={clsx(
-        "flex flex-col justify-start items-start relative w-full h-auto max-h-[256px] bg-inherit dark:text-gray-300",
+        "flex flex-col justify-start items-start relative w-full h-auto max-h-[50vh] bg-inherit dark:text-gray-300",
         className,
       )}
     >


### PR DESCRIPTION
### Description
Setting max height to 50vh than limiting to 256px only for better editing in larger screens.

![image](https://github.com/usememos/memos/assets/32908963/5304bd8b-3e7e-47a5-aadc-1396adf708b1)
