### PR TITLE
feat: return not found error instead internal error for local file not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ bin/air
 dev-dist
 
 dist
+
+# VSCode settings
+/.vscode

--- a/server/router/api/v1/resource_service.go
+++ b/server/router/api/v1/resource_service.go
@@ -197,6 +197,9 @@ func (s *APIV1Service) GetResourceBinary(ctx context.Context, request *v1pb.GetR
 		}
 
 		file, err := os.Open(resourcePath)
+		if os.IsNotExist(err) {
+			return nil, status.Errorf(codes.NotFound, "file not found for resource: %s", request.Name)
+		}
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to open the file: %v", err)
 		}

--- a/server/router/api/v1/resource_service.go
+++ b/server/router/api/v1/resource_service.go
@@ -197,10 +197,10 @@ func (s *APIV1Service) GetResourceBinary(ctx context.Context, request *v1pb.GetR
 		}
 
 		file, err := os.Open(resourcePath)
-		if os.IsNotExist(err) {
-			return nil, status.Errorf(codes.NotFound, "file not found for resource: %s", request.Name)
-		}
 		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, status.Errorf(codes.NotFound, "file not found for resource: %s", request.Name)
+			}
 			return nil, status.Errorf(codes.Internal, "failed to open the file: %v", err)
 		}
 		defer file.Close()


### PR DESCRIPTION
Sometimes there may be some resource store on file system disappeared, as the user here described https://github.com/RyoJerryYu/obsidian-memos-sync/issues/14 .  (Though I don't know how this happened)

Returning a gRPC NotFound error would be better than returning Internal error. Then we could got a 404 status code when we use gRPC-web or gRPC-gateway API if this was happened.