### PR TITLE
chore: apply styles to the correct month

### DIFF
--- a/web/src/components/ActivityCalendar.tsx
+++ b/web/src/components/ActivityCalendar.tsx
@@ -84,9 +84,10 @@ const ActivityCalendar = (props: Props) => {
                 "w-6 h-6 text-xs rounded-xl flex justify-center items-center border cursor-default",
                 "text-gray-400",
                 item.isCurrentMonth ? getCellAdditionalStyles(count, maxCount) : "opacity-60",
-                isToday && "border-zinc-400",
-                isSelected && "font-bold border-zinc-400",
-                !isToday && !isSelected && "border-transparent",
+                item.isCurrentMonth && isToday && "border-zinc-400",
+                item.isCurrentMonth && isSelected && "bg-success font-bold",
+                item.isCurrentMonth && !isToday && !isSelected && "border-transparent",
+                !item.isCurrentMonth && "border-transparent",
               )}
               onClick={() => count && onClick && onClick(date)}
             >


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e1e2fb86-8ce1-4f84-a724-3782e22f87a7)

In the latest version, there's a small issue with the ActivityCalendar component where styles are being applied to the same date in the previous month. Here's some code to fix it.