### PR TITLE
feat: allow mobile user zooming in image preview

### DIFF
--- a/web/src/components/PreviewImageDialog.tsx
+++ b/web/src/components/PreviewImageDialog.tsx
@@ -31,7 +31,7 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
   let endX = -1;
 
   const handleCloseBtnClick = () => {
-    destroy();
+    destroyAndResetViewport();
   };
 
   const handleTouchStart = (event: React.TouchEvent) => {
@@ -73,7 +73,7 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
       setState(defaultState);
       setCurrentIndex(currentIndex - 1);
     } else {
-      destroy();
+      destroyAndResetViewport();
     }
   };
 
@@ -82,7 +82,7 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
       setState(defaultState);
       setCurrentIndex(currentIndex + 1);
     } else {
-      destroy();
+      destroyAndResetViewport();
     }
   };
 
@@ -107,10 +107,33 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
     });
   };
 
+  function setViewportScalable() {
+    const viewport = document.querySelector("meta[name=viewport]");
+    if (viewport) {
+      const contentAttrs = viewport.getAttribute('content');
+      if (contentAttrs) {
+        viewport.setAttribute('content', contentAttrs.replace('user-scalable=no', 'user-scalable=yes'));
+      }
+    }
+  }
+
+  function destroyAndResetViewport() {
+    const viewport = document.querySelector("meta[name=viewport]");
+    if (viewport) {
+      const contentAttrs = viewport.getAttribute('content');
+      if (contentAttrs) {
+        viewport.setAttribute('content', contentAttrs.replace('user-scalable=yes', 'user-scalable=no'));
+      }
+    }
+    destroy();
+  }
+
   const imageComputedStyle = {
     transform: `scale(${state.scale})`,
     transformOrigin: `${state.originX === -1 ? "center" : `${state.originX}px`} ${state.originY === -1 ? "center" : `${state.originY}px`}`,
   };
+
+  setViewportScalable();
 
   return (
     <>

--- a/web/src/components/PreviewImageDialog.tsx
+++ b/web/src/components/PreviewImageDialog.tsx
@@ -1,5 +1,5 @@
 import { XIcon } from "lucide-react";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { generateDialog } from "./Dialog";
 import "@/less/preview-image-dialog.less";
 
@@ -133,7 +133,9 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
     transformOrigin: `${state.originX === -1 ? "center" : `${state.originX}px`} ${state.originY === -1 ? "center" : `${state.originY}px`}`,
   };
 
-  setViewportScalable();
+  useEffect(() => {
+    setViewportScalable();
+  }, []);
 
   return (
     <>

--- a/web/src/components/PreviewImageDialog.tsx
+++ b/web/src/components/PreviewImageDialog.tsx
@@ -110,9 +110,9 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
   function setViewportScalable() {
     const viewport = document.querySelector("meta[name=viewport]");
     if (viewport) {
-      const contentAttrs = viewport.getAttribute('content');
+      const contentAttrs = viewport.getAttribute("content");
       if (contentAttrs) {
-        viewport.setAttribute('content', contentAttrs.replace('user-scalable=no', 'user-scalable=yes'));
+        viewport.setAttribute("content", contentAttrs.replace("user-scalable=no", "user-scalable=yes"));
       }
     }
   }
@@ -120,9 +120,9 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
   function destroyAndResetViewport() {
     const viewport = document.querySelector("meta[name=viewport]");
     if (viewport) {
-      const contentAttrs = viewport.getAttribute('content');
+      const contentAttrs = viewport.getAttribute("content");
       if (contentAttrs) {
-        viewport.setAttribute('content', contentAttrs.replace('user-scalable=yes', 'user-scalable=no'));
+        viewport.setAttribute("content", contentAttrs.replace("user-scalable=yes", "user-scalable=no"));
       }
     }
     destroy();

--- a/web/src/components/PreviewImageDialog.tsx
+++ b/web/src/components/PreviewImageDialog.tsx
@@ -107,7 +107,7 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
     });
   };
 
-  function setViewportScalable() {
+  const setViewportScalable = () => {
     const viewport = document.querySelector("meta[name=viewport]");
     if (viewport) {
       const contentAttrs = viewport.getAttribute("content");
@@ -115,9 +115,9 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
         viewport.setAttribute("content", contentAttrs.replace("user-scalable=no", "user-scalable=yes"));
       }
     }
-  }
+  };
 
-  function destroyAndResetViewport() {
+  const destroyAndResetViewport = () => {
     const viewport = document.querySelector("meta[name=viewport]");
     if (viewport) {
       const contentAttrs = viewport.getAttribute("content");
@@ -126,7 +126,7 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
       }
     }
     destroy();
-  }
+  };
 
   const imageComputedStyle = {
     transform: `scale(${state.scale})`,


### PR DESCRIPTION
Allow mobile user to zoom by temporary set the `user-scalable` attribute to `yes` in `viewport meta`. 
Reset to `no` before the dialog destroy.