### PR TITLE
Allow storing resource references >256 chars long in mysql

### DIFF
--- a/store/migration/mysql/0.25/00__s3_reference_length.sql
+++ b/store/migration/mysql/0.25/00__s3_reference_length.sql
@@ -1,0 +1,3 @@
+-- https://github.com/usememos/memos/issues/4322
+
+ALTER TABLE `resource` MODIFY `reference` TEXT NOT NULL DEFAULT ('');

--- a/store/migration/mysql/LATEST.sql
+++ b/store/migration/mysql/LATEST.sql
@@ -77,7 +77,7 @@ CREATE TABLE `resource` (
   `size` INT NOT NULL DEFAULT '0',
   `memo_id` INT DEFAULT NULL,
   `storage_type` VARCHAR(256) NOT NULL DEFAULT '',
-  `reference` VARCHAR(256) NOT NULL DEFAULT '',
+  `reference` TEXT NOT NULL DEFAULT (''),
   `payload` TEXT NOT NULL
 );
 


### PR DESCRIPTION
This PR  fixes #4322.

I have verified this on my own Memos instance, running MySQL 8.4, by running: 

```
ALTER TABLE `resource` MODIFY `reference` TEXT NOT NULL DEFAULT ('');
```

After this change, B2-backed file uploads appear to work as expected.

Caveat: I am not familiar with how this project likes to handle version numbering and DB migrations, so please accept my apologies if this migration isn't in quite the right place at this time.