### PR TITLE
fix: calendar coloring

### DIFF
--- a/web/src/components/ActivityCalendar.tsx
+++ b/web/src/components/ActivityCalendar.tsx
@@ -17,11 +17,11 @@ const getCellAdditionalStyles = (count: number, maxCount: number) => {
   if (count === 0) {
     return "";
   }
-  if (count >= 3) {
-    const ratio = count / maxCount;
+  const ratio = count / maxCount;
+  if (count >= 3 and ratio > 0.4) {
     if (ratio > 0.7) {
       return "bg-primary-darker/80 text-gray-100 dark:opacity-80";
-    } else if (ratio > 0.4) {
+    } else {
       return "bg-primary/80 text-gray-100 dark:opacity-80";
     }
   } else {


### PR DESCRIPTION
Fixed an issue where the color was not painted on days with a ratio smaller than 0.4 and with memos of 3 or more.