### PR TITLE
Fix hashtag parsing

### DIFF
--- a/proto/gen/apidocs.swagger.yaml
+++ b/proto/gen/apidocs.swagger.yaml
@@ -305,9 +305,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
-          description: |-
-            The parent is the owner of the memos.
-            If not specified or `users/-`, it will list all memos.
+          description: "The parent is the owner of the memos.\r\nIf not specified or `users/-`, it will list all memos."
           in: query
           required: false
           type: string
@@ -318,16 +316,12 @@ paths:
           type: integer
           format: int32
         - name: pageToken
-          description: |-
-            A page token, received from a previous `ListMemos` call.
-            Provide this to retrieve the subsequent page.
+          description: "A page token, received from a previous `ListMemos` call.\r\nProvide this to retrieve the subsequent page."
           in: query
           required: false
           type: string
         - name: state
-          description: |-
-            The state of the memos to list.
-            Default to `NORMAL`. Set to `ARCHIVED` to list archived memos.
+          description: "The state of the memos to list.\r\nDefault to `NORMAL`. Set to `ARCHIVED` to list archived memos."
           in: query
           required: false
           type: string
@@ -337,16 +331,12 @@ paths:
             - ARCHIVED
           default: STATE_UNSPECIFIED
         - name: sort
-          description: |-
-            What field to sort the results by.
-            Default to display_time.
+          description: "What field to sort the results by.\r\nDefault to display_time."
           in: query
           required: false
           type: string
         - name: direction
-          description: |-
-            The direction to sort the results by.
-            Default to DESC.
+          description: "The direction to sort the results by.\r\nDefault to DESC."
           in: query
           required: false
           type: string
@@ -356,16 +346,12 @@ paths:
             - DESC
           default: DIRECTION_UNSPECIFIED
         - name: filter
-          description: |-
-            Filter is a CEL expression to filter memos.
-            Refer to `Shortcut.filter`.
+          description: "Filter is a CEL expression to filter memos.\r\nRefer to `Shortcut.filter`."
           in: query
           required: false
           type: string
         - name: oldFilter
-          description: |-
-            [Deprecated] Old filter contains some specific conditions to filter memos.
-            Format: "creator == 'users/{user}' && visibilities == ['PUBLIC', 'PROTECTED']"
+          description: "[Deprecated] Old filter contains some specific conditions to filter memos.\r\nFormat: \"creator == 'users/{user}' && visibilities == ['PUBLIC', 'PROTECTED']\""
           in: query
           required: false
           type: string
@@ -410,9 +396,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: id
-          description: |-
-            The id of the reaction.
-            Refer to the `Reaction.id`.
+          description: "The id of the reaction.\r\nRefer to the `Reaction.id`."
           in: path
           required: true
           type: integer
@@ -678,9 +662,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
-          description: |-
-            The resource name of the workspace setting.
-            Format: settings/{setting}
+          description: "The resource name of the workspace setting.\r\nFormat: settings/{setting}"
           in: path
           required: true
           type: string
@@ -702,9 +684,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: setting.name
-          description: |-
-            name is the name of the setting.
-            Format: settings/{setting}
+          description: "name is the name of the setting.\r\nFormat: settings/{setting}"
           in: path
           required: true
           type: string
@@ -740,9 +720,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: identityProvider.name
-          description: |-
-            The name of the identityProvider.
-            Format: identityProviders/{id}, id is the system generated auto-incremented id.
+          description: "The name of the identityProvider.\r\nFormat: identityProviders/{id}, id is the system generated auto-incremented id."
           in: path
           required: true
           type: string
@@ -780,9 +758,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: inbox.name
-          description: |-
-            The name of the inbox.
-            Format: inboxes/{id}, id is the system generated auto-incremented id.
+          description: "The name of the inbox.\r\nFormat: inboxes/{id}, id is the system generated auto-incremented id."
           in: path
           required: true
           type: string
@@ -826,17 +802,13 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: memo.name
-          description: |-
-            The name of the memo.
-            Format: memos/{memo}, memo is the user defined id or uuid.
+          description: "The name of the memo.\r\nFormat: memos/{memo}, memo is the user defined id or uuid."
           in: path
           required: true
           type: string
           pattern: memos/[^/]+
         - name: memo
