### PR TITLE
fix: update first day logic for months starting on Sunday

### DIFF
--- a/web/src/components/ActivityCalendar.tsx
+++ b/web/src/components/ActivityCalendar.tsx
@@ -41,8 +41,7 @@ const ActivityCalendar = (props: Props) => {
   const year = dayjs(monthStr).toDate().getFullYear();
   const month = dayjs(monthStr).toDate().getMonth() + 1;
   const dayInMonth = new Date(year, month, 0).getDate();
-  let firstDay = (new Date(year, month - 1, 1).getDay() - weekStartDayOffset) % 7;
-  if (firstDay < 0) firstDay += 7;
+  const firstDay = ((new Date(year, month - 1, 1).getDay() - weekStartDayOffset) % 7 + 7) % 7;
   const lastDay = new Date(year, month - 1, dayInMonth).getDay() - weekStartDayOffset;
   const weekDays = WEEK_DAYS.slice(weekStartDayOffset).concat(WEEK_DAYS.slice(0, weekStartDayOffset));
   const maxCount = Math.max(...Object.values(data));

--- a/web/src/components/ActivityCalendar.tsx
+++ b/web/src/components/ActivityCalendar.tsx
@@ -41,7 +41,8 @@ const ActivityCalendar = (props: Props) => {
   const year = dayjs(monthStr).toDate().getFullYear();
   const month = dayjs(monthStr).toDate().getMonth() + 1;
   const dayInMonth = new Date(year, month, 0).getDate();
-  const firstDay = (new Date(year, month - 1, 1).getDay() - weekStartDayOffset) % 7;
+  let firstDay = (new Date(year, month - 1, 1).getDay() - weekStartDayOffset) % 7;
+  if (firstDay < 0) firstDay += 7;
   const lastDay = new Date(year, month - 1, dayInMonth).getDay() - weekStartDayOffset;
   const weekDays = WEEK_DAYS.slice(weekStartDayOffset).concat(WEEK_DAYS.slice(0, weekStartDayOffset));
   const maxCount = Math.max(...Object.values(data));


### PR DESCRIPTION
Settings the start day of the week to Monday causes the memo calendar to display incorrectly

Memos
![image](https://github.com/user-attachments/assets/bafd8f2f-c52b-494a-8217-62b5d3c160b1)

System calendar
![image](https://github.com/user-attachments/assets/4081e92a-81b4-4c9c-9324-b2225cdc29c0)

This seems to only be an issue for months where the first day is on a Sunday

Calendar after update, the start day now matches up even when the first day of the month is a Sunday e.g. Sep 2024 and Dec 2024:

Sep 2024
Memos
![image](https://github.com/user-attachments/assets/d530f303-5a6d-4b83-9291-38a045fabe87)

System calendar
![image](https://github.com/user-attachments/assets/b4d51692-e370-4e47-b9c4-9dc415676607)

Oct 2024
Memos
![image](https://github.com/user-attachments/assets/baae3c26-794f-4dd1-8d65-e056da89db9e)

System calendar
![image](https://github.com/user-attachments/assets/7ea02a64-32e9-47a5-b557-5d1914aa5567)

Nov 2024
Memos
![image](https://github.com/user-attachments/assets/d04b7524-afa0-49bd-bcec-b43d91a145bd)

System calendar
![image](https://github.com/user-attachments/assets/1f580504-7ab5-4e88-8bb8-8a668d757477)

Dec 2024
Memos
![image](https://github.com/user-attachments/assets/09d47979-1e99-4695-849f-dfc0192ffc0a)

System calendar
![image](https://github.com/user-attachments/assets/cafe0085-2b79-402a-95de-e02ebdbc27cf)



