### PR TITLE
fix: code blocks of unknown languages cause HTML injection

### DIFF
--- a/web/src/components/MemoContent/CodeBlock.tsx
+++ b/web/src/components/MemoContent/CodeBlock.tsx
@@ -42,7 +42,10 @@ const CodeBlock: React.FC<Props> = ({ language, content }: Props) => {
       // Skip error and use default highlighted code.
     }
 
-    return content;
+    // escape any HTML entities when rendering original content
+    return Object.assign(document.createElement('span'), {
+      textContent: content,
+    }).innerHTML;
   }, [formatedLanguage, content]);
 
   const handleCopyButtonClick = useCallback(() => {

--- a/web/src/components/MemoContent/CodeBlock.tsx
+++ b/web/src/components/MemoContent/CodeBlock.tsx
@@ -43,7 +43,7 @@ const CodeBlock: React.FC<Props> = ({ language, content }: Props) => {
     }
 
     // escape any HTML entities when rendering original content
-    return Object.assign(document.createElement('span'), {
+    return Object.assign(document.createElement("span"), {
       textContent: content,
     }).innerHTML;
   }, [formatedLanguage, content]);


### PR DESCRIPTION
A code block of unknown language (that is, a language not treated as special by Memos and not handled by highlight.js) should fall back on rendering its plaintext content. However, the content is never properly escaped before it is appended to the DOM, and thus any string that happens to contain HTML is unsafely rendered. This commit fixes the issue by ensuring that, when none of the previous cases handle the text, any HTML entities are escaped first.