### PR TITLE
search for multiple words

### DIFF
--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -17,10 +17,12 @@ const SearchBar = () => {
     if (e.key === "Enter") {
       e.preventDefault();
       if (queryText !== "") {
-        memoFilterStore.removeFilter((f) => f.factor === "contentSearch");
-        memoFilterStore.addFilter({
-          factor: "contentSearch",
-          value: queryText,
+        const words = queryText.split(" ");
+        words.forEach((word) => {
+          memoFilterStore.addFilter({
+            factor: "contentSearch",
+            value: word,
+          });
         });
         setQueryText("");
       }


### PR DESCRIPTION
As per discussion https://github.com/orgs/usememos/discussions/4361, it would be nice to search for multiple search terms

This PR aims to allow for multiple search terms to be used when filtering notes.

Design decision:
Chose to split the provided text up into individual words rather than adding multiple word terms to the search filter. 
I felt that a user being able to easily add multiple search terms in one go outweighed the ability to do a very precise search containing multiple words.
Not clearing out the filter allows for new text to be added so that searches can be further refined by adding more words

E.g.
Starting with `3` notes
![image](https://github.com/user-attachments/assets/7336c7fa-761f-441f-887c-bd4fa80c49a4)

Searching query `this is text` adds the `3` words as filters and finds the `2` matching notes
![image](https://github.com/user-attachments/assets/08f10766-7f62-4713-84bf-9daee0a15de4)

Adding search query `more` adds the `1` additional word as a filter and finds the `1` matching note
![image](https://github.com/user-attachments/assets/a362fdf0-ac6b-4829-9c13-d17582ccd385)

Removing `this` `is` `text` clears the `3` filters and finds the `2` matching notes 
![image](https://github.com/user-attachments/assets/250d974d-e697-4287-92ec-e8175bfb223d)
