### PR TITLE
fix #4257 fixed ui for mermaid diagrams in dark mode

### DIFF
--- a/web/src/components/MemoContent/MermaidBlock.tsx
+++ b/web/src/components/MemoContent/MermaidBlock.tsx
@@ -11,7 +11,8 @@ const MermaidBlock: React.FC<Props> = ({ content }: Props) => {
     // Dynamically import mermaid to ensure compatibility with Vite
     const initializeMermaid = async () => {
       const mermaid = (await import("mermaid")).default;
-      mermaid.initialize({ startOnLoad: false, theme: "default" });
+      mermaid.initialize({ startOnLoad: false, theme: 'dark', darkMode: true
+      });
       if (mermaidDockBlock.current) {
         mermaid.run({
           nodes: [mermaidDockBlock.current],


### PR DESCRIPTION
fixes #4257 
The diagrams are now visible and can be seen easily in dark mode

![image](https://github.com/user-attachments/assets/11e09d42-0580-4bca-9270-24419686ba8c)