-          description: |-
-            The memo to update.
-            The `name` field is required.
+          description: "The memo to update.\r\nThe `name` field is required."
           in: body
           required: true
           schema:
@@ -846,9 +818,7 @@ paths:
                 $ref: '#/definitions/v1State'
               creator:
                 type: string
-                title: |-
-                  The name of the creator.
-                  Format: users/{user}
+                title: "The name of the creator.\r\nFormat: users/{user}"
               createTime:
                 type: string
                 format: date-time
@@ -896,9 +866,7 @@ paths:
                 readOnly: true
               parent:
                 type: string
-                title: |-
-                  The name of the parent memo.
-                  Format: memos/{id}
+                title: "The name of the parent memo.\r\nFormat: memos/{id}"
                 readOnly: true
               snippet:
                 type: string
@@ -907,9 +875,7 @@ paths:
               location:
                 $ref: '#/definitions/apiv1Location'
                 description: The location of the memo.
-            title: |-
-              The memo to update.
-              The `name` field is required.
+            title: "The memo to update.\r\nThe `name` field is required."
             required:
               - memo
       tags:
@@ -1105,9 +1071,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: name
-          description: |-
-            The name of the activity.
-            Format: activities/{id}, id is the system generated auto-incremented id.
+          description: "The name of the activity.\r\nFormat: activities/{id}, id is the system generated auto-incremented id."
           in: path
           required: true
           type: string
@@ -1466,9 +1430,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
-          description: |-
-            The parent is the owner of the memos.
-            If not specified or `users/-`, it will list all memos.
+          description: "The parent is the owner of the memos.\r\nIf not specified or `users/-`, it will list all memos."
           in: path
           required: true
           type: string
@@ -1480,16 +1442,12 @@ paths:
           type: integer
           format: int32
         - name: pageToken
-          description: |-
-            A page token, received from a previous `ListMemos` call.
-            Provide this to retrieve the subsequent page.
+          description: "A page token, received from a previous `ListMemos` call.\r\nProvide this to retrieve the subsequent page."
           in: query
           required: false
           type: string
         - name: state
-          description: |-
-            The state of the memos to list.
-            Default to `NORMAL`. Set to `ARCHIVED` to list archived memos.
+          description: "The state of the memos to list.\r\nDefault to `NORMAL`. Set to `ARCHIVED` to list archived memos."
           in: query
           required: false
           type: string
@@ -1499,16 +1457,12 @@ paths:
             - ARCHIVED
           default: STATE_UNSPECIFIED
         - name: sort
-          description: |-
-            What field to sort the results by.
-            Default to display_time.
+          description: "What field to sort the results by.\r\nDefault to display_time."
           in: query
           required: false
           type: string
         - name: direction
-          description: |-
-            The direction to sort the results by.
-            Default to DESC.
+          description: "The direction to sort the results by.\r\nDefault to DESC."
           in: query
           required: false
           type: string
@@ -1518,16 +1472,12 @@ paths:
             - DESC
           default: DIRECTION_UNSPECIFIED
         - name: filter
-          description: |-
-            Filter is a CEL expression to filter memos.
-            Refer to `Shortcut.filter`.
+          description: "Filter is a CEL expression to filter memos.\r\nRefer to `Shortcut.filter`."
           in: query
           required: false
           type: string
         - name: oldFilter
-          description: |-
-            [Deprecated] Old filter contains some specific conditions to filter memos.
-            Format: "creator == 'users/{user}' && visibilities == ['PUBLIC', 'PROTECTED']"
+          description: "[Deprecated] Old filter contains some specific conditions to filter memos.\r\nFormat: \"creator == 'users/{user}' && visibilities == ['PUBLIC', 'PROTECTED']\""
           in: query
           required: false
           type: string
@@ -1665,9 +1615,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
-          description: |-
-            The parent, who owns the tags.
-            Format: memos/{id}. Use "memos/-" to delete all tags.
+          description: "The parent, who owns the tags.\r\nFormat: memos/{id}. Use \"memos/-\" to delete all tags."
           in: path
           required: true
           type: string
