### PR TITLE
buf: specify version of stephenh-ts-proto plugin

### DIFF
--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -22,7 +22,7 @@ plugins:
     out: ../docs
     opt: output_format=yaml,allow_merge=true
   # Build the TypeScript definitions for the web.
-  - plugin: buf.build/community/stephenh-ts-proto
+  - plugin: buf.build/community/stephenh-ts-proto:v1.178.0
     out: ../web/src/types/proto
     # reference: https://github.com/deeplay-io/nice-grpc/blob/master/packages/nice-grpc-web/README.md#using-ts-proto
     opt:


### PR DESCRIPTION
Hi there - I was trying to build this locally, and with docker, and kept receiving errors during `pnpm build`:

```
src/types/proto/store/workspace_setting.ts:8:44 - error TS2307: Cannot find module '@bufbuild/protobuf/wire' or its corresponding type declarations.
```

While digging through everything - it looks like the plugins used by `buf` aren't tracked by any package managers/lockfiles/etc, it seems like `buf` pulls them in dynamically.

Looking at https://buf.build/community/stephenh-ts-proto?version=v2.2.0 - it looks like v2.2.0 came out September 19th and I suspect it generates code that's incompatible with something, because when I changed the buf.gen.yaml file to reference a specific version (the previous one listed) - everything compiles without issue.

I'm guessing there's some dependency that can be updated somewhere to enable stephenh-ts-proto v2+ but in the meantime, seems like it's a good idea to specify plugin versions to known-good versions.

Not sure if the other plugins need to receive the same treatment? I'll be honest, I'm way outside my area of expertise, I just wanted to build the app.