### PR TITLE
Import highlight.js css to fix code block not showing color

### DIFF
--- a/web/src/components/MemoContent/CodeBlock.tsx
+++ b/web/src/components/MemoContent/CodeBlock.tsx
@@ -6,6 +6,7 @@ import toast from "react-hot-toast";
 import { cn } from "@/utils";
 import MermaidBlock from "./MermaidBlock";
 import { BaseProps } from "./types";
+import "highlight.js/styles/github.css";
 
 // Special languages that are rendered differently.
 enum SpecialLanguage {


### PR DESCRIPTION
This PR addresses issue #4571 by importing the highlight.js CSS file, which fixes the syntax highlighting issue for code blocks.

Let me know if any changes are needed. Thanks!