@@ -1698,9 +1646,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: parent
-          description: |-
-            The parent, who owns the tags.
-            Format: memos/{id}. Use "memos/-" to rename all tags.
+          description: "The parent, who owns the tags.\r\nFormat: memos/{id}. Use \"memos/-\" to rename all tags."
           in: path
           required: true
           type: string
@@ -1727,9 +1673,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: resource.name
-          description: |-
-            The name of the resource.
-            Format: resources/{resource}, resource is the user defined if or uuid.
+          description: "The name of the resource.\r\nFormat: resources/{resource}, resource is the user defined if or uuid."
           in: path
           required: true
           type: string
@@ -1815,9 +1759,7 @@ paths:
             $ref: '#/definitions/googlerpcStatus'
       parameters:
         - name: user.name
-          description: |-
-            The name of the user.
-            Format: users/{id}, id is the system generated auto-incremented id.
+          description: "The name of the user.\r\nFormat: users/{id}, id is the system generated auto-incremented id."
           in: path
           required: true
           type: string
@@ -2080,9 +2022,7 @@ definitions:
     properties:
       memo:
         type: string
-        description: |-
-          The memo name of comment.
-          Refer to `Memo.name`.
+        description: "The memo name of comment.\r\nRefer to `Memo.name`."
       relatedMemo:
         type: string
         description: The name of related memo.
@@ -2106,9 +2046,7 @@ definitions:
     properties:
       name:
         type: string
-        description: |-
-          The name of the identityProvider.
-          Format: identityProviders/{id}, id is the system generated auto-incremented id.
+        description: "The name of the identityProvider.\r\nFormat: identityProviders/{id}, id is the system generated auto-incremented id."
       type:
         $ref: '#/definitions/apiv1IdentityProviderType'
       title:
@@ -2144,17 +2082,13 @@ definitions:
     properties:
       name:
         type: string
-        description: |-
-          The name of the memo.
-          Format: memos/{memo}, memo is the user defined id or uuid.
+        description: "The name of the memo.\r\nFormat: memos/{memo}, memo is the user defined id or uuid."
         readOnly: true
       state:
         $ref: '#/definitions/v1State'
       creator:
         type: string
-        title: |-
-          The name of the creator.
-          Format: users/{user}
+        title: "The name of the creator.\r\nFormat: users/{user}"
       createTime:
         type: string
         format: date-time
@@ -2202,9 +2136,7 @@ definitions:
         readOnly: true
       parent:
         type: string
-        title: |-
-          The name of the parent memo.
-          Format: memos/{id}
+        title: "The name of the parent memo.\r\nFormat: memos/{id}"
         readOnly: true
       snippet:
         type: string
@@ -2290,10 +2222,7 @@ definitions:
       weekStartDayOffset:
         type: integer
         format: int32
-        description: |-
-          week_start_day_offset is the week start day offset from Sunday.
-          0: Sunday, 1: Monday, 2: Tuesday, 3: Wednesday, 4: Thursday, 5: Friday, 6: Saturday
-          Default is Sunday.
+        description: "week_start_day_offset is the week start day offset from Sunday.\r\n0: Sunday, 1: Monday, 2: Tuesday, 3: Wednesday, 4: Thursday, 5: Friday, 6: Saturday\r\nDefault is Sunday."
       disallowChangeUsername:
         type: boolean
         description: disallow_change_username disallows changing username.
@@ -2346,9 +2275,7 @@ definitions:
     properties:
       name:
         type: string
-        title: |-
-          name is the name of the setting.
-          Format: settings/{setting}
+        title: "name is the name of the setting.\r\nFormat: settings/{setting}"
       generalSetting:
         $ref: '#/definitions/apiv1WorkspaceGeneralSetting'
       storageSetting:
@@ -2363,9 +2290,7 @@ definitions:
         description: storage_type is the storage type.
       filepathTemplate:
         type: string
