### PR TITLE
fix: dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ docker run -d --name memos -p 5230:5230 -v ~/.memos/:/var/opt/memos neosmemo/mem
 ```
 
 > [!NOTE]
-> This command is only applicable for Unix/Linux systems. For Windows, please refer to the detailed [documentation](https://www.usememos.com/docs/install/self-hosting).
+> This command is only applicable for Unix/Linux systems. For Windows, please refer to the detailed [documentation](https://www.usememos.com/docs/install/container-install#docker-on-windows).
 >
 > The `~/.memos/` directory will be used as the data directory on your local machine, while `/var/opt/memos` is the directory of the volume in Docker and should not be modified.
 


### PR DESCRIPTION
The previous page no longer exists.  The new one takes users to the Docker directions for Windows.