### PR TITLE
Fix MySQL database migration 0.21.0 -> 0.22.0

### DIFF
--- a/store/db/mysql/migration/prod/0.22/01__memo_tags.sql
+++ b/store/db/mysql/migration/prod/0.22/01__memo_tags.sql
@@ -1,4 +1,3 @@
 ALTER TABLE `memo` ADD COLUMN `tags_temp` JSON;
 UPDATE `memo` SET `tags_temp` = '[]';
-ALTER TABLE `memo` DROP COLUMN IF EXISTS `tags`;
 ALTER TABLE `memo` CHANGE COLUMN `tags_temp` `tags` JSON NOT NULL;

--- a/store/db/mysql/migration/prod/0.22/01__memo_tags.sql
+++ b/store/db/mysql/migration/prod/0.22/01__memo_tags.sql
@@ -1,4 +1,4 @@
 ALTER TABLE `memo` ADD COLUMN `tags_temp` JSON;
 UPDATE `memo` SET `tags_temp` = '[]';
-ALTER TABLE `memo` DROP COLUMN `tags`;
+ALTER TABLE `memo` DROP COLUMN IF EXISTS `tags`;
 ALTER TABLE `memo` CHANGE COLUMN `tags_temp` `tags` JSON NOT NULL;

--- a/store/db/mysql/migration/prod/0.22/02__memo_payload.sql
+++ b/store/db/mysql/migration/prod/0.22/02__memo_payload.sql
@@ -1,4 +1,3 @@
 ALTER TABLE `memo` ADD COLUMN `payload_temp` JSON;
 UPDATE `memo` SET `payload_temp` = '{}';
-ALTER TABLE `memo` DROP COLUMN IF EXISTS `payload`;
 ALTER TABLE `memo` CHANGE COLUMN `payload_temp` `payload` JSON NOT NULL;

--- a/store/db/mysql/migration/prod/0.22/02__memo_payload.sql
+++ b/store/db/mysql/migration/prod/0.22/02__memo_payload.sql
@@ -1,4 +1,4 @@
 ALTER TABLE `memo` ADD COLUMN `payload_temp` JSON;
 UPDATE `memo` SET `payload_temp` = '{}';
-ALTER TABLE `memo` DROP COLUMN `payload`;
+ALTER TABLE `memo` DROP COLUMN IF EXISTS `payload`;
 ALTER TABLE `memo` CHANGE COLUMN `payload_temp` `payload` JSON NOT NULL;


### PR DESCRIPTION
This pull request addresses #3348, which implements the fix I worked out, mentioned in the issue.

SQLite migrations and PostgreSQL migrations seems to be fine, as they are not trying `DROP`ping non-exist columns.

Besides, a version bump (e.g. 0.22.0 -> 0.22.1) is suggested to aware the downstream users to upgrade.