-        title: |-
-          The template of file path.
-          e.g. assets/{timestamp}_{filename}
+        title: "The template of file path.\r\ne.g. assets/{timestamp}_{filename}"
       uploadSizeLimitMb:
         type: string
         format: int64
@@ -2524,15 +2449,11 @@ definitions:
     properties:
       name:
         type: string
-        title: |-
-          The name of the activity.
-          Format: activities/{id}
+        title: "The name of the activity.\r\nFormat: activities/{id}"
         readOnly: true
       creator:
         type: string
-        title: |-
-          The name of the creator.
-          Format: users/{user}
+        title: "The name of the creator.\r\nFormat: users/{user}"
       type:
         type: string
         description: The type of the activity.
@@ -2659,9 +2580,7 @@ definitions:
     properties:
       name:
         type: string
-        description: |-
-          The name of the inbox.
-          Format: inboxes/{id}, id is the system generated auto-incremented id.
+        description: "The name of the inbox.\r\nFormat: inboxes/{id}, id is the system generated auto-incremented id."
       sender:
         type: string
         title: 'Format: users/{user}'
@@ -2749,9 +2668,7 @@ definitions:
           $ref: '#/definitions/v1Inbox'
       nextPageToken:
         type: string
-        description: |-
-          A token, which can be sent as `page_token` to retrieve the next page.
-          If this field is omitted, there are no subsequent pages.
+        description: "A token, which can be sent as `page_token` to retrieve the next page.\r\nIf this field is omitted, there are no subsequent pages."
   v1ListMemoCommentsResponse:
     type: object
     properties:
@@ -2794,9 +2711,7 @@ definitions:
           $ref: '#/definitions/apiv1Memo'
       nextPageToken:
         type: string
-        description: |-
-          A token, which can be sent as `page_token` to retrieve the next page.
-          If this field is omitted, there are no subsequent pages.
+        description: "A token, which can be sent as `page_token` to retrieve the next page.\r\nIf this field is omitted, there are no subsequent pages."
   v1ListNode:
     type: object
     properties:
@@ -2885,9 +2800,7 @@ definitions:
     properties:
       name:
         type: string
-        title: |-
-          The name of the memo.
-          Format: memos/{id}
+        title: "The name of the memo.\r\nFormat: memos/{id}"
       uid:
         type: string
       snippet:
@@ -3051,14 +2964,10 @@ definitions:
         format: int32
       creator:
         type: string
-        title: |-
-          The name of the creator.
-          Format: users/{user}
+        title: "The name of the creator.\r\nFormat: users/{user}"
       contentId:
         type: string
-        description: |-
-          The content identifier.
-          For memo, it should be the `Memo.name`.
+        description: "The content identifier.\r\nFor memo, it should be the `Memo.name`."
       reactionType:
         type: string
   v1ReferencedContentNode:
@@ -3073,9 +2982,7 @@ definitions:
     properties:
       name:
         type: string
-        description: |-
-          The name of the resource.
-          Format: resources/{resource}, resource is the user defined if or uuid.
+        description: "The name of the resource.\r\nFormat: resources/{resource}, resource is the user defined if or uuid."
         readOnly: true
       createTime:
         type: string
@@ -3209,9 +3116,7 @@ definitions:
     properties:
       name:
         type: string
-        description: |-
-          The name of the user.
-          Format: users/{id}, id is the system generated auto-incremented id.
+        description: "The name of the user.\r\nFormat: users/{id}, id is the system generated auto-incremented id."
         readOnly: true
       role:
         $ref: '#/definitions/UserRole'
@@ -3261,9 +3166,7 @@ definitions:
         items:
           type: string
           format: date-time
-        description: |-
-          The timestamps when the memos were displayed.
-          We should return raw data to the client, and let the client format the data with the user's timezone.
+        description: "The timestamps when the memos were displayed.\r\nWe should return raw data to the client, and let the client format the data with the user's timezone."
       memoTypeStats:
         $ref: '#/definitions/UserStatsMemoTypeStats'
         description: The stats of memo types.
@@ -3272,9 +3175,7 @@ definitions:
         additionalProperties:
           type: integer
           format: int32
