### PR TITLE
test: add test for searching memos by tags

### DIFF
--- a/test/store/memo_test.go
+++ b/test/store/memo_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/usememos/memos/store"
+
+	storepb "github.com/usememos/memos/proto/gen/store"
 )
 
 func TestMemoStore(t *testing.T) {
@@ -59,6 +61,42 @@ func TestMemoStore(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, 0, len(memoList))
+	ts.Close()
+}
+
+func TestMemoListByTags(t *testing.T) {
+	ctx := context.Background()
+	ts := NewTestingStore(ctx, t)
+	user, err := createTestingHostUser(ctx, ts)
+	require.NoError(t, err)
+	memoCreate := &store.Memo{
+		UID:        "test-resource-name",
+		CreatorID:  user.ID,
+		Content:    "test_content",
+		Visibility: store.Public,
+		Payload: &storepb.MemoPayload{
+			Property: &storepb.MemoPayload_Property{
+				Tags: []string{"test_tag"},
+			},
+		},
+	}
+	memo, err := ts.CreateMemo(ctx, memoCreate)
+	require.NoError(t, err)
+	require.Equal(t, memoCreate.Content, memo.Content)
+	memo, err = ts.GetMemo(ctx, &store.FindMemo{
+		ID: &memo.ID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, memo)
+
+	memoList, err := ts.ListMemos(ctx, &store.FindMemo{
+		PayloadFind: &store.FindMemoPayload{
+			TagSearch: []string{"test_tag"},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(memoList))
+	require.Equal(t, memo, memoList[0])
 	ts.Close()
 }
 


### PR DESCRIPTION
Added test for searching memos by tags, which has been fixed in #3785.