### PR TITLE
Fix typo s/contnet/content/.

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -129,7 +129,7 @@
   "memo": {
     "archived-at": "Archived at",
     "click-to-hide-nsfw-content": "Click to hide NSFW content",
-    "click-to-show-nsfw-content": "Click to show NSFW contnet",
+    "click-to-show-nsfw-content": "Click to show NSFW content",
     "code": "Code",
     "comment": {
       "self": "Comments",


### PR DESCRIPTION
Noticed this typo from the screenshot in the new 0.24.1 release. 