### PR TITLE
Adding missing translations

### DIFF
--- a/web/src/components/MemoDisplaySettingMenu.tsx
+++ b/web/src/components/MemoDisplaySettingMenu.tsx
@@ -3,12 +3,14 @@ import clsx from "clsx";
 import { Settings2Icon } from "lucide-react";
 import { useMemoFilterStore } from "@/store/v1";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/Popover";
+import { useTranslate } from "@/utils/i18n";
 
 interface Props {
   className?: string;
 }
 
 const MemoDisplaySettingMenu = ({ className }: Props) => {
+  const t = useTranslate();
   const memoFilterStore = useMemoFilterStore();
   const isApplying = Boolean(memoFilterStore.orderByTimeAsc) !== false;
 
@@ -22,16 +24,16 @@ const MemoDisplaySettingMenu = ({ className }: Props) => {
       <PopoverContent align="end" alignOffset={-12} sideOffset={14}>
         <div className="flex flex-col gap-2">
           <div className="w-full flex flex-row justify-between items-center">
-            <span className="text-sm shrink-0 mr-3">Order by</span>
+            <span className="text-sm shrink-0 mr-3">{t("memo.order-by")}</span>
             <Select value="displayTime">
-              <Option value={"displayTime"}>Display Time</Option>
+              <Option value={"displayTime"}>{t("memo.display-time")}</Option>
             </Select>
           </div>
           <div className="w-full flex flex-row justify-between items-center">
-            <span className="text-sm shrink-0 mr-3">Direction</span>
+            <span className="text-sm shrink-0 mr-3">{t("memo.direction")}</span>
             <Select value={memoFilterStore.orderByTimeAsc} onChange={(_, value) => memoFilterStore.setOrderByTimeAsc(Boolean(value))}>
-              <Option value={false}>DESC</Option>
-              <Option value={true}>ASC</Option>
+              <Option value={false}>{t("memo.direction-desc")}</Option>
+              <Option value={true}>{t("memo.direction-asc")}</Option>
             </Select>
           </div>
         </div>

--- a/web/src/components/MemoEditor/ActionButton/AddMemoRelationPopover.tsx
+++ b/web/src/components/MemoEditor/ActionButton/AddMemoRelationPopover.tsx
@@ -92,7 +92,7 @@ const AddMemoRelationPopover = (props: Props) => {
     // If embedded mode is enabled, embed the memo instead of creating a relation.
     if (embedded) {
       if (!editorRef.current) {
-        toast.error("Failed to embed memo");
+        toast.error(t("message.failed-to-embed-memo"));
         return;
       }
 

--- a/web/src/components/MemoFilters.tsx
+++ b/web/src/components/MemoFilters.tsx
@@ -3,8 +3,10 @@ import { CalendarIcon, CheckCircleIcon, CodeIcon, EyeIcon, FilterIcon, LinkIcon,
 import { useEffect, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 import { FilterFactor, getMemoFilterKey, MemoFilter, parseFilterQuery, stringifyFilters, useMemoFilterStore } from "@/store/v1";
+import { useTranslate } from "@/utils/i18n";
 
 const MemoFilters = () => {
+  const t = useTranslate();
   const [searchParams, setSearchParams] = useSearchParams();
   const memoFilterStore = useMemoFilterStore();
   const filters = memoFilterStore.filters;
@@ -75,7 +77,7 @@ const MemoFilters = () => {
     <div className="w-full mb-2 flex flex-row justify-start items-start gap-2">
       <span className="flex flex-row items-center gap-0.5 text-gray-500 text-sm leading-6 border border-transparent">
         <FilterIcon className="w-4 h-auto opacity-60 inline" />
-        Filters
+        {t("memo.filters")}
       </span>
       <div className="flex flex-row justify-start items-center flex-wrap gap-2 leading-6 h-6">
         {filters.map((filter) => (

--- a/web/src/components/UserStatisticsView.tsx
+++ b/web/src/components/UserStatisticsView.tsx
@@ -90,14 +90,14 @@ const UserStatisticsView = () => {
           onClick={onCalendarClick}
         />
         {memoAmount === 0 ? (
-          <p className="mt-1 w-full text-xs italic opacity-80">No memos</p>
+          <p className="mt-1 w-full text-xs italic opacity-80">{t('memo.no-memos')}</p>
         ) : memoAmount === 1 ? (
           <p className="mt-1 w-full text-xs italic opacity-80">
-            <span>{memoAmount}</span> memo in <span>{days}</span> {days > 1 ? "days" : "day"}
+            <span>{memoAmount}</span> {t("common.memo").toLocaleLowerCase()} {t("common.in").toLowerCase()} <span>{days}</span> {days > 1 ? t("common.days").toLocaleLowerCase() : t("common.day").toLocaleLowerCase()}
           </p>
         ) : (
           <p className="mt-1 w-full text-xs italic opacity-80">
-            <span>{memoAmount}</span> memos in <span>{days}</span> {days > 1 ? "days" : "day"}
+            <span>{memoAmount}</span> {t("common.memos").toLocaleLowerCase()} {t("common.in").toLowerCase()} <span>{days}</span> {days > 1 ? t("common.days").toLocaleLowerCase() : t("common.day").toLocaleLowerCase()}
           </p>
         )}
       </div>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -24,6 +24,7 @@
     "collapse": "Collapse",
     "create": "Create",
     "database": "Database",
+    "day": "Day",
     "days": "Days",
     "delete": "Delete",
     "description": "Description",
@@ -34,12 +35,14 @@
     "file": "File",
     "filter": "Filter",
     "home": "Home",
+    "in": "In",
     "image": "Image",
     "inbox": "Inbox",
     "language": "Language",
     "learn-more": "Learn more",
     "link": "Link",
     "mark": "Mark",
+    "memo": "Memo",
     "memos": "Memos",
     "name": "Name",
     "new": "New",
@@ -121,7 +124,14 @@
     "to-do": "To-do",
     "code": "Code",
     "remove-completed-task-list-items": "Remove done",
-    "remove-completed-task-list-items-confirm": "Are you sure you want to remove all completed to-dos? THIS ACTION IS IRREVERSIBLE"
+    "remove-completed-task-list-items-confirm": "Are you sure you want to remove all completed to-dos? THIS ACTION IS IRREVERSIBLE",
+    "filters": "Filters",
+    "order-by": "Order By",
+    "display-time": "Display Time",
+    "direction": "Direction",
+    "direction-desc": "Descending",
+    "direction-asc": "Ascending",
+    "no-memos": "No memos."
   },
   "message": {
     "archived-successfully": "Archived successfully",
@@ -139,7 +149,8 @@
     "succeed-copy-link": "Link copied successfully.",
     "update-succeed": "Update succeeded",
     "user-not-found": "User not found",
-    "remove-completed-task-list-items-successfully": "The removal was successful"
+    "remove-completed-task-list-items-successfully": "The removal was successful",
+    "failed-to-embed-memo": "Failed to embed memo"
   },
   "reference": {
     "add-references": "Add references",
@@ -351,5 +362,12 @@
     "code-block": "Code block",
     "checkbox": "Checkbox",
     "content-syntax": "Content syntax"
+  },
+  "about": {
+    "description": "A privacy-first, lightweight note-taking service. Easily capture and share your great thoughts.",
+    "github-repository": "GitHub Repo",
+    "official-website": "Official Website",
+    "blogs": "Blogs",
+    "documents": "Documents"
   }
 }

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -24,6 +24,7 @@
     "collapse": "Réduire",
     "create": "Créer",
     "database": "Base de données",
+    "day": "Jour",
     "days": "Jours",
     "delete": "Supprimer",
     "description": "Description",
@@ -34,12 +35,14 @@
     "file": "Fichier",
     "filter": "Filtre",
     "home": "Accueil",
+    "in": "En",
     "image": "Image",
     "inbox": "Notifications",
     "language": "Langue",
     "learn-more": "En savoir plus",
     "link": "Lien",
     "mark": "Lier",
+    "memo": "Memo",
     "memos": "Memos",
     "name": "Nom",
     "new": "Nouveau",
@@ -121,7 +124,14 @@
     "to-do": "À faire",
     "code": "Code",
     "remove-completed-task-list-items": "Supprimer terminées",
-    "remove-completed-task-list-items-confirm": "Êtes-vous sûr de vouloir supprimer toutes les tâches terminées ? (Cette action est irréversible)"
+    "remove-completed-task-list-items-confirm": "Êtes-vous sûr de vouloir supprimer toutes les tâches terminées ? CETTE ACTION EST IRRÉVERSIBLE",
+    "filters": "Filtres",
+    "order-by": "Ordonner par",
+    "display-time": "Date d'Affichage",
+    "direction": "Ordre",
+    "direction-desc": "Descendant",
+    "direction-asc": "Ascendant",
+    "no-memos": "Pas de memos."
   },
   "message": {
     "archived-successfully": "Archivé avec succès",
@@ -139,7 +149,8 @@
     "succeed-copy-link": "Succeed to copy link to clipboard.",
     "update-succeed": "Mise à jour effectuée",
     "user-not-found": "Utilisateur introuvable",
-    "remove-completed-task-list-items-successfully": "Supprimé avec succès !"
+    "remove-completed-task-list-items-successfully": "Supprimé avec succès !",
+    "failed-to-embed-memo": "Échec de l'intégration du memo."
   },
   "reference": {
     "add-references": "Ajouter des références",
@@ -155,7 +166,7 @@
         "file-name": "Nom du fichier",
         "file-name-placeholder": "Nom du fichier",
         "link": "Lien",
-        "link-placeholder": "https://the.link.to/your/resource",
+        "link-placeholder": "https://le.lien.vers/votre/ressource",
         "option": "Lien externe",
         "type": "Type",
         "type-placeholder": "Type de fichier"
@@ -351,5 +362,12 @@
     "code-block": "Bloc de code",
     "checkbox": "Case à cocher",
     "content-syntax": "Syntaxe du contenu"
+  },
+  "about": {
+    "description": "Un service de prise de notes léger et respectueux de la vie privée. Capturez et partagez facilement vos meilleures idées.",
+    "github-repository": "Dépôt GitHub",
+    "official-website": "Site web officiel",
+    "blogs": "Blogs",
+    "documents": "Documents"
   }
 }

--- a/web/src/pages/About.tsx
+++ b/web/src/pages/About.tsx
@@ -1,8 +1,11 @@
 import { Link } from "@mui/joy";
 import { DotIcon } from "lucide-react";
 import MobileHeader from "@/components/MobileHeader";
+import { useTranslate } from "@/utils/i18n";
 
 const About = () => {
+  const t = useTranslate();
+
   return (
     <section className="@container w-full max-w-5xl min-h-full flex flex-col justify-start items-center sm:pt-3 md:pt-6 pb-8">
       <MobileHeader />
@@ -11,22 +14,22 @@ const About = () => {
           <a href="https://www.usememos.com" target="_blank">
             <img className="w-auto h-12" src="https://www.usememos.com/full-logo-landscape.png" alt="memos" />
           </a>
-          <p className="text-base">A privacy-first, lightweight note-taking service. Easily capture and share your great thoughts.</p>
+          <p className="text-base">{t("about.description")}</p>
           <div className="mt-1 flex flex-row items-center flex-wrap">
             <Link underline="always" href="https://www.github.com/usememos/memos" target="_blank">
-              GitHub Repo
+              {t("about.github-repository")}
             </Link>
             <DotIcon className="w-4 h-auto opacity-60" />
             <Link underline="always" href="https://www.usememos.com/" target="_blank">
-              Official Website
+              {t("about.official-website")}
             </Link>
             <DotIcon className="w-4 h-auto opacity-60" />
             <Link underline="always" href="https://www.usememos.com/blog" target="_blank">
-              Blogs
+              {t("about.blogs")}
             </Link>
             <DotIcon className="w-4 h-auto opacity-60" />
             <Link underline="always" href="https://www.usememos.com/docs" target="_blank">
-              Documents
+              {t("about.documents")} 
             </Link>
           </div>
         </div>


### PR DESCRIPTION
Whilst fixing #4271 I noticed that a couple of extra strings could also be translated (including for example the about page).
I added the necessary code and translation strings for both EN and FR languages.