### PR TITLE
fix: tag query for mysql

### DIFF
--- a/store/db/mysql/memo.go
+++ b/store/db/mysql/memo.go
@@ -92,7 +92,7 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 		}
 		if len(v.TagSearch) != 0 {
 			for _, tag := range v.TagSearch {
-				where, args = append(where, "JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.property.tags'), ?)"), append(args, fmt.Sprintf(`%%"%s"%%`, tag))
+				where, args = append(where, "JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.property.tags'), ?)"), append(args, fmt.Sprintf(`"%s"`, tag))
 			}
 		}
 		if v.HasLink {


### PR DESCRIPTION
In version v0.22.4, filtering timeline via tags when using MySQL as database driver will cause the `ListMemos` API to fail due to an invalid query. 

This pull request removes the `%` in the query and should resolve the issue.