### PR TITLE
feat: Trim space on webhook url

### DIFF
--- a/server/router/api/v1/webhook_service.go
+++ b/server/router/api/v1/webhook_service.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -23,7 +24,7 @@ func (s *APIV1Service) CreateWebhook(ctx context.Context, request *v1pb.CreateWe
 	webhook, err := s.Store.CreateWebhook(ctx, &store.Webhook{
 		CreatorID: currentUser.ID,
 		Name:      request.Name,
-		URL:       request.Url,
+		URL:       strings.TrimSpace(request.Url),
 	})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create webhook, error: %+v", err)


### PR DESCRIPTION
This removes spaces that can cause invalid URLs. While I was using the webhooks I kept pasting urls with spaces and discovering the problem in the logs later.

Eg,
`http://192.168.1.10:8080/webhook ` is accepted, but will return 404 when used. This change removes the space at the end