### PR TITLE
fix: user stats changes based on selected tab

### DIFF
--- a/web/src/store/v2/user.ts
+++ b/web/src/store/v2/user.ts
@@ -179,7 +179,6 @@ const userStore = (() => {
     }
     state.setPartial({
       userStatsByName: {
-        ...state.userStatsByName,
         ...userStatsByName,
       },
     });


### PR DESCRIPTION
- set partial only the relevant user stats instead of only adding up stats

closes #4500 