### PR TITLE
fix: use UTC date for calendar filter

### DIFF
--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -34,7 +34,9 @@ const Home = () => {
       } else if (filter.factor === "property.hasCode") {
         filters.push(`has_code == true`);
       } else if (filter.factor === "displayTime") {
-        const timestampAfter = new Date(filter.value).getTime() / 1000;
+        const filterDate = new Date(filter.value);
+        const filterUtcTimestamp = filterDate.getTime() + filterDate.getTimezoneOffset() * 60 * 1000;
+        const timestampAfter = filterUtcTimestamp / 1000;
         filters.push(`display_time_after == ${timestampAfter}`);
         filters.push(`display_time_before == ${timestampAfter + 60 * 60 * 24}`);
       }


### PR DESCRIPTION
As per issue: https://github.com/usememos/memos/issues/2765#issuecomment-2431346655

Memos are stored with a UTC timestamp. When the calendar dates are selected the UTC offset is not used to create the timestamps between which the memo creation date should fall.

e.g. of incorrect memos being shown
![image](https://github.com/user-attachments/assets/a0bd9461-ea2f-486d-8194-2e4e64c9d072)
![image](https://github.com/user-attachments/assets/921195c2-3979-4e4c-8571-d2c6072cbe89)
![image](https://github.com/user-attachments/assets/8f1518b5-5de4-4d91-8b63-7fe9cf54053f)


This PR aims to include the UTC offset in filter dates


e.g. of correct memos being shown
![image](https://github.com/user-attachments/assets/7f913715-02ef-4ca9-8193-d3e80ff0dc78)
![image](https://github.com/user-attachments/assets/aa0df5ea-4341-4cbf-90e8-aa2f86d3b80c)
![image](https://github.com/user-attachments/assets/236a8fa0-cdd0-4a27-af2b-38894cd51492)






