### PR TITLE
chore: set max thumbnail width to home/explore image max width

### DIFF
--- a/server/router/api/v1/resource_service.go
+++ b/server/router/api/v1/resource_service.go
@@ -438,7 +438,7 @@ func (s *APIV1Service) getOrGenerateThumbnail(resource *store.Resource) ([]byte,
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to decode thumbnail image")
 		}
-		thumbnailImage := imaging.Resize(image, 512, 0, imaging.Lanczos)
+		thumbnailImage := imaging.Resize(image, 700, 0, imaging.Lanczos)
 		if err := imaging.Save(thumbnailImage, filePath); err != nil {
 			return nil, errors.Wrap(err, "failed to save thumbnail file")
 		}

--- a/server/router/api/v1/resource_service.go
+++ b/server/router/api/v1/resource_service.go
@@ -442,7 +442,6 @@ func (s *APIV1Service) getOrGenerateThumbnail(resource *store.Resource) ([]byte,
 
 		thumbnailMaxWidth := 700 // equal to home/explore screen image max width
 		var thumbnailImage image.Image
-
 		if img.Bounds().Max.X > thumbnailMaxWidth {
 			thumbnailImage = imaging.Resize(img, thumbnailMaxWidth, 0, imaging.Lanczos)
 		} else {


### PR DESCRIPTION
Images in the web client have a maximum width of 700px.

This PR is to update the width of thumbnails being generated to align with the home/explore page image max width. This will allow the images to take up the full space provided

Images with a width smaller than the thumbnail width are not scaled up. Note: for these images the cache and resource will be the same image.

See PR comment for original discussion: https://github.com/usememos/memos/pull/3821#discussion_r1731674073

e.g. 

original 512px width compared to new 700px width
![image](https://github.com/user-attachments/assets/7edb4a09-5b38-498f-a951-bd90fb393ee1)

smaller than 700px width does not get upscaled
![image](https://github.com/user-attachments/assets/01c45f8a-0472-466a-9176-ed21155792e2)