### PR TITLE
Load server name and icon from settings

### DIFF
--- a/web/src/components/UserBanner.tsx
+++ b/web/src/components/UserBanner.tsx
@@ -5,6 +5,9 @@ import { authServiceClient } from "@/grpcweb";
 import useCurrentUser from "@/hooks/useCurrentUser";
 import useNavigateTo from "@/hooks/useNavigateTo";
 import { Routes } from "@/router";
+import { useWorkspaceSettingStore } from "@/store/v1";
+import { WorkspaceGeneralSetting } from "@/types/proto/api/v1/workspace_setting_service";
+import { WorkspaceSettingKey } from "@/types/proto/store/workspace_setting";
 import { useTranslate } from "@/utils/i18n";
 import UserAvatar from "./UserAvatar";
 
@@ -17,8 +20,11 @@ const UserBanner = (props: Props) => {
   const t = useTranslate();
   const navigateTo = useNavigateTo();
   const user = useCurrentUser();
-  const title = user ? user.nickname || user.username : "Memos";
-  const avatarUrl = user ? user.avatarUrl : "/full-logo.webp";
+  const workspaceSettingStore = useWorkspaceSettingStore();
+  const workspaceGeneralSetting =
+    workspaceSettingStore.getWorkspaceSettingByKey(WorkspaceSettingKey.GENERAL).generalSetting || WorkspaceGeneralSetting.fromPartial({});
+  const title = user ? user.nickname || user.username : workspaceGeneralSetting.customProfile?.title;
+  const avatarUrl = user ? user.avatarUrl : workspaceGeneralSetting.customProfile?.logoUrl;
 
   const handleSignOut = async () => {
     await authServiceClient.signOut({});


### PR DESCRIPTION
Display the saved server name and icon to unregistered users viewing the explore page as per issue https://github.com/usememos/memos/issues/3904

Testing:

Fresh signup page
![sign up](https://github.com/user-attachments/assets/3f9b9584-e5cb-4253-b1a7-8e3cad43f774)

Setting only server name
![no icon](https://github.com/user-attachments/assets/8b585e04-c83c-4d1a-bbbe-ef5a397d2793)

Signin page with new server name and default image
![signin no icon](https://github.com/user-attachments/assets/6081b743-d479-4145-a857-82214e2c8fe1)

Explore page when unregistered without icon set
![explore no icon](https://github.com/user-attachments/assets/481f0401-5ddd-4859-99a1-66f139ec66a5)

Setting server icon
![settings with icon](https://github.com/user-attachments/assets/05146eb1-37ce-4c13-9074-375c6e9ca3d2)

Signin page with new server name and icon
![login with icon](https://github.com/user-attachments/assets/1db75207-94b3-4a48-91ff-a6ff546b6c0b)

Explore page when unregistered with icon set
![explore with icon](https://github.com/user-attachments/assets/ef3496dc-2c7e-48cb-a0c1-65c02584707a)