-        title: |-
-          The count of tags.
-          Format: "tag1": 1, "tag2": 2
+        title: "The count of tags.\r\nFormat: \"tag1\": 1, \"tag2\": 2"
       pinnedMemos:
         type: array
         items:
@@ -3315,9 +3216,7 @@ definitions:
     properties:
       owner:
         type: string
-        title: |-
-          The name of instance owner.
-          Format: users/{user}
+        title: "The name of instance owner.\r\nFormat: users/{user}"
       version:
         type: string
         title: version is the current version of instance

--- a/server/router/api/v1/markdown_service.go
+++ b/server/router/api/v1/markdown_service.go
@@ -2,13 +2,13 @@ package v1
 
 import (
 	"context"
-
 	"github.com/pkg/errors"
 	"github.com/usememos/gomark/ast"
 	"github.com/usememos/gomark/parser"
 	"github.com/usememos/gomark/parser/tokenizer"
 	"github.com/usememos/gomark/renderer"
 	"github.com/usememos/gomark/restore"
+	"regexp"
 
 	"github.com/usememos/memos/plugin/httpgetter"
 	v1pb "github.com/usememos/memos/proto/gen/api/v1"
@@ -110,7 +110,15 @@ func convertFromASTNode(rawNode ast.Node) *v1pb.Node {
 	case *ast.AutoLink:
 		node.Node = &v1pb.Node_AutoLinkNode{AutoLinkNode: &v1pb.AutoLinkNode{Url: n.URL, IsRawText: n.IsRawText}}
 	case *ast.Tag:
-		node.Node = &v1pb.Node_TagNode{TagNode: &v1pb.TagNode{Content: n.Content}}
+		re := regexp.MustCompile(`^([\p{L}\p{N}_\x{1F300}-\x{1FAD6}]+)`)
+		tag := re.FindString(n.Content)
+		if tag != "" {
+			node.Node = &v1pb.Node_TagNode{
+				TagNode: &v1pb.TagNode{
+					Content: tag,
+				},
+			}
+		}
 	case *ast.Strikethrough:
 		node.Node = &v1pb.Node_StrikethroughNode{StrikethroughNode: &v1pb.StrikethroughNode{Content: n.Content}}
 	case *ast.EscapingCharacter:

--- a/server/router/api/v1/markdown_service.go
+++ b/server/router/api/v1/markdown_service.go
@@ -2,13 +2,14 @@ package v1
 
 import (
 	"context"
+	"regexp"
+
 	"github.com/pkg/errors"
 	"github.com/usememos/gomark/ast"
 	"github.com/usememos/gomark/parser"
 	"github.com/usememos/gomark/parser/tokenizer"
 	"github.com/usememos/gomark/renderer"
 	"github.com/usememos/gomark/restore"
-	"regexp"
 
 	"github.com/usememos/memos/plugin/httpgetter"
 	v1pb "github.com/usememos/memos/proto/gen/api/v1"

--- a/server/runner/memopayload/runner.go
+++ b/server/runner/memopayload/runner.go
@@ -3,6 +3,7 @@ package memopayload
 import (
 	"context"
 	"log/slog"
+	"regexp"
 	"slices"
 
 	"github.com/pkg/errors"
@@ -60,9 +61,12 @@ func RebuildMemoPayload(memo *store.Memo) error {
 	TraverseASTNodes(nodes, func(node ast.Node) {
 		switch n := node.(type) {
 		case *ast.Tag:
-			tag := n.Content
-			if !slices.Contains(tags, tag) {
-				tags = append(tags, tag)
+			re := regexp.MustCompile(`^[\w\p{L}\p{N}\x{1F300}-\x{1FAD6}]+`)
+			tag := re.FindString(n.Content)
+			if tag != "" {
+				if !slices.Contains(tags, tag) {
+					tags = append(tags, tag)
+				}
 			}
 		case *ast.Link, *ast.AutoLink:
 			property.HasLink = true


### PR DESCRIPTION
Fixes an issue where hashtags incorrectly include trailing punctuation such as ,, :, and .... Now hashtags are parsed correctly, ignoring special characters at the end.

Also adds support for multi-language and emoji tags like #标签 and #🚀go.