### PR TITLE
Allow screen scrollbar to scroll  tag contrainer

### DIFF
--- a/web/src/components/ExploreSidebar/ExploreSidebar.tsx
+++ b/web/src/components/ExploreSidebar/ExploreSidebar.tsx
@@ -26,7 +26,7 @@ const ExploreSidebar = (props: Props) => {
   return (
     <aside
       className={clsx(
-        "relative w-full h-auto max-h-screen overflow-auto hide-scrollbar flex flex-col justify-start items-start",
+        "relative w-full h-auto overflow-auto hide-scrollbar flex flex-col justify-start items-start",
         props.className,
       )}
     >

--- a/web/src/components/ExploreSidebar/ExploreSidebar.tsx
+++ b/web/src/components/ExploreSidebar/ExploreSidebar.tsx
@@ -24,12 +24,7 @@ const ExploreSidebar = (props: Props) => {
   );
 
   return (
-    <aside
-      className={clsx(
-        "relative w-full h-auto overflow-auto hide-scrollbar flex flex-col justify-start items-start",
-        props.className,
-      )}
-    >
+    <aside className={clsx("relative w-full h-auto overflow-auto hide-scrollbar flex flex-col justify-start items-start", props.className)}>
       <SearchBar />
       <TagsSection readonly={true} />
     </aside>

--- a/web/src/components/HomeSidebar/HomeSidebar.tsx
+++ b/web/src/components/HomeSidebar/HomeSidebar.tsx
@@ -28,7 +28,7 @@ const HomeSidebar = (props: Props) => {
   return (
     <aside
       className={clsx(
-        "relative w-full h-auto max-h-screen overflow-auto hide-scrollbar flex flex-col justify-start items-start",
+        "relative w-full h-auto overflow-auto hide-scrollbar flex flex-col justify-start items-start",
         props.className,
       )}
     >

--- a/web/src/components/HomeSidebar/HomeSidebar.tsx
+++ b/web/src/components/HomeSidebar/HomeSidebar.tsx
@@ -26,12 +26,7 @@ const HomeSidebar = (props: Props) => {
   );
 
   return (
-    <aside
-      className={clsx(
-        "relative w-full h-auto overflow-auto hide-scrollbar flex flex-col justify-start items-start",
-        props.className,
-      )}
-    >
+    <aside className={clsx("relative w-full h-auto overflow-auto hide-scrollbar flex flex-col justify-start items-start", props.className)}>
       <SearchBar />
       <UserStatisticsView />
       <TagsSection />

--- a/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
+++ b/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
@@ -15,12 +15,7 @@ const MemoDetailSidebar = ({ memo, className }: Props) => {
   const hasSpecialProperty = property.hasLink || property.hasTaskList || property.hasCode || property.hasIncompleteTasks;
 
   return (
-    <aside
-      className={clsx(
-        "relative w-full h-auto overflow-auto hide-scrollbar flex flex-col justify-start items-start",
-        className,
-      )}
-    >
+    <aside className={clsx("relative w-full h-auto overflow-auto hide-scrollbar flex flex-col justify-start items-start", className)}>
       <div className="flex flex-col justify-start items-start w-full mt-1 px-1 gap-2 h-auto shrink-0 flex-nowrap hide-scrollbar">
         <div className="w-full flex flex-col">
           <p className="flex flex-row justify-start items-center w-full gap-1 mb-1 text-sm leading-6 text-gray-400 dark:text-gray-500 select-none">

--- a/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
+++ b/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
@@ -17,7 +17,7 @@ const MemoDetailSidebar = ({ memo, className }: Props) => {
   return (
     <aside
       className={clsx(
-        "relative w-full h-auto max-h-screen overflow-auto hide-scrollbar flex flex-col justify-start items-start",
+        "relative w-full h-auto overflow-auto hide-scrollbar flex flex-col justify-start items-start",
         className,
       )}
     >


### PR DESCRIPTION
Currently (on a 1080p screen) you can only see the top 17 tags. The side navigation does not allow for you to scroll further down the list. You need to click on the side navigation and use the keyboard arrows to navigate down the list.

This PR is to allow for the main page scrollbar to scroll the tag list content as well

Current state:
Heavy tagged memo shows only 17 tags
![Screenshot from 2024-10-12 23-07-12](https://github.com/user-attachments/assets/bd71f1b3-4a58-4358-9c56-4dcb5338e67c)

Many memos with unique tags shows only 17 tags
![Screenshot from 2024-10-12 23-12-47](https://github.com/user-attachments/assets/1de0b131-68bc-4a7a-bde2-4cd0ad51c1d8)

PR state:
Heavy tagged memo shows all tags on scroll
![Screenshot from 2024-10-12 23-08-46](https://github.com/user-attachments/assets/5ce7822f-0307-48b7-b04c-be25a8992e75)

Many memos with unique tags shows all tags on scroll
![Screenshot from 2024-10-12 23-13-34](https://github.com/user-attachments/assets/20517027-4f23-4bae-b856-91e62d02c53e)
