### PR TITLE
chore: update translation files

### DIFF
--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -115,8 +115,7 @@
       "private": "Privé",
       "protected": "Accès aux membres",
       "public": "Public"
-    },
-    "wrapping": "Enveloppe"
+    }
   },
   "message": {
     "archived-successfully": "Archivé avec succès",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -115,8 +115,7 @@
       "private": "非公開",
       "protected": "メンバーに表示",
       "public": "公開メモ"
-    },
-    "wrapping": "ラッピング"
+    }
   },
   "message": {
     "archived-successfully": "アーカイブが完了しました",

--- a/web/src/locales/mr.json
+++ b/web/src/locales/mr.json
@@ -115,8 +115,7 @@
       "private": "खाजगी",
       "protected": "कार्यक्षेत्र",
       "public": "सार्वजनिक"
-    },
-    "wrapping": "गुंडाळा"
+    }
   },
   "message": {
     "archived-successfully": "यशस्वीरित्या संग्रहित केले",

--- a/web/src/locales/pt-BR.json
+++ b/web/src/locales/pt-BR.json
@@ -115,8 +115,7 @@
       "private": "Privado (eu)",
       "protected": "Protegido (membros)",
       "public": "Público (todos)"
-    },
-    "wrapping": "Quebra"
+    }
   },
   "message": {
     "archived-successfully": "Arquivado com êxito",

--- a/web/src/locales/ru.json
+++ b/web/src/locales/ru.json
@@ -112,8 +112,7 @@
       "private": "Видно только вам",
       "protected": "Видно только пользователям",
       "public": "Видно всем"
-    },
-    "wrapping": "Перенос"
+    }
   },
   "message": {
     "archived-successfully": "Успешная архивация",

--- a/web/src/locales/tr.json
+++ b/web/src/locales/tr.json
@@ -115,8 +115,7 @@
       "private": "Sadece sizin için görünür",
       "protected": "Çalışma Alanı",
       "public": "Herkese açık"
-    },
-    "wrapping": "Paketleme"
+    }
   },
   "message": {
     "archived-successfully": "Başarıyla arşivlendi",


### PR DESCRIPTION
Updated by "Cleanup translation files" hook in Weblate.

Translation: memos-i18n/i18n
Translate-URL: https://hosted.weblate.org/projects/memos-i18n/english/