### PR TITLE
Preventing future package manager error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,3 @@ dist
 
 # VSCode settings
 .vscode
-
-# Wrong package manager used to install frontend dependencies
-web/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ dist
 
 # VSCode settings
 .vscode
+
+# Wrong package manager used to install frontend dependencies
+web/package-lock.json

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -5,3 +5,4 @@ dist
 dist-ssr
 *.local
 src/types/proto
+package-lock.json


### PR DESCRIPTION
New contributors like me might miss the package manager and end up running `npm install` instead of `pnpm install`. Which generates a `package-lock.json` that should not be uploaded to the remote repository since the correct lockfile is `pnpm-lock.yaml`.