### PR TITLE
Cancel out of trying to save

### DIFF
--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -336,6 +336,9 @@ const MemoEditor = (props: Props) => {
           }
           if (updateMask.size === 0) {
             toast.error("No changes detected");
+            if (onCancel) {
+              onCancel();
+            }
             return;
           }
           const memo = await memoStore.updateMemo(memoPatch, Array.from(updateMask));


### PR DESCRIPTION
As per https://github.com/usememos/memos/issues/4334 the editor stays in an editing state when no changes are found.

The PR aims to reset the editor to its normal state