### PR TITLE
feat: remove RSS titles

### DIFF
--- a/server/router/rss/rss.go
+++ b/server/router/rss/rss.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gorilla/feeds"
 	"github.com/labstack/echo/v4"
 	"github.com/usememos/gomark"
-	"github.com/usememos/gomark/ast"
 	"github.com/usememos/gomark/renderer"
 
 	storepb "github.com/usememos/memos/proto/gen/store"
@@ -20,8 +18,7 @@ import (
 )
 
 const (
-	maxRSSItemCount       = 100
-	maxRSSItemTitleLength = 128
+	maxRSSItemCount = 100
 )
 
 type RSSService struct {
@@ -112,7 +109,6 @@ func (s *RSSService) generateRSSFromMemoList(ctx context.Context, memoList []*st
 			return "", err
 		}
 		feed.Items[i] = &feeds.Item{
-			Title:       getRSSItemTitle(memo.Content),
 			Link:        &feeds.Link{Href: baseURL + "/m/" + memo.UID},
 			Description: description,
 			Created:     time.Unix(memo.CreatedTs, 0),
@@ -142,22 +138,6 @@ func (s *RSSService) generateRSSFromMemoList(ctx context.Context, memoList []*st
 		return "", err
 	}
 	return rss, nil
-}
-
-func getRSSItemTitle(content string) string {
-	nodes, _ := gomark.Parse(content)
-	if len(nodes) > 0 {
-		firstNode := nodes[0]
-		title := renderer.NewStringRenderer().Render([]ast.Node{firstNode})
-		return title
-	}
-
-	title := strings.Split(content, "\n")[0]
-	var titleLengthLimit = min(len(title), maxRSSItemTitleLength)
-	if titleLengthLimit < len(title) {
-		title = title[:titleLengthLimit] + "..."
-	}
-	return title
 }
 
 func getRSSItemDescription(content string) (string, error) {


### PR DESCRIPTION
Hi folks, the long and duplicate titles in Memos RSS feeds have been a nuissance in an otherwise superlative app for me, so I figured I'd roll my sleeves up and help out 😊 What do you think?

---

This PR removes the content of the `<title>` element in the RSS feeds that Memo produces.

**Why remove?** Every RSS client I can find shows the `<title>` next to the `<description>` when viewing an item. This creates a duplicate (but often trimmed, so less useful) version of `<description>` right above the actual text the user wants to read (often in a much larger font). It similarly makes lists of items in some clients extremely tall, as 128 characters is a lot of hard-to-read text — especially when Memos renders links as their URL in titles.

**Why an empty tag?** The RSS 1.0 and 2.0 specs require that a `<title>` element is present.

Examples from elsewhere:
- micro.blog uses an empty `<title />` element: [example](https://www.manton.org/feed.xml)
- Bluesky omits the `<title>` element: [example](https://bsky.app/profile/did%3Aplc%3Aqvzn322kmcvd7xtnips5xaun/rss)
- Mastodon omits the <title> element: [example](https://mastodon.social/@scalzi.rss)