### PR TITLE
Clocktime of created memos

### DIFF
--- a/web/src/components/MemoContent/EmbeddedContent/EmbeddedMemo.tsx
+++ b/web/src/components/MemoContent/EmbeddedContent/EmbeddedMemo.tsx
@@ -80,7 +80,7 @@ const EmbeddedMemo = ({ resourceId: uid, params: paramsStr }: Props) => {
               minute: "numeric",
             })
           ) : (
-            <relative-time datetime={memo.displayTime?.toISOString()} format={relativeTimeFormat}></relative-time>
+            <relative-time datetime={memo.displayTime?.toISOString()} format="datetime"></relative-time>
           )}
         </div>
         <div className="flex justify-end items-center gap-1">

--- a/web/src/components/MemoContent/EmbeddedContent/EmbeddedMemo.tsx
+++ b/web/src/components/MemoContent/EmbeddedContent/EmbeddedMemo.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/utils";
 import MemoContent from "..";
 import { RendererContext } from "../types";
 import Error from "./Error";
+import i18n from 'i18next';
 
 interface Props {
   resourceId: string;
@@ -22,6 +23,7 @@ const EmbeddedMemo = ({ resourceId: uid, params: paramsStr }: Props) => {
   const memoStore = useMemoStore();
   const memoName = `memos/${uid}`;
   const memo = memoStore.getMemoByName(memoName);
+  const isMemoOlderThan24Hours = Date.now() - memo.displayTime!.getTime() > 1000 * 60 * 60 * 24
 
   useEffect(() => {
     memoStore.getOrFetchMemoByName(memoName).finally(() => loadingState.setFinish());
@@ -69,7 +71,11 @@ const EmbeddedMemo = ({ resourceId: uid, params: paramsStr }: Props) => {
     <div className="relative flex flex-col justify-start items-start w-full px-3 py-2 bg-zinc-50 dark:bg-zinc-900 rounded-lg border border-gray-200 dark:border-zinc-700 hover:shadow">
       <div className="w-full mb-1 flex flex-row justify-between items-center text-gray-400 dark:text-gray-500">
         <div className="text-sm leading-5 select-none">
-          <relative-time datetime={memo.displayTime?.toISOString()} format="datetime"></relative-time>
+          {
+            isMemoOlderThan24Hours
+            ? memo.displayTime?.toLocaleString(i18n.resolvedLanguage, { weekday: 'short', day: 'numeric', month: 'short', hour: 'numeric', minute: 'numeric' })
+            : <relative-time datetime={memo.displayTime?.toISOString()} format={relativeTimeFormat}></relative-time>
+          }
         </div>
         <div className="flex justify-end items-center gap-1">
           <span

--- a/web/src/components/MemoContent/EmbeddedContent/EmbeddedMemo.tsx
+++ b/web/src/components/MemoContent/EmbeddedContent/EmbeddedMemo.tsx
@@ -1,4 +1,5 @@
 import copy from "copy-to-clipboard";
+import i18n from "i18next";
 import { ArrowUpRightIcon } from "lucide-react";
 import { useContext, useEffect } from "react";
 import toast from "react-hot-toast";
@@ -10,7 +11,6 @@ import { cn } from "@/utils";
 import MemoContent from "..";
 import { RendererContext } from "../types";
 import Error from "./Error";
-import i18n from 'i18next';
 
 interface Props {
   resourceId: string;
@@ -23,7 +23,7 @@ const EmbeddedMemo = ({ resourceId: uid, params: paramsStr }: Props) => {
   const memoStore = useMemoStore();
   const memoName = `memos/${uid}`;
   const memo = memoStore.getMemoByName(memoName);
-  const isMemoOlderThan24Hours = Date.now() - memo.displayTime!.getTime() > 1000 * 60 * 60 * 24
+  const isMemoOlderThan24Hours = Date.now() - memo.displayTime!.getTime() > 1000 * 60 * 60 * 24;
 
   useEffect(() => {
     memoStore.getOrFetchMemoByName(memoName).finally(() => loadingState.setFinish());
@@ -71,11 +71,17 @@ const EmbeddedMemo = ({ resourceId: uid, params: paramsStr }: Props) => {
     <div className="relative flex flex-col justify-start items-start w-full px-3 py-2 bg-zinc-50 dark:bg-zinc-900 rounded-lg border border-gray-200 dark:border-zinc-700 hover:shadow">
       <div className="w-full mb-1 flex flex-row justify-between items-center text-gray-400 dark:text-gray-500">
         <div className="text-sm leading-5 select-none">
-          {
-            isMemoOlderThan24Hours
-            ? memo.displayTime?.toLocaleString(i18n.resolvedLanguage, { weekday: 'short', day: 'numeric', month: 'short', hour: 'numeric', minute: 'numeric' })
-            : <relative-time datetime={memo.displayTime?.toISOString()} format={relativeTimeFormat}></relative-time>
-          }
+          {isMemoOlderThan24Hours ? (
+            memo.displayTime?.toLocaleString(i18n.resolvedLanguage, {
+              weekday: "short",
+              day: "numeric",
+              month: "short",
+              hour: "numeric",
+              minute: "numeric",
+            })
+          ) : (
+            <relative-time datetime={memo.displayTime?.toISOString()} format={relativeTimeFormat}></relative-time>
+          )}
         </div>
         <div className="flex justify-end items-center gap-1">
           <span

--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -11,6 +11,7 @@ import { State } from "@/types/proto/api/v1/common";
 import { Memo, MemoRelation_Type, Visibility } from "@/types/proto/api/v1/memo_service";
 import { cn } from "@/utils";
 import { useTranslate } from "@/utils/i18n";
+import i18n from 'i18next';
 import { convertVisibilityToString } from "@/utils/memo";
 import { isSuperUser } from "@/utils/user";
 import MemoActionMenu from "./MemoActionMenu";
@@ -53,7 +54,8 @@ const MemoView: React.FC<Props> = (props: Props) => {
   const commentAmount = memo.relations.filter(
     (relation) => relation.type === MemoRelation_Type.COMMENT && relation.relatedMemo?.name === memo.name,
   ).length;
-  const relativeTimeFormat = Date.now() - memo.displayTime!.getTime() > 1000 * 60 * 60 * 24 ? "datetime" : "auto";
+  const isMemoOlderThan24Hours = Date.now() - memo.displayTime!.getTime() > 1000 * 60 * 60 * 24
+  const relativeTimeFormat = isMemoOlderThan24Hours ? "datetime" : "auto";
   const isArchived = memo.state === State.ARCHIVED;
   const readonly = memo.creator !== user?.name && !isSuperUser(user);
   const isInMemoDetailPage = location.pathname.startsWith(`/${memo.name}`);
@@ -118,7 +120,9 @@ const MemoView: React.FC<Props> = (props: Props) => {
   const displayTime = isArchived ? (
     memo.displayTime?.toLocaleString()
   ) : (
-    <relative-time datetime={memo.displayTime?.toISOString()} format={relativeTimeFormat}></relative-time>
+    isMemoOlderThan24Hours
+    ? memo.displayTime?.toLocaleString(i18n.resolvedLanguage, { weekday: 'short', day: 'numeric', month: 'short', hour: 'numeric', minute: 'numeric' })
+    : <relative-time datetime={memo.displayTime?.toISOString()} format={relativeTimeFormat}></relative-time>
   );
 
   return (

--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from "@mui/joy";
+import i18n from "i18next";
 import { BookmarkIcon, EyeOffIcon, MessageCircleMoreIcon } from "lucide-react";
 import { memo, useCallback, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
@@ -11,7 +12,6 @@ import { State } from "@/types/proto/api/v1/common";
 import { Memo, MemoRelation_Type, Visibility } from "@/types/proto/api/v1/memo_service";
 import { cn } from "@/utils";
 import { useTranslate } from "@/utils/i18n";
-import i18n from 'i18next';
 import { convertVisibilityToString } from "@/utils/memo";
 import { isSuperUser } from "@/utils/user";
 import MemoActionMenu from "./MemoActionMenu";
@@ -54,7 +54,7 @@ const MemoView: React.FC<Props> = (props: Props) => {
   const commentAmount = memo.relations.filter(
     (relation) => relation.type === MemoRelation_Type.COMMENT && relation.relatedMemo?.name === memo.name,
   ).length;
-  const isMemoOlderThan24Hours = Date.now() - memo.displayTime!.getTime() > 1000 * 60 * 60 * 24
+  const isMemoOlderThan24Hours = Date.now() - memo.displayTime!.getTime() > 1000 * 60 * 60 * 24;
   const relativeTimeFormat = isMemoOlderThan24Hours ? "datetime" : "auto";
   const isArchived = memo.state === State.ARCHIVED;
   const readonly = memo.creator !== user?.name && !isSuperUser(user);
@@ -119,10 +119,16 @@ const MemoView: React.FC<Props> = (props: Props) => {
 
   const displayTime = isArchived ? (
     memo.displayTime?.toLocaleString()
+  ) : isMemoOlderThan24Hours ? (
+    memo.displayTime?.toLocaleString(i18n.resolvedLanguage, {
+      weekday: "short",
+      day: "numeric",
+      month: "short",
+      hour: "numeric",
+      minute: "numeric",
+    })
   ) : (
-    isMemoOlderThan24Hours
-    ? memo.displayTime?.toLocaleString(i18n.resolvedLanguage, { weekday: 'short', day: 'numeric', month: 'short', hour: 'numeric', minute: 'numeric' })
-    : <relative-time datetime={memo.displayTime?.toISOString()} format={relativeTimeFormat}></relative-time>
+    <relative-time datetime={memo.displayTime?.toISOString()} format={relativeTimeFormat}></relative-time>
   );
 
   return (


### PR DESCRIPTION
When reading old memos I didn't had the vision of when I did that specific post because the display date only showed weekday followed by date (Sun, Mar 9). Now the display time also shows the clocktime of memo creation (Sun, Mar 9, 1:40 PM) while keeping the relative time for newest memos such as "1 hour ago". Different time formats for different countries is already accomplished via i18n.

(en-US time)
![image](https://github.com/user-attachments/assets/2d6451a7-895e-466e-ac18-3a5cbcc4fdf9)

(pt-BR time)
![image](https://github.com/user-attachments/assets/3de24b11-1622-4788-be66-db8b226e6bf8)