### PR TITLE
fix: show loader icon while refreshing

### DIFF
--- a/web/src/components/PagedMemoList/PagedMemoList.tsx
+++ b/web/src/components/PagedMemoList/PagedMemoList.tsx
@@ -57,7 +57,7 @@ const PagedMemoList = (props: Props) => {
   const refreshList = async () => {
     memoList.reset();
     setState((state) => ({ ...state, nextPageToken: "" }));
-    fetchMoreMemos("");
+    await fetchMoreMemos("");
   };
 
   useEffect(() => {


### PR DESCRIPTION
Fixed the issue that the loader icon is not displayed when pulling to refresh.