### PR TITLE
feat: navigate image view with keyboard keys

### DIFF
--- a/store/db/mysql/memo.go
+++ b/store/db/mysql/memo.go
@@ -92,7 +92,7 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 		}
 		if len(v.TagSearch) != 0 {
 			for _, tag := range v.TagSearch {
-				where, args = append(where, "(JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.property.tags'), ?) OR JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.property.tags'), ?))"), append(args, fmt.Sprintf(`"%s"`, tag), fmt.Sprintf(`"%s/`, tag))
+				where, args = append(where, "(JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.property.tags'), ?) OR JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.property.tags'), ?))"), append(args, fmt.Sprintf(`"%s"`, tag), fmt.Sprintf(`"%s/"`, tag))
 			}
 		}
 		if v.HasLink {

--- a/store/db/mysql/memo.go
+++ b/store/db/mysql/memo.go
@@ -92,7 +92,7 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 		}
 		if len(v.TagSearch) != 0 {
 			for _, tag := range v.TagSearch {
-				where, args = append(where, "(JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.property.tags'), ?) OR JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.property.tags'), ?))"), append(args, fmt.Sprintf(`"%s"`, tag), fmt.Sprintf(`"%s/"`, tag))
+				where, args = append(where, "(JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.property.tags'), ?) OR JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.property.tags'), ?))"), append(args, fmt.Sprintf(`"%s"`, tag), fmt.Sprintf(`"%s/`, tag))
 			}
 		}
 		if v.HasLink {

--- a/web/src/components/PreviewImageDialog.tsx
+++ b/web/src/components/PreviewImageDialog.tsx
@@ -97,8 +97,7 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
   const handleImageContainerKeyDown = (event: KeyboardEvent) => {
     if (event.key == "ArrowLeft") {
       showPrevImg();
-    }
-    else if (event.key == "ArrowRight") {
+    } else if (event.key == "ArrowRight") {
       showNextImg();
     }
   };
@@ -150,7 +149,7 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
     document.addEventListener("keydown", handleImageContainerKeyDown);
     return () => {
       document.removeEventListener("keydown", handleImageContainerKeyDown);
-    }
+    };
   }, [currentIndex]);
 
   return (

--- a/web/src/components/PreviewImageDialog.tsx
+++ b/web/src/components/PreviewImageDialog.tsx
@@ -94,6 +94,15 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
     }
   };
 
+  const handleImageContainerKeyDown = (event: KeyboardEvent) => {
+    if (event.key == "ArrowLeft") {
+      showPrevImg();
+    }
+    else if (event.key == "ArrowRight") {
+      showNextImg();
+    }
+  };
+
   const handleImgContainerScroll = (event: React.WheelEvent) => {
     const offsetX = event.nativeEvent.offsetX;
     const offsetY = event.nativeEvent.offsetY;
@@ -136,6 +145,13 @@ const PreviewImageDialog: React.FC<Props> = ({ destroy, imgUrls, initialIndex }:
   useEffect(() => {
     setViewportScalable();
   }, []);
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleImageContainerKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleImageContainerKeyDown);
+    }
+  }, [currentIndex]);
 
   return (
     <>


### PR DESCRIPTION
Issue: https://github.com/usememos/memos/issues/4024

This PR is to allow for navigating between images using the `left` and `right` keyboard keys when viewed in the image dialog.

Build decisions:
- Because the dialog does not have an input the event listener had to be added to `document` for the keys to fire the events.
- Due to the listener being on `document` it is outside of the component scope so the state does not get updated on key pressed. According to [this](https://stackoverflow.com/a/53846698) article there are a couple of ways around it. I chose event listener re-registration so that I did not need to keep 2 sets of state in sync (one foe keyboard, one for mouse) and existing functionality could be used.