### PR TITLE
perf: reduce image size by 21.3MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,12 @@ WORKDIR /backend-build
 COPY . .
 COPY --from=frontend /frontend-build/web/dist /backend-build/server/router/frontend/dist
 
-RUN CGO_ENABLED=0 go build -o memos ./bin/memos/main.go
+RUN CGO_ENABLED=0 go build -ldflags='-s -w' -trimpath -o memos ./bin/memos/main.go
 
 # Make workspace with above generated files.
-FROM alpine:latest AS monolithic
+FROM gcr.io/distroless/static-debian12:latest AS monolithic
 WORKDIR /usr/local/memos
 
-RUN apk add --no-cache tzdata
 ENV TZ="UTC"
 
 COPY --from=backend /backend-build/memos /usr/local/memos/
@@ -31,7 +30,6 @@ COPY --from=backend /backend-build/memos /usr/local/memos/
 EXPOSE 5230
 
 # Directory to store the data, which can be referenced as the mounting point.
-RUN mkdir -p /var/opt/memos
 VOLUME /var/opt/memos
 
 ENV MEMOS_MODE="prod"


### PR DESCRIPTION
# Summary
Container image size reduced from 63.8MB to 42.5MB.

# changes made
- Change base image to distroless (static-debian12)
- Remove unnecessary RUN instructions
- Add build options
  - add options to delete debug information
  - add options to remobe embedded paths

# Refs
- https://github.com/GoogleContainerTools/distroless