### PR TITLE
feat: add tag count to tree view

### DIFF
--- a/web/src/components/HomeSidebar/TagsSection.tsx
+++ b/web/src/components/HomeSidebar/TagsSection.tsx
@@ -86,7 +86,7 @@ const TagsSection = (props: Props) => {
       </div>
       {tagAmounts.length > 0 ? (
         treeMode ? (
-          <TagTree tags={tagAmounts.map((t) => t[0])} />
+          <TagTree tags={tagAmounts} />
         ) : (
           <div className="w-full flex flex-row justify-start items-center relative flex-wrap gap-x-2 gap-y-1">
             {tagAmounts.map(([tag, amount]) => (

--- a/web/src/components/HomeSidebar/TagsSection.tsx
+++ b/web/src/components/HomeSidebar/TagsSection.tsx
@@ -86,7 +86,7 @@ const TagsSection = (props: Props) => {
       </div>
       {tagAmounts.length > 0 ? (
         treeMode ? (
-          <TagTree tags={tagAmounts} />
+          <TagTree tagAmounts={tagAmounts} />
         ) : (
           <div className="w-full flex flex-row justify-start items-center relative flex-wrap gap-x-2 gap-y-1">
             {tagAmounts.map(([tag, amount]) => (

--- a/web/src/components/TagTree.tsx
+++ b/web/src/components/TagTree.tsx
@@ -6,11 +6,12 @@ import { useMemoFilterStore } from "@/store/v1";
 interface Tag {
   key: string;
   text: string;
+  amount: string;
   subTags: Tag[];
 }
 
 interface Props {
-  tags: string[];
+  tags: [string, number][];
 }
 
 const TagTree = ({ tags: rawTags }: Props) => {
@@ -21,13 +22,15 @@ const TagTree = ({ tags: rawTags }: Props) => {
     const root: Tag = {
       key: "",
       text: "",
+      amount: "",
       subTags: [],
     };
 
     for (const tag of sortedTags) {
-      const subtags = tag.split("/");
+      const subtags = tag[0].split("/");
       let tempObj = root;
       let tagText = "";
+      let tagAmountText = "";
 
       for (let i = 0; i < subtags.length; i++) {
         const key = subtags[i];
@@ -35,6 +38,9 @@ const TagTree = ({ tags: rawTags }: Props) => {
           tagText += key;
         } else {
           tagText += "/" + key;
+        }
+        if (sortedTags.some((x) => x[0] == tagText)) {
+          tagAmountText = `(${tag[1]})`;
         }
 
         let obj = null;
@@ -50,6 +56,7 @@ const TagTree = ({ tags: rawTags }: Props) => {
           obj = {
             key,
             text: tagText,
+            amount: tagAmountText,
             subTags: [],
           };
           tempObj.subTags.push(obj);
@@ -111,7 +118,7 @@ const TagItemContainer: React.FC<TagItemContainerProps> = (props: TagItemContain
             <HashIcon className="w-4 h-auto shrink-0 mr-1 text-gray-400 dark:text-gray-500" />
           </div>
           <span className="truncate cursor-pointer hover:opacity-80" onClick={handleTagClick}>
-            {tag.key}
+            {tag.key} {tag.amount}
           </span>
         </div>
         <div className="flex flex-row justify-end items-center">

--- a/web/src/components/TagTree.tsx
+++ b/web/src/components/TagTree.tsx
@@ -6,7 +6,7 @@ import { useMemoFilterStore } from "@/store/v1";
 interface Tag {
   key: string;
   text: string;
-  amount: string;
+  amountDisplay: string;
   subTags: Tag[];
 }
 
@@ -22,7 +22,7 @@ const TagTree = ({ tags: rawTags }: Props) => {
     const root: Tag = {
       key: "",
       text: "",
-      amount: "",
+      amountDisplay: "",
       subTags: [],
     };
 
@@ -57,7 +57,7 @@ const TagTree = ({ tags: rawTags }: Props) => {
           obj = {
             key,
             text: tagText,
-            amount: tagAmountText,
+            amountDisplay: tagAmountText,
             subTags: [],
           };
           tempObj.subTags.push(obj);
@@ -119,7 +119,7 @@ const TagItemContainer: React.FC<TagItemContainerProps> = (props: TagItemContain
             <HashIcon className="w-4 h-auto shrink-0 mr-1 text-gray-400 dark:text-gray-500" />
           </div>
           <span className="truncate cursor-pointer hover:opacity-80" onClick={handleTagClick}>
-            {tag.key} {tag.amount}
+            {tag.key} {tag.amountDisplay}
           </span>
         </div>
         <div className="flex flex-row justify-end items-center">

--- a/web/src/components/TagTree.tsx
+++ b/web/src/components/TagTree.tsx
@@ -30,16 +30,17 @@ const TagTree = ({ tags: rawTags }: Props) => {
       const subtags = tag[0].split("/");
       let tempObj = root;
       let tagText = "";
-      let tagAmountText = "";
 
       for (let i = 0; i < subtags.length; i++) {
         const key = subtags[i];
+        let tagAmountText = "";
+
         if (i === 0) {
           tagText += key;
         } else {
           tagText += "/" + key;
         }
-        if (sortedTags.some((x) => x[0] == tagText)) {
+        if (sortedTags.some((x) => x[0] === tagText && x[1] > 1)) {
           tagAmountText = `(${tag[1]})`;
         }
 

--- a/web/src/components/TagTree.tsx
+++ b/web/src/components/TagTree.tsx
@@ -6,42 +6,42 @@ import { useMemoFilterStore } from "@/store/v1";
 interface Tag {
   key: string;
   text: string;
-  amountDisplay: string;
+  amount: number;
   subTags: Tag[];
 }
 
 interface Props {
-  tags: [string, number][];
+  tagAmounts: [tag: string, amount: number][];
 }
 
-const TagTree = ({ tags: rawTags }: Props) => {
+const TagTree = ({ tagAmounts: rawTagAmounts }: Props) => {
   const [tags, setTags] = useState<Tag[]>([]);
 
   useEffect(() => {
-    const sortedTags = Array.from(rawTags).sort();
+    const sortedTagAmounts = Array.from(rawTagAmounts).sort();
     const root: Tag = {
       key: "",
       text: "",
-      amountDisplay: "",
+      amount: 0,
       subTags: [],
     };
 
-    for (const tag of sortedTags) {
-      const subtags = tag[0].split("/");
+    for (const tagAmount of sortedTagAmounts) {
+      const subtags = tagAmount[0].split("/");
       let tempObj = root;
       let tagText = "";
 
       for (let i = 0; i < subtags.length; i++) {
         const key = subtags[i];
-        let tagAmountText = "";
+        let amount: number = 0;
 
         if (i === 0) {
           tagText += key;
         } else {
           tagText += "/" + key;
         }
-        if (sortedTags.some((x) => x[0] === tagText && x[1] > 1)) {
-          tagAmountText = `(${tag[1]})`;
+        if (sortedTagAmounts.some(([tag, amount]) => tag === tagText && amount > 1)) {
+          amount = tagAmount[1];
         }
 
         let obj = null;
@@ -57,7 +57,7 @@ const TagTree = ({ tags: rawTags }: Props) => {
           obj = {
             key,
             text: tagText,
-            amountDisplay: tagAmountText,
+            amount: amount,
             subTags: [],
           };
           tempObj.subTags.push(obj);
@@ -68,7 +68,7 @@ const TagTree = ({ tags: rawTags }: Props) => {
     }
 
     setTags(root.subTags as Tag[]);
-  }, [rawTags]);
+  }, [rawTagAmounts]);
 
   return (
     <div className="flex flex-col justify-start items-start relative w-full h-auto flex-nowrap gap-2 mt-1">
@@ -119,7 +119,7 @@ const TagItemContainer: React.FC<TagItemContainerProps> = (props: TagItemContain
             <HashIcon className="w-4 h-auto shrink-0 mr-1 text-gray-400 dark:text-gray-500" />
           </div>
           <span className="truncate cursor-pointer hover:opacity-80" onClick={handleTagClick}>
-            {tag.key} {tag.amountDisplay}
+            {tag.key} {tag.amount > 1 && `(${tag.amount})`}
           </span>
         </div>
         <div className="flex flex-row justify-end items-center">


### PR DESCRIPTION
As per issue https://github.com/usememos/memos/issues/3947#issuecomment-2381853439 the tag list does not show usage numbers in tree view. This PR aims to add usage numbers

Design decisions:
Parent nodes only has a number next to them if they are uniquely used, they do not contain the sum of their child nodes

Examples:
![image](https://github.com/user-attachments/assets/a0960af0-f09b-4c31-883a-dd13d742dd52)

Notes from the above:
- Parent1 has no direct reference so no usage number is displayed
- Parent2 has a direct reference so a usage number is displayed
- Parent3 child1 has no direct reference so no usage number is displayed
- Parent2 child1 has a direct reference so a usage number is displayed