### PR TITLE
fix: explicitly disabling `autocapitalize` and `spellcheck`

### DIFF
--- a/web/src/pages/SignIn.tsx
+++ b/web/src/pages/SignIn.tsx
@@ -128,6 +128,9 @@ const SignIn = () => {
                   readOnly={actionBtnLoadingState.isLoading}
                   placeholder={t("common.username")}
                   value={username}
+                  autoComplete="username"
+                  autoCapitalize="off"
+                  spellCheck={false}
                   onChange={handleUsernameInputChanged}
                   required
                 />
@@ -141,6 +144,9 @@ const SignIn = () => {
                   readOnly={actionBtnLoadingState.isLoading}
                   placeholder={t("common.password")}
                   value={password}
+                  autoComplete="password"
+                  autoCapitalize="off"
+                  spellCheck={false}
                   onChange={handlePasswordInputChanged}
                   required
                 />

--- a/web/src/pages/SignUp.tsx
+++ b/web/src/pages/SignUp.tsx
@@ -93,6 +93,9 @@ const SignUp = () => {
                     readOnly={actionBtnLoadingState.isLoading}
                     placeholder={t("common.username")}
                     value={username}
+                    autoComplete="username"
+                    autoCapitalize="off"
+                    spellCheck={false}
                     onChange={handleUsernameInputChanged}
                     required
                   />
@@ -106,6 +109,9 @@ const SignUp = () => {
                     readOnly={actionBtnLoadingState.isLoading}
                     placeholder={t("common.password")}
                     value={password}
+                    autoComplete="password"
+                    autoCapitalize="off"
+                    spellCheck={false}
                     onChange={handlePasswordInputChanged}
                     required
                   />


### PR DESCRIPTION
## Background
See #3747 for more context on the ask behind this pull request.

## Summary of the changes 
- Altered both `web/src/pages/SignIn.tsx` and `web/src/pages/SignUp.tsx` to explicitly disable the `spellcheck` and `autocapitalize ` fields. This should improve the mobile experience of typing in your username/password 
- Altered both `web/src/pages/SignIn.tsx` and `web/src/pages/SignUp.tsx` to have explicit `autocomplete` fields. This will make it easier for password managers to autofill these fields. Typically they fallback to the input id or name, but explicit autocomplete values won't hurt 😄 

## Feedback
Maintainers, If you see any issues with this PR, please let me know and I can make some changes. 
Thanks in advance.