### PR TITLE
fix: thumbnail creation race condition

### DIFF
--- a/server/router/api/v1/resource_service.go
+++ b/server/router/api/v1/resource_service.go
@@ -456,7 +456,7 @@ func (s *APIV1Service) getOrGenerateThumbnail(resource *store.Resource) ([]byte,
 		}
 
 		if err := os.Rename(tempFilePath, filePath); err != nil {
-			return nil, errors.Wrap(err, "failed to rename thumbnail file")
+			return nil, errors.Wrap(err, "failed to rename temp thumbnail file")
 		}
 	}
 

--- a/server/router/api/v1/resource_service.go
+++ b/server/router/api/v1/resource_service.go
@@ -8,6 +8,7 @@ import (
 	"image"
 	"io"
 	"log/slog"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -411,6 +412,7 @@ func (s *APIV1Service) GetResourceBlob(resource *store.Resource) ([]byte, error)
 
 // getOrGenerateThumbnail returns the thumbnail image of the resource.
 func (s *APIV1Service) getOrGenerateThumbnail(resource *store.Resource) ([]byte, error) {
+	r := rand.IntN(1000)
 	thumbnailCacheFolder := filepath.Join(s.Profile.Data, ThumbnailCacheFolder)
 	if err := os.MkdirAll(thumbnailCacheFolder, os.ModePerm); err != nil {
 		return nil, errors.Wrap(err, "failed to create thumbnail cache folder")
@@ -448,8 +450,13 @@ func (s *APIV1Service) getOrGenerateThumbnail(resource *store.Resource) ([]byte,
 			thumbnailImage = img
 		}
 
-		if err := imaging.Save(thumbnailImage, filePath); err != nil {
+		tempFilePath := filepath.Join(thumbnailCacheFolder, fmt.Sprintf("temp_%d_%d%s", resource.ID, r, filepath.Ext(resource.Filename)))
+		if err := imaging.Save(thumbnailImage, tempFilePath); err != nil {
 			return nil, errors.Wrap(err, "failed to save thumbnail file")
+		}
+
+		if err := os.Rename(tempFilePath, filePath); err != nil {
+			return nil, errors.Wrap(err, "failed to rename thumbnail file")
 		}
 	}
 

--- a/server/router/api/v1/resource_service.go
+++ b/server/router/api/v1/resource_service.go
@@ -412,7 +412,6 @@ func (s *APIV1Service) GetResourceBlob(resource *store.Resource) ([]byte, error)
 
 // getOrGenerateThumbnail returns the thumbnail image of the resource.
 func (s *APIV1Service) getOrGenerateThumbnail(resource *store.Resource) ([]byte, error) {
-	r := rand.IntN(1000)
 	thumbnailCacheFolder := filepath.Join(s.Profile.Data, ThumbnailCacheFolder)
 	if err := os.MkdirAll(thumbnailCacheFolder, os.ModePerm); err != nil {
 		return nil, errors.Wrap(err, "failed to create thumbnail cache folder")
@@ -450,7 +449,8 @@ func (s *APIV1Service) getOrGenerateThumbnail(resource *store.Resource) ([]byte,
 			thumbnailImage = img
 		}
 
-		tempFilePath := filepath.Join(thumbnailCacheFolder, fmt.Sprintf("temp_%d_%d%s", resource.ID, r, filepath.Ext(resource.Filename)))
+		rnd := rand.IntN(1000)
+		tempFilePath := filepath.Join(thumbnailCacheFolder, fmt.Sprintf("temp_%d_%d%s", resource.ID, rnd, filepath.Ext(resource.Filename)))
 		if err := imaging.Save(thumbnailImage, tempFilePath); err != nil {
 			return nil, errors.Wrap(err, "failed to save thumbnail file")
 		}


### PR DESCRIPTION
When uploading resources to a memo, Firefox sends the creation request and then sends the get resourcebinary request 2 times
![firefox double network call](https://github.com/user-attachments/assets/d9769876-c4b5-495b-ae75-47339b490f71)

This causes a race condition where request 1 creates the thumbnail file and while saving the data to the file, request 2 sees the file exists and tries to loads the data from the incomplete file

e.g. of request (ref 3) returning the image before request (ref 1) has completed saving the file
![image](https://github.com/user-attachments/assets/f5bee99e-9999-440b-a3b1-a28b9d9d413c)

The result is that the UI shows a broken image
![Broken image](https://github.com/user-attachments/assets/aa278d45-45b3-44e8-9421-a7f3a2489894)

Refreshing the page loads the fixed image

Changes made:
- Created a temporary random thumbnail file path so that other requests have a very low chance of referencing the thumbnail file being created.
- After processing renamed the random file to the required thumbnail file name for future reference  

e.g. of both requests now following the full flow
![flow sync](https://github.com/user-attachments/assets/e444a05c-a260-47f1-9adb-792e46159a26)

