### PR TITLE
chore: use translations for calendar days

### DIFF
--- a/web/src/components/ActivityCalendar.tsx
+++ b/web/src/components/ActivityCalendar.tsx
@@ -6,8 +6,6 @@ import { WorkspaceGeneralSetting } from "@/types/proto/api/v1/workspace_setting_
 import { WorkspaceSettingKey } from "@/types/proto/store/workspace_setting";
 import { useTranslate } from "@/utils/i18n";
 
-const WEEK_DAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
-
 interface Props {
   // Format: 2021-1
   month: string;
@@ -43,6 +41,7 @@ const ActivityCalendar = (props: Props) => {
   const dayInMonth = new Date(year, month, 0).getDate();
   const firstDay = (new Date(year, month - 1, 1).getDay() - weekStartDayOffset) % 7;
   const lastDay = new Date(year, month - 1, dayInMonth).getDay() - weekStartDayOffset;
+  const WEEK_DAYS = [t("days.sun"), t("days.mon"), t("days.tue"), t("days.wed"), t("days.thu"), t("days.fri"), t("days.sat")];
   const weekDays = WEEK_DAYS.slice(weekStartDayOffset).concat(WEEK_DAYS.slice(0, weekStartDayOffset));
   const maxCount = Math.max(...Object.values(data));
   const days = [];


### PR DESCRIPTION
Use translated day of week values for calendar as per issue (https://github.com/usememos/memos/issues/3879)

Design decisions:
Used the existing translations but some of these are 3 char translations vs the 2 char strings that are currently used in the calendar. e.g. English was `Mo` for Monday but after translating the value is `Mon`. From testing this looks to not be an issue for most languages. I did notice Hindi has no spaces, but need to evaluate if this can be fixed with a translation update or if CSS needs to be used for just a select view languages

English
![image](https://github.com/user-attachments/assets/54b05b9f-fd08-42d2-b689-82928bd25a25)

Spanish
![image](https://github.com/user-attachments/assets/4eb8b84f-b11c-40d6-ae6f-f7e8e6a5a785)

German
![image](https://github.com/user-attachments/assets/2f4e50f7-e02e-4d00-8129-579575fab1c7)

Hindi
![image](https://github.com/user-attachments/assets/5dab6c67-f2c6-46d1-88b3-af159361f428)

