### PR TITLE
Add id to RSS feed items

### DIFF
--- a/server/router/rss/rss.go
+++ b/server/router/rss/rss.go
@@ -108,10 +108,12 @@ func (s *RSSService) generateRSSFromMemoList(ctx context.Context, memoList []*st
 		if err != nil {
 			return "", err
 		}
+		link := &feeds.Link{Href: baseURL + "/memos/" + memo.UID}
 		feed.Items[i] = &feeds.Item{
-			Link:        &feeds.Link{Href: baseURL + "/memos/" + memo.UID},
+			Link:        link,
 			Description: description,
 			Created:     time.Unix(memo.CreatedTs, 0),
+			Id:          link.Href,
 		}
 		resources, err := s.Store.ListResources(ctx, &store.FindResource{
 			MemoID: &memo.ID,


### PR DESCRIPTION
This change adds the permalink as GUID to RSS feed items. [micro.blog](https://micro.blog) requires feed items to provide a GUID for content ingestion.

**Please note**: I was not able to verify this change locally as the `u/USER/rss.xml` 404s before and after this change locally.