### PR TITLE
Add sh entrypoint to allow MEMOS_DSN_FILE to load variable from secret

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apk add --no-cache tzdata
 ENV TZ="UTC"
 
 COPY --from=backend /backend-build/memos /usr/local/memos/
+COPY entrypoint.sh /usr/local/memos/
 
 EXPOSE 5230
 
@@ -37,4 +38,4 @@ VOLUME /var/opt/memos
 ENV MEMOS_MODE="prod"
 ENV MEMOS_PORT="5230"
 
-ENTRYPOINT ["./memos"]
+ENTRYPOINT ["./entrypoint.sh", "./memos"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+
+file_env() {
+   var="$1"
+   fileVar="${var}_FILE"
+
+   val_var="$(printenv "$var")"
+   val_fileVar="$(printenv "$fileVar")"
+
+   if [ -n "$val_var" ] && [ -n "$val_fileVar" ]; then
+      echo "error: both $var and $fileVar are set (but are exclusive)" >&2
+      exit 1
+   fi
+
+   if [ -n "$val_var" ]; then
+      val="$val_var"
+   elif [ -n "$val_fileVar" ]; then
+      val="$(cat "$val_fileVar")"
+   fi
+
+   export "$var"="$val"
+   unset "$fileVar"
+}
+
+file_env "MEMOS_DSN"
+
+exec "$@"


### PR DESCRIPTION
Hi,

I love your software, thank you for opening it to be used.

I was wondering if you would accept a PR to use a shell entrypoint to load the DSN from a secret? You might prefer to keep everything in go? I thought I would ask.

This is useful for docker swarm and the likes where secrets are exposed on the filesystem.