### PR TITLE
fix: automatic indentation follows previous lines in lists (#4048)

### DIFF
--- a/web/src/components/MemoEditor/Editor/index.tsx
+++ b/web/src/components/MemoEditor/Editor/index.tsx
@@ -158,13 +158,19 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
 
       const cursorPosition = editorActions.getCursorPosition();
       const prevContent = editorActions.getContent().substring(0, cursorPosition);
+      const lines = prevContent.split("\n");
+      const lastLine = lines[lines.length - 1];
+
+      // Get the indentation of the previous line
+      const indentationMatch = lastLine.match(/^\s*/);
+      const indentation = indentationMatch ? indentationMatch[0] : "";
       const { nodes } = await markdownServiceClient.parseMarkdown({ markdown: prevContent });
       const lastNode = last(last(nodes)?.listNode?.children);
       if (!lastNode) {
         return;
       }
 
-      let insertText = "";
+      let insertText = indentation; // Keep the indentation of the previous line
       if (lastNode.type === NodeType.TASK_LIST_ITEM) {
         const { symbol } = lastNode.taskListItemNode as TaskListItemNode;
         insertText = `${symbol} [ ] `;

--- a/web/src/components/MemoEditor/Editor/index.tsx
+++ b/web/src/components/MemoEditor/Editor/index.tsx
@@ -158,19 +158,17 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
 
       const cursorPosition = editorActions.getCursorPosition();
       const prevContent = editorActions.getContent().substring(0, cursorPosition);
-      const lines = prevContent.split("\n");
-      const lastLine = lines[lines.length - 1];
-
-      // Get the indentation of the previous line
-      const indentationMatch = lastLine.match(/^\s*/);
-      const indentation = indentationMatch ? indentationMatch[0] : "";
       const { nodes } = await markdownServiceClient.parseMarkdown({ markdown: prevContent });
       const lastNode = last(last(nodes)?.listNode?.children);
       if (!lastNode) {
         return;
       }
 
-      let insertText = indentation; // Keep the indentation of the previous line
+      // Get the indentation of the previous line
+      const lines = prevContent.split("\n");
+      const lastLine = lines[lines.length - 1];
+      const indentationMatch = lastLine.match(/^\s*/);
+      let insertText = indentationMatch ? indentationMatch[0] : ""; // Keep the indentation of the previous line
       if (lastNode.type === NodeType.TASK_LIST_ITEM) {
         const { symbol } = lastNode.taskListItemNode as TaskListItemNode;
         insertText = `${symbol} [ ] `;


### PR DESCRIPTION
This PR fixes the issue where new list items do not inherit the indentation level of the previous item. Now, when pressing the Enter key in a list, the new line will have the same indentation as the previous line.