### PR TITLE
Allow single letter user id.

### DIFF
--- a/internal/util/resource_name.go
+++ b/internal/util/resource_name.go
@@ -3,5 +3,5 @@ package util
 import "regexp"
 
 var (
-	UIDMatcher = regexp.MustCompile("^[a-zA-Z0-9]([a-zA-Z0-9-]{1,30}[a-zA-Z0-9])$")
+	UIDMatcher = regexp.MustCompile("^[a-zA-Z0-9]([a-zA-Z0-9-]{1,30}[a-zA-Z0-9])?$")
 )


### PR DESCRIPTION
They do work - I use one (by login using Authelia), but then I am not able to update the profile to update avatar or add comment because "Invalid username: r" errors.

I don't know `go` at all, so not sure how to add proper test for this.