### PR TITLE
fix: fixed the block layout in compact mode on iOS/MacOS

### DIFF
--- a/web/src/components/MemoContent/index.tsx
+++ b/web/src/components/MemoContent/index.tsx
@@ -7,6 +7,7 @@ import { useTranslate } from "@/utils/i18n";
 import { isSuperUser } from "@/utils/user";
 import Renderer from "./Renderer";
 import { RendererContext } from "./types";
+import "@/less/content-compact.less";
 
 // MAX_DISPLAY_HEIGHT is the maximum height of the memo content to display in compact mode.
 const MAX_DISPLAY_HEIGHT = 256;
@@ -80,7 +81,7 @@ const MemoContent: React.FC<Props> = (props: Props) => {
           ref={memoContentContainerRef}
           className={clsx(
             "w-full max-w-full word-break text-base leading-snug space-y-2 whitespace-pre-wrap",
-            showCompactMode && "line-clamp-6",
+            showCompactMode && "max-h-[256px] overflow-y-hidden content-compact--shadow",
             contentClassName,
           )}
           onClick={handleMemoContentClick}

--- a/web/src/less/content-compact.less
+++ b/web/src/less/content-compact.less
@@ -1,0 +1,3 @@
+.content-compact--shadow {
+    mask-image: linear-gradient(to bottom, black 75%, transparent 100%);
+}


### PR DESCRIPTION
When using `compact mode`, layout display is abnormal on **iOS browsers (Safari and latest Chrome) and macOS Safari** when the folded content contains code blocks. Use `mask-image` instead of `-webkit-line-clamp`.

Issue eg:
MacOS Safari
![Snipaste_2024-09-16_03-04-41](https://github.com/user-attachments/assets/52a5d5cf-2137-492e-8f51-5a7d61dbb7fc)

iOS Chrome120
![2024-09-16 03 08 04](https://github.com/user-attachments/assets/dd7f981d-174a-439b-a4ad-6ef9718c4952)

**After:**
![SmartSelect_20240917_070810_Chrome](https://github.com/user-attachments/assets/6ea53989-cdc0-4da4-96b4-3ea5b038016b)
![SmartSelect_20240917_070722_Chrome](https://github.com/user-attachments/assets/1006d069-38ef-446e-84ce-84641b8bbf61)


