### PR TITLE
migration version

### DIFF
--- a/store/migrator.go
+++ b/store/migrator.go
@@ -242,7 +242,7 @@ func (s *Store) getSchemaVersionOfMigrateScript(filePath string) (string, error)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to convert patch version to int: %s", rawPatchVersion)
 	}
-	return fmt.Sprintf("%s.%d", minorVersion, patchVersion+1), nil
+	return fmt.Sprintf("%s.%d", minorVersion, patchVersion), nil
 }
 
 // execute runs a single SQL statement within a transaction.


### PR DESCRIPTION
as per https://github.com/usememos/memos/issues/4060 the `00__reactions.sql` migration for `v0.23` does not run when you start with a fresh install

`GetCurrentSchemaVersion` get the current version (`v0.23`) and passes it into the migration logic. `getSchemaVersionOfMigrateScript` then increases the minor version so the version is `v0.23.1` and because of this the migration files to run are not found.

From debugging and testing this change work, but I'm not confident how it will affect already running version that upgrade to the latest. Some insights from someone with a deeper understanding of how the migrations system works would be appreciated.