### PR TITLE
chore: migrate of Docker compose v2

### DIFF
--- a/scripts/compose.yaml
+++ b/scripts/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.0"
 services:
   memos:
     image: neosmemo/memos:latest


### PR DESCRIPTION
# Summary
- change `docker-compose.yaml` to `compose.yaml`
- remove deprecated field

Close #3855 