### PR TITLE
Limit the size of the resource list viewer

### DIFF
--- a/web/src/components/MemoEditor/ResourceListView.tsx
+++ b/web/src/components/MemoEditor/ResourceListView.tsx
@@ -33,7 +33,7 @@ const ResourceListView = (props: Props) => {
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
       <SortableContext items={resourceList.map((resource) => resource.name)} strategy={verticalListSortingStrategy}>
         {resourceList.length > 0 && (
-          <div className="w-full flex flex-row justify-start flex-wrap gap-2 mt-2">
+          <div className="w-full flex flex-row justify-start flex-wrap gap-2 mt-2 max-h-[50vh] overflow-y-auto">
             {resourceList.map((resource) => {
               return (
                 <div


### PR DESCRIPTION
As per issue https://github.com/usememos/memos/issues/4209, when the text input area goes off screen (in this case due to a large number of images being uploaded) clicking on the `submit` button you get taken back to the text input are. this is due to the `memoEditor` `handleEditorFocus` triggering.

This PR is to try keep the text input are in focus so that clicking the `submit` button does not trigger `handleEditorFocus`

Design decisions:
The max height is the same as the max height for the text area to support large amounts of text

File upload current view
![Text input out of focus](https://github.com/user-attachments/assets/41a7c242-a2d0-4723-aca0-467c96215936)

File upload pr view
![Text input in focus](https://github.com/user-attachments/assets/419ea0b7-8220-420c-bfd4-62f80783a3c8)


