### PR TITLE
chore: respect supplied listening address

### DIFF
--- a/server/router/api/v1/v1.go
+++ b/server/router/api/v1/v1.go
@@ -63,7 +63,7 @@ func NewAPIV1Service(secret string, profile *profile.Profile, store *store.Store
 func (s *APIV1Service) RegisterGateway(ctx context.Context, echoServer *echo.Echo) error {
 	conn, err := grpc.DialContext(
 		ctx,
-		fmt.Sprintf(":%d", s.Profile.Port),
+		fmt.Sprintf("%s:%d", s.Profile.Addr, s.Profile.Port),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(100*1024*1024)),
 	)

--- a/server/server.go
+++ b/server/server.go
@@ -88,7 +88,7 @@ func NewServer(ctx context.Context, profile *profile.Profile, store *store.Store
 }
 
 func (s *Server) Start(ctx context.Context) error {
-	address := fmt.Sprintf(":%d", s.Profile.Port)
+	address := fmt.Sprintf("%s:%d", s.Profile.Addr, s.Profile.Port)
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return errors.Wrap(err, "failed to listen")


### PR DESCRIPTION
Restore the behavior broken by 5d967f41d968c882c342e65578a36da2e2df9579 