### PR TITLE
fix: apply system theme dynamically

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,10 +34,8 @@ const App = () => {
   useEffect(() => {
     const darkMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     const handleColorSchemeChange = (e: MediaQueryListEvent) => {
-      if (commonContext.appearance === "system") {
-        const mode = e.matches ? "dark" : "light";
-        setMode(mode);
-      }
+      const mode = e.matches ? "dark" : "light";
+      setMode(mode);
     };
 
     try {


### PR DESCRIPTION
As per issue https://github.com/usememos/memos/issues/4005 when toggling the operating system them between light and dark mode the web UI only takes effect after page reload

This PR allows for the them to change as the operating system theme changes without refreshing the page

e.g. 
Dark
![image](https://github.com/user-attachments/assets/e323c1ff-d137-497a-bea3-a220eb32e4bd)

Light
![image](https://github.com/user-attachments/assets/7f810179-033c-4a28-82be-7690f814318c)

This change work with Browser theme settings as well