### PR TITLE
Added show less action and language files

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -109,6 +109,7 @@
     "no-archived-memos": "No archived memos.",
     "search-placeholder": "Search memos",
     "show-more": "Show more",
+    "show-less": "Show less",
     "view-detail": "View Detail",
     "visibility": {
       "disabled": "Public memos are disabled",

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -99,6 +99,7 @@
     "no-archived-memos": "No hay memos archivados.",
     "search-placeholder": "Buscar memos",
     "show-more": "Mostrar más",
+    "show-less": "Mostrar menos",
     "view-detail": "Ver detalles",
     "visibility": {
       "disabled": "Los memos públicos están deshabilitados",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -111,6 +111,7 @@
     "no-archived-memos": "Pas de memos archivés.",
     "search-placeholder": "Recherche de memos",
     "show-more": "Afficher plus",
+    "show-less": "Afficher moins",
     "to-do": "À faire",
     "view-detail": "Voir le détail",
     "visibility": {

--- a/web/src/locales/hu.json
+++ b/web/src/locales/hu.json
@@ -107,6 +107,7 @@
     "no-archived-memos": "Nincsenek archivált jegyzetek.",
     "search-placeholder": "Jegyzetek keresése",
     "show-more": "Több mutatása",
+    "show-less": "Mutass kevesebbet",
     "view-detail": "Részletek",
     "visibility": {
       "disabled": "A nyilvános jegyzetek le vannak tiltva",

--- a/web/src/locales/id.json
+++ b/web/src/locales/id.json
@@ -109,6 +109,7 @@
     "no-archived-memos": "Tidak ada memo yang diarsipkan.",
     "search-placeholder": "Cari memo",
     "show-more": "Tampilkan lebih banyak",
+    "show-less": "Tampilkan lebih sedikit",
     "view-detail": "Lihat Detail",
     "visibility": {
       "disabled": "Memo publik dinonaktifkan",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -111,6 +111,7 @@
     "no-archived-memos": "アーカイブされたメモはありません。",
     "search-placeholder": "メモを検索",
     "show-more": "続きを見る",
+    "show-less": "表示を少なくする",
     "to-do": "To-do",
     "view-detail": "詳細を見る",
     "visibility": {

--- a/web/src/locales/ka-GE.json
+++ b/web/src/locales/ka-GE.json
@@ -109,6 +109,7 @@
     "no-archived-memos": "დაარქივებული მემოები არ არის.",
     "search-placeholder": "მემოების ძიება",
     "show-more": "მეტის ჩვენება",
+    "show-less": "ნაკლების ჩვენება",
     "view-detail": "დეტალების ნახვა",
     "visibility": {
       "disabled": "საჯარო მემოები გამორთულია",

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -96,6 +96,7 @@
     "no-archived-memos": "보관처리된 메모가 없습니다.",
     "search-placeholder": "메모 검색하기",
     "show-more": "더보기",
+    "show-less": "간략히 보기",
     "view-detail": "자세히 보기",
     "visibility": {
       "disabled": "공개 메모는 비활성화됨",

--- a/web/src/locales/mr.json
+++ b/web/src/locales/mr.json
@@ -109,6 +109,7 @@
     "no-archived-memos": "कोणतेही संग्रहित मेमो नाहीत.",
     "search-placeholder": "मेमोज शोधा",
     "show-more": "अधिक दाखवा",
+    "show-less": "कमी दाखवा",
     "view-detail": "तपशील दाखवा",
     "visibility": {
       "disabled": "सार्वजनिक मेमो अक्षम केले आहेत",

--- a/web/src/locales/pl.json
+++ b/web/src/locales/pl.json
@@ -108,6 +108,7 @@
     "no-archived-memos": "Brak zarchiwizowanych notatek.",
     "search-placeholder": "Szukaj notatek",
     "show-more": "Pokaż więcej",
+    "show-less": "Pokaż mniej",
     "view-detail": "Zobacz szczegóły",
     "visibility": {
       "disabled": "Publiczne notatki są wyłączone",

--- a/web/src/locales/pt-BR.json
+++ b/web/src/locales/pt-BR.json
@@ -111,6 +111,7 @@
     "no-archived-memos": "Nenhum memo arquivado.",
     "search-placeholder": "Pesquisar memos",
     "show-more": "Mostrar mais",
+    "show-less": "Mostrar menos",
     "to-do": "Tarefas",
     "view-detail": "Ver detalhes",
     "visibility": {

--- a/web/src/locales/pt-PT.json
+++ b/web/src/locales/pt-PT.json
@@ -109,6 +109,7 @@
     "no-archived-memos": "Não existem memos arquivados.",
     "search-placeholder": "Pesquisar memos",
     "show-more": "Mostrar mais",
+    "show-less": "Mostrar menos",
     "view-detail": "Ver detalhes",
     "visibility": {
       "disabled": "Memos públicos estão desativados",

--- a/web/src/locales/ru.json
+++ b/web/src/locales/ru.json
@@ -106,6 +106,7 @@
     "no-archived-memos": "Нет заархивированных записей.",
     "search-placeholder": "Поиск записей",
     "show-more": "Подробнее",
+    "show-less": "Показать меньше",
     "view-detail": "Подробно",
     "visibility": {
       "disabled": "Публичные записи отключены",

--- a/web/src/locales/sl.json
+++ b/web/src/locales/sl.json
@@ -109,6 +109,7 @@
     "no-archived-memos": "Ni arhiviranih beležk.",
     "search-placeholder": "Poišči beležke",
     "show-more": "Prikaži več",
+    "show-less": "Prikaži manj",
     "view-detail": "Poglej podrobnosti",
     "visibility": {
       "disabled": "Javne beležke so onemogočene",

--- a/web/src/locales/th.json
+++ b/web/src/locales/th.json
@@ -111,6 +111,7 @@
     "no-archived-memos": "ไม่มีบันทึกช่วยจำที่ถูกเก็บถาวร",
     "search-placeholder": "ค้นหาบันทึกช่วยจำ",
     "show-more": "แสดงเพิ่มเติม",
+    "show-less": "แสดงน้อยลง",
     "to-do": "สิ่งที่ต้องทำ",
     "view-detail": "ดูรายละเอียด",
     "visibility": {

--- a/web/src/locales/tr.json
+++ b/web/src/locales/tr.json
@@ -111,6 +111,7 @@
     "no-archived-memos": "Arşivlenmiş not yok.",
     "search-placeholder": "Notları ara",
     "show-more": "Daha fazlasını göster",
+    "show-less": "Daha az göster",
     "to-do": "Yapılacaklar",
     "view-detail": "Detayları görüntüle",
     "visibility": {

--- a/web/src/locales/uk.json
+++ b/web/src/locales/uk.json
@@ -109,6 +109,7 @@
       "no-archived-memos": "Немає архівованих нотаток.",
       "search-placeholder": "Пошук нотаток",
       "show-more": "Показати більше",
+      "show-less": "Показувати менше",
       "view-detail": "Переглянути деталі",
       "visibility": {
         "disabled": "Публічні нотатки вимкнені",

--- a/web/src/locales/vi.json
+++ b/web/src/locales/vi.json
@@ -109,6 +109,7 @@
     "no-archived-memos": "Không có ghi chú nào được lưu trữ.",
     "search-placeholder": "Tìm kiếm ghi chú",
     "show-more": "Hiển thị thêm",
+    "show-less": "Hiển thị ít hơn",
     "view-detail": "Xem chi tiết",
     "visibility": {
       "disabled": "Ghi chú công khai đã bị vô hiệu hóa",

--- a/web/src/locales/zh-Hans.json
+++ b/web/src/locales/zh-Hans.json
@@ -109,6 +109,7 @@
     "no-archived-memos": "没有已归档备忘录。",
     "search-placeholder": "搜索备忘录",
     "show-more": "查看更多",
+    "show-less": "显示较少",
     "view-detail": "查看详情",
     "visibility": {
       "disabled": "已禁用公开备忘录",

--- a/web/src/locales/zh-Hant.json
+++ b/web/src/locales/zh-Hant.json
@@ -111,6 +111,7 @@
     "no-archived-memos": "無封存的 Memos",
     "search-placeholder": "搜尋 Memos",
     "show-more": "查看更多",
+    "show-less": "顯示較少",
     "to-do": "待辦",
     "view-detail": "查看詳情",
     "visibility": {


### PR DESCRIPTION
As per issue https://github.com/usememos/memos/issues/4142. Currently large memos has an option to start compacted and show more, but can then not be set back to a compacted state.

This PR is to add the functionality to set an expanded memo back to a compacted state

Show more state:
![show more](https://github.com/user-attachments/assets/d622315d-c3b5-454d-ad31-5ee774fcf8d1)

Show less state:
![show less](https://github.com/user-attachments/assets/ef91f98b-71df-4661-8b4a-aff07d8c99a2)