### PR TITLE
Adds ids and classes for easier CSS/JS selectors

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -86,5 +86,6 @@
     "onlyBuiltDependencies": [
       "@bufbuild/buf"
     ]
-  }
+  },
+  "packageManager": "pnpm@10.6.2+sha512.47870716bea1572b53df34ad8647b42962bc790ce2bf4562ba0f643237d7302a3d6a8ecef9e4bdfc01d23af1969aa90485d4cebb0b9638fa5ef1daef656f6c1b"
 }

--- a/web/src/components/HomeSidebar/HomeSidebar.tsx
+++ b/web/src/components/HomeSidebar/HomeSidebar.tsx
@@ -71,7 +71,7 @@ const HomeSidebar = observer((props: Props) => {
   );
 
   return (
-    <aside className={cn("relative w-full h-full overflow-auto flex flex-col justify-start items-start", props.className)}>
+    <aside id="home-sidebar" className={cn("relative w-full h-full overflow-auto flex flex-col justify-start items-start", props.className)}>
       <SearchBar />
       <div className="mt-2 w-full space-y-1">
         {navLinks.map((navLink) => (

--- a/web/src/components/HomeSidebar/HomeSidebar.tsx
+++ b/web/src/components/HomeSidebar/HomeSidebar.tsx
@@ -73,10 +73,7 @@ const HomeSidebar = observer((props: Props) => {
   return (
     <aside
       id="home-sidebar"
-      className={cn(
-        "relative w-full h-full overflow-auto flex flex-col justify-start items-start",
-        props.className
-      )}
+      className={cn("relative w-full h-full overflow-auto flex flex-col justify-start items-start", props.className)}
     >
       <SearchBar />
       <div className="mt-2 w-full space-y-1">

--- a/web/src/components/HomeSidebar/HomeSidebar.tsx
+++ b/web/src/components/HomeSidebar/HomeSidebar.tsx
@@ -71,7 +71,13 @@ const HomeSidebar = observer((props: Props) => {
   );
 
   return (
-    <aside id="home-sidebar" className={cn("relative w-full h-full overflow-auto flex flex-col justify-start items-start", props.className)}>
+    <aside
+      id="home-sidebar"
+      className={cn(
+        "relative w-full h-full overflow-auto flex flex-col justify-start items-start",
+        props.className
+      )}
+    >
       <SearchBar />
       <div className="mt-2 w-full space-y-1">
         {navLinks.map((navLink) => (

--- a/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
+++ b/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
@@ -21,7 +21,7 @@ const MemoDetailSidebar = ({ memo, className, parentPage }: Props) => {
     <aside
       className={cn(
         "memo-detail-sidebar relative w-full h-auto max-h-screen overflow-auto hide-scrollbar flex flex-col justify-start items-start",
-        className
+        className,
       )}
     >
       <div className="flex flex-col justify-start items-start w-full px-1 gap-2 h-auto shrink-0 flex-nowrap hide-scrollbar">

--- a/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
+++ b/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
@@ -19,7 +19,10 @@ const MemoDetailSidebar = ({ memo, className, parentPage }: Props) => {
 
   return (
     <aside
-      className={cn("memo-detail-sidebar relative w-full h-auto max-h-screen overflow-auto hide-scrollbar flex flex-col justify-start items-start", className)}
+      className={cn(
+        "memo-detail-sidebar relative w-full h-auto max-h-screen overflow-auto hide-scrollbar flex flex-col justify-start items-start",
+        className
+      )}
     >
       <div className="flex flex-col justify-start items-start w-full px-1 gap-2 h-auto shrink-0 flex-nowrap hide-scrollbar">
         {shouldShowRelationGraph && (

--- a/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
+++ b/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
@@ -19,7 +19,7 @@ const MemoDetailSidebar = ({ memo, className, parentPage }: Props) => {
 
   return (
     <aside
-      className={cn("relative w-full h-auto max-h-screen overflow-auto hide-scrollbar flex flex-col justify-start items-start", className)}
+      className={cn("memo-detail-sidebar relative w-full h-auto max-h-screen overflow-auto hide-scrollbar flex flex-col justify-start items-start", className)}
     >
       <div className="flex flex-col justify-start items-start w-full px-1 gap-2 h-auto shrink-0 flex-nowrap hide-scrollbar">
         {shouldShowRelationGraph && (

--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -24,6 +24,7 @@ import showPreviewImageDialog from "./PreviewImageDialog";
 import ReactionSelector from "./ReactionSelector";
 import UserAvatar from "./UserAvatar";
 import VisibilityIcon from "./VisibilityIcon";
+import { log } from "mermaid/dist/logger";
 
 interface Props {
   memo: Memo;
@@ -121,10 +122,15 @@ const MemoView: React.FC<Props> = (props: Props) => {
     <relative-time datetime={memo.displayTime?.toISOString()} format={relativeTimeFormat}></relative-time>
   );
 
+  let memoTags = '';
+  memo.tags?.forEach((tag) => {
+    memoTags = memoTags + ' tagged-' + tag.toLowerCase();
+  });
+  
   return (
     <div
       className={cn(
-        "group relative flex flex-col justify-start items-start w-full px-4 py-3 mb-2 gap-2 bg-white dark:bg-zinc-800 rounded-lg border border-white dark:border-zinc-800 hover:border-gray-200 dark:hover:border-zinc-700",
+        "memo " + memoTags + " group relative flex flex-col justify-start items-start w-full px-4 py-3 mb-2 gap-2 bg-white dark:bg-zinc-800 rounded-lg border border-white dark:border-zinc-800 hover:border-gray-200 dark:hover:border-zinc-700",
         className,
       )}
       ref={memoContainerRef}
@@ -140,7 +146,7 @@ const MemoView: React.FC<Props> = (props: Props) => {
         />
       ) : (
         <>
-          <div className="w-full flex flex-row justify-between items-center gap-2">
+          <div className="memo-header w-full flex flex-row justify-between items-center gap-2">
             <div className="w-auto max-w-[calc(100%-8rem)] grow flex flex-row justify-start items-center">
               {props.showCreator && creator ? (
                 <div className="w-full flex flex-row justify-start items-center">
@@ -216,7 +222,7 @@ const MemoView: React.FC<Props> = (props: Props) => {
           </div>
           <div
             className={cn(
-              "w-full flex flex-col justify-start items-start gap-2",
+              "memo-content w-full flex flex-col justify-start items-start gap-2",
               nsfw && !showNSFWContent && "blur-lg transition-all duration-200",
             )}
           >

--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -1,5 +1,6 @@
 import { Tooltip } from "@mui/joy";
 import { BookmarkIcon, EyeOffIcon, MessageCircleMoreIcon } from "lucide-react";
+// import { log } from "mermaid/dist/logger";
 import { memo, useCallback, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import useAsyncEffect from "@/hooks/useAsyncEffect";
@@ -24,7 +25,6 @@ import showPreviewImageDialog from "./PreviewImageDialog";
 import ReactionSelector from "./ReactionSelector";
 import UserAvatar from "./UserAvatar";
 import VisibilityIcon from "./VisibilityIcon";
-import { log } from "mermaid/dist/logger";
 
 interface Props {
   memo: Memo;
@@ -126,13 +126,13 @@ const MemoView: React.FC<Props> = (props: Props) => {
   memo.tags?.forEach((tag) => {
     memoTags = memoTags + " tagged-" + tag.toLowerCase();
   });
-  
+
   return (
     <div
       className={cn(
-        "memo " + 
-        memoTags + 
-        " group relative flex flex-col justify-start items-start w-full px-4 py-3 mb-2 gap-2 bg-white dark:bg-zinc-800 rounded-lg border border-white dark:border-zinc-800 hover:border-gray-200 dark:hover:border-zinc-700",
+        "memo " +
+          memoTags +
+          " group relative flex flex-col justify-start items-start w-full px-4 py-3 mb-2 gap-2 bg-white dark:bg-zinc-800 rounded-lg border border-white dark:border-zinc-800 hover:border-gray-200 dark:hover:border-zinc-700",
         className,
       )}
       ref={memoContainerRef}

--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -122,15 +122,17 @@ const MemoView: React.FC<Props> = (props: Props) => {
     <relative-time datetime={memo.displayTime?.toISOString()} format={relativeTimeFormat}></relative-time>
   );
 
-  let memoTags = '';
+  let memoTags = "";
   memo.tags?.forEach((tag) => {
-    memoTags = memoTags + ' tagged-' + tag.toLowerCase();
+    memoTags = memoTags + " tagged-" + tag.toLowerCase();
   });
   
   return (
     <div
       className={cn(
-        "memo " + memoTags + " group relative flex flex-col justify-start items-start w-full px-4 py-3 mb-2 gap-2 bg-white dark:bg-zinc-800 rounded-lg border border-white dark:border-zinc-800 hover:border-gray-200 dark:hover:border-zinc-700",
+        "memo " + 
+        memoTags + 
+        " group relative flex flex-col justify-start items-start w-full px-4 py-3 mb-2 gap-2 bg-white dark:bg-zinc-800 rounded-lg border border-white dark:border-zinc-800 hover:border-gray-200 dark:hover:border-zinc-700",
         className,
       )}
       ref={memoContainerRef}

--- a/web/src/components/PagedMemoList/PagedMemoList.tsx
+++ b/web/src/components/PagedMemoList/PagedMemoList.tsx
@@ -72,7 +72,7 @@ const PagedMemoList = observer((props: Props) => {
   }, [props.owner, props.state, props.direction, props.filter, props.oldFilter, props.pageSize]);
 
   const children = (
-    <div className="flex flex-col justify-start items-start w-full max-w-full">
+    <div id="memo-list" className="flex flex-col justify-start items-start w-full max-w-full">
       <MasonryView
         memoList={sortedMemoList}
         renderer={props.renderer}

--- a/web/src/pages/MemoDetail.tsx
+++ b/web/src/pages/MemoDetail.tsx
@@ -113,7 +113,7 @@ const MemoDetail = () => {
             showPinned
             showNsfwContent
           />
-          <div className="pt-8 pb-16 w-full">
+          <div id="memo-comments" className="pt-8 pb-16 w-full">
             <h2 id="comments" className="sr-only">
               {t("memo.comment.self")}
             </h2>


### PR DESCRIPTION
This PR adds ids and classes for easier CSS/JS selectors.

Added ids:
* #memo-list
* #memo-comments
* #home-sidebar

Added classes:
* .memo
  * .tagged-[tag] for all tags
  * .memo-header
  * .memo-content
* .memo-detail-sidebar

Closes #4481