### PR TITLE
fix: PATCH requests on /api/v1 not working

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -106,7 +106,7 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}()
 	go func() {
-		httpListener := muxServer.Match(cmux.HTTP1Fast())
+		httpListener := muxServer.Match(cmux.HTTP1Fast("PATCH"))
 		s.echoServer.Listener = httpListener
 		if err := s.echoServer.Start(address); err != nil {
 			slog.Error("failed to start echo server", err)

--- a/server/server.go
+++ b/server/server.go
@@ -106,7 +106,7 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}()
 	go func() {
-		httpListener := muxServer.Match(cmux.HTTP1Fast("PATCH"))
+		httpListener := muxServer.Match(cmux.HTTP1Fast(http.MethodPatch))
 		s.echoServer.Listener = httpListener
 		if err := s.echoServer.Start(address); err != nil {
 			slog.Error("failed to start echo server", err)


### PR DESCRIPTION
Because of https://github.com/soheilhy/cmux/issues/99, PATCH requests can't be handled by Memos v1 API (0.22+). Thankfully, cmux has a parameter to add supported HTTP methods for `cmux.HTTP1Fast`.

With some user agents and reverse proxy servers, this issue can't be reproduced because the PATCH request reused previous HTTP connections which were used by GET or POST requests, and didn't go through the match process of cmux.

This patch (pun intended) also fixes #3494, https://github.com/mudkipme/MoeMemosAndroid/issues/187 and https://github.com/mudkipme/MoeMemos/issues/189.