### PR TITLE
chore: build release containers from tags rather than branches

### DIFF
--- a/.github/workflows/build-and-push-release-image.yml
+++ b/.github/workflows/build-and-push-release-image.yml
@@ -2,9 +2,9 @@ name: build-and-push-release-image
 
 on:
   push:
-    branches:
-      # Run on pushing branches like `release/1.0.0`
-      - "release/*.*.*"
+    tags:
+      # Run on pushing a tag in the format of 'v0.0.0'
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   build-and-push-release-image:
@@ -19,10 +19,10 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Extract build args
-        # Extract version from branch name
-        # Example: branch name `release/1.0.0` sets up env.VERSION=1.0.0
+        # Extract version from tag name
+        # Example: tag name `v1.0.0` sets up env.VERSION=1.0.0
         run: |
-          echo "VERSION=${GITHUB_REF_NAME#release/}" >> $GITHUB_ENV
+          echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
Fixes #3645, currently the release containers are build from the release branches, which are created in preparation for a release. This causes some users with automated CI/CD to either deploy a pre-release version or be notified of a release version before it has actually been released. 

This change switches the workflow to be triggered by tags, which are created on the release version.