### PR TITLE
Added charset that allow for emojis

### DIFF
--- a/store/migration/mysql/dev/LATEST.sql
+++ b/store/migration/mysql/dev/LATEST.sql
@@ -1,3 +1,8 @@
+-- Set character set and collation to MySQL recommended default
+ALTER DATABASE `memos_prod`
+DEFAULT CHARACTER SET utf8mb4
+DEFAULT COLLATE utf8mb4_0900_ai_ci;
+
 -- migration_history
 CREATE TABLE `migration_history` (
   `version` VARCHAR(256) NOT NULL PRIMARY KEY,

--- a/store/migration/mysql/dev/LATEST.sql
+++ b/store/migration/mysql/dev/LATEST.sql
@@ -7,7 +7,7 @@ CREATE TABLE `migration_history` (
 -- system_setting
 CREATE TABLE `system_setting` (
   `name` VARCHAR(256) NOT NULL PRIMARY KEY,
-  `value` LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `value` LONGTEXT NOT NULL,
   `description` TEXT NOT NULL
 );
 
@@ -127,6 +127,6 @@ CREATE TABLE `reaction` (
   `created_ts` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `creator_id` INT NOT NULL,
   `content_id` VARCHAR(256) NOT NULL,
-  `reaction_type` VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `reaction_type` VARCHAR(256) NOT NULL,
   UNIQUE(`creator_id`,`content_id`,`reaction_type`)  
 );

--- a/store/migration/mysql/dev/LATEST.sql
+++ b/store/migration/mysql/dev/LATEST.sql
@@ -1,5 +1,5 @@
 -- Set character set and collation to MySQL recommended default
-ALTER DATABASE `memos_prod`
+ALTER DATABASE
 DEFAULT CHARACTER SET utf8mb4
 DEFAULT COLLATE utf8mb4_0900_ai_ci;
 

--- a/store/migration/mysql/dev/LATEST.sql
+++ b/store/migration/mysql/dev/LATEST.sql
@@ -7,7 +7,7 @@ CREATE TABLE `migration_history` (
 -- system_setting
 CREATE TABLE `system_setting` (
   `name` VARCHAR(256) NOT NULL PRIMARY KEY,
-  `value` LONGTEXT NOT NULL,
+  `value` LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `description` TEXT NOT NULL
 );
 
@@ -127,6 +127,6 @@ CREATE TABLE `reaction` (
   `created_ts` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `creator_id` INT NOT NULL,
   `content_id` VARCHAR(256) NOT NULL,
-  `reaction_type` VARCHAR(256) NOT NULL,
+  `reaction_type` VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   UNIQUE(`creator_id`,`content_id`,`reaction_type`)  
 );

--- a/store/migration/mysql/prod/0.23/00__reactions.sql
+++ b/store/migration/mysql/prod/0.23/00__reactions.sql
@@ -1,3 +1,8 @@
+-- Set character set and collation to MySQL recommended default
+ALTER DATABASE `memos_prod`
+DEFAULT CHARACTER SET utf8mb4
+DEFAULT COLLATE utf8mb4_0900_ai_ci;
+
 UPDATE `reaction` SET `reaction_type` = '👍' WHERE `reaction_type` = 'THUMBS_UP';
 UPDATE `reaction` SET `reaction_type` = '👎' WHERE `reaction_type` = 'THUMBS_DOWN';
 UPDATE `reaction` SET `reaction_type` = '💛' WHERE `reaction_type` = 'HEART';

--- a/store/migration/mysql/prod/0.23/00__reactions.sql
+++ b/store/migration/mysql/prod/0.23/00__reactions.sql
@@ -1,5 +1,5 @@
 -- Set character set and collation to MySQL recommended default
-ALTER DATABASE `memos_prod`
+ALTER DATABASE
 DEFAULT CHARACTER SET utf8mb4
 DEFAULT COLLATE utf8mb4_0900_ai_ci;
 

--- a/store/migration/mysql/prod/0.23/01__reaction_charsets.sql
+++ b/store/migration/mysql/prod/0.23/01__reaction_charsets.sql
@@ -1,5 +1,0 @@
-ALTER TABLE memos_prod.system_setting 
-MODIFY COLUMN `value` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
-
-ALTER TABLE memos_prod.reaction 
-MODIFY COLUMN `reaction_type` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;

--- a/store/migration/mysql/prod/0.23/01__reaction_charsets.sql
+++ b/store/migration/mysql/prod/0.23/01__reaction_charsets.sql
@@ -1,0 +1,5 @@
+ALTER TABLE memos_prod.system_setting 
+MODIFY COLUMN `value` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;
+
+ALTER TABLE memos_prod.reaction 
+MODIFY COLUMN `reaction_type` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL;

--- a/store/migration/mysql/prod/LATEST.sql
+++ b/store/migration/mysql/prod/LATEST.sql
@@ -1,3 +1,8 @@
+-- Set character set and collation to MySQL recommended default
+ALTER DATABASE `memos_prod`
+DEFAULT CHARACTER SET utf8mb4
+DEFAULT COLLATE utf8mb4_0900_ai_ci;
+
 -- migration_history
 CREATE TABLE `migration_history` (
   `version` VARCHAR(256) NOT NULL PRIMARY KEY,

--- a/store/migration/mysql/prod/LATEST.sql
+++ b/store/migration/mysql/prod/LATEST.sql
@@ -7,7 +7,7 @@ CREATE TABLE `migration_history` (
 -- system_setting
 CREATE TABLE `system_setting` (
   `name` VARCHAR(256) NOT NULL PRIMARY KEY,
-  `value` LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `value` LONGTEXT NOT NULL,
   `description` TEXT NOT NULL
 );
 
@@ -127,6 +127,6 @@ CREATE TABLE `reaction` (
   `created_ts` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `creator_id` INT NOT NULL,
   `content_id` VARCHAR(256) NOT NULL,
-  `reaction_type` VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `reaction_type` VARCHAR(256) NOT NULL,
   UNIQUE(`creator_id`,`content_id`,`reaction_type`)  
 );

--- a/store/migration/mysql/prod/LATEST.sql
+++ b/store/migration/mysql/prod/LATEST.sql
@@ -1,5 +1,5 @@
 -- Set character set and collation to MySQL recommended default
-ALTER DATABASE `memos_prod`
+ALTER DATABASE
 DEFAULT CHARACTER SET utf8mb4
 DEFAULT COLLATE utf8mb4_0900_ai_ci;
 

--- a/store/migration/mysql/prod/LATEST.sql
+++ b/store/migration/mysql/prod/LATEST.sql
@@ -7,7 +7,7 @@ CREATE TABLE `migration_history` (
 -- system_setting
 CREATE TABLE `system_setting` (
   `name` VARCHAR(256) NOT NULL PRIMARY KEY,
-  `value` LONGTEXT NOT NULL,
+  `value` LONGTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `description` TEXT NOT NULL
 );
 
@@ -127,6 +127,6 @@ CREATE TABLE `reaction` (
   `created_ts` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `creator_id` INT NOT NULL,
   `content_id` VARCHAR(256) NOT NULL,
-  `reaction_type` VARCHAR(256) NOT NULL,
+  `reaction_type` VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   UNIQUE(`creator_id`,`content_id`,`reaction_type`)  
 );


### PR DESCRIPTION
As per https://github.com/usememos/memos/issues/4127, emojis are causing migration and website usage issues

MySQL required a specific charset to store emojis.
This PR adds the required charset to the field that store the full list of available emojis for reactions as well as the field that stores emoji reactions added to memos