### PR TITLE
Implement grpc health service checking database connection

### DIFF
--- a/server/router/api/v1/health_service.go
+++ b/server/router/api/v1/health_service.go
@@ -1,0 +1,21 @@
+package v1
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+
+	"github.com/usememos/memos/store"
+)
+
+func (s *APIV1Service) Check(ctx context.Context,
+	_ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	history, err := s.Store.GetDriver().FindMigrationHistoryList(ctx, &store.FindMigrationHistory{})
+	if err != nil || len(history) == 0 {
+		return nil, status.Errorf(codes.Unavailable, "not available")
+	}
+
+	return &grpc_health_v1.HealthCheckResponse{Status: grpc_health_v1.HealthCheckResponse_SERVING}, nil
+}

--- a/server/router/api/v1/v1.go
+++ b/server/router/api/v1/v1.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 
 	v1pb "github.com/usememos/memos/proto/gen/api/v1"
@@ -19,6 +20,8 @@ import (
 )
 
 type APIV1Service struct {
+	grpc_health_v1.UnimplementedHealthServer
+
 	v1pb.UnimplementedWorkspaceServiceServer
 	v1pb.UnimplementedWorkspaceSettingServiceServer
 	v1pb.UnimplementedAuthServiceServer
@@ -46,6 +49,7 @@ func NewAPIV1Service(secret string, profile *profile.Profile, store *store.Store
 		Store:      store,
 		grpcServer: grpcServer,
 	}
+	grpc_health_v1.RegisterHealthServer(grpcServer, apiv1Service)
 	v1pb.RegisterWorkspaceServiceServer(grpcServer, apiv1Service)
 	v1pb.RegisterWorkspaceSettingServiceServer(grpcServer, apiv1Service)
 	v1pb.RegisterAuthServiceServer(grpcServer, apiv1Service)


### PR DESCRIPTION
This pull request introduces a health check service to the API v1 server. The main changes include adding a new health service implementation, registering the health server, and updating imports to support the new functionality.

Key changes:

* Added a new health check service implementation in `server/router/api/v1/health_service.go`, which includes a `Check` method to verify the service status.
* Updated `server/router/api/v1/v1.go` to import the necessary gRPC health check package.
* Updated the `APIV1Service` struct in `server/router/api/v1/v1.go` to embed `grpc_health_v1.UnimplementedHealthServer`.
* Registered the health server in the `NewAPIV1Service` function within `server/router/api/v1/v1.go`.

closes #4498 