### PR TITLE
feat: configure database connection pool settings

### DIFF
--- a/server/profile/profile.go
+++ b/server/profile/profile.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -30,6 +31,12 @@ type Profile struct {
 	Version string
 	// InstanceURL is the url of your memos instance.
 	InstanceURL string
+	// DBMaxOpenConns is the maximum number of open connections to the database.
+	DBMaxOpenConns int
+	// DBMaxIdleConns is the maximum number of idle connections to the database.
+	DBMaxIdleConns int
+	// DBConnMaxLifetime is the maximum amount of time a connection may be reused.
+	DBConnMaxLifetime time.Duration
 }
 
 func (p *Profile) IsDev() bool {
@@ -76,7 +83,7 @@ func (p *Profile) Validate() error {
 
 	dataDir, err := checkDataDir(p.Data)
 	if err != nil {
-		slog.Error("failed to check dsn", slog.String("data", dataDir), slog.String("error", err.Error()))
+		slog.Error("failed to check data directory", slog.String("data", dataDir), slog.String("error", err.Error()))
 		return err
 	}
 

--- a/store/db/db.go
+++ b/store/db/db.go
@@ -1,6 +1,9 @@
 package db
 
 import (
+	"runtime"
+	"time"
+
 	"github.com/pkg/errors"
 
 	"github.com/usememos/memos/server/profile"
@@ -28,5 +31,10 @@ func NewDBDriver(profile *profile.Profile) (store.Driver, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create db driver")
 	}
+
+	cores := runtime.NumCPU()
+	driver.GetDB().SetMaxOpenConns(cores * 2)
+	driver.GetDB().SetMaxIdleConns(cores)
+	driver.GetDB().SetConnMaxLifetime(time.Minute * 5)
 	return driver, nil
 }

--- a/store/db/db.go
+++ b/store/db/db.go
@@ -1,9 +1,6 @@
 package db
 
 import (
-	"runtime"
-	"time"
-
 	"github.com/pkg/errors"
 
 	"github.com/usememos/memos/server/profile"
@@ -32,9 +29,8 @@ func NewDBDriver(profile *profile.Profile) (store.Driver, error) {
 		return nil, errors.Wrap(err, "failed to create db driver")
 	}
 
-	cores := runtime.NumCPU()
-	driver.GetDB().SetMaxOpenConns(cores * 2)
-	driver.GetDB().SetMaxIdleConns(cores)
-	driver.GetDB().SetConnMaxLifetime(time.Minute * 5)
+	driver.GetDB().SetMaxOpenConns(profile.DBMaxOpenConns)
+	driver.GetDB().SetMaxIdleConns(profile.DBMaxIdleConns)
+	driver.GetDB().SetConnMaxLifetime(profile.DBConnMaxLifetime)
 	return driver, nil
 }

--- a/store/test/store_bench_test.go
+++ b/store/test/store_bench_test.go
@@ -1,0 +1,133 @@
+package teststore
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/lithammer/shortuuid/v4"
+	"github.com/usememos/memos/store"
+)
+
+// BenchmarkDB groups all database benchmarks
+func BenchmarkDB(b *testing.B) {
+	b.Run("BenchmarkDBConnPool", BenchmarkDBConnPool)
+}
+
+// benchmarkConfig defines the configuration for benchmark testing
+type benchmarkConfig struct {
+	maxOpenConns    int
+	maxIdleConns    int
+	connMaxLifetime *time.Duration
+}
+
+// benchmarkConnectionPool tests the performance of sql.DB connection pooling.
+func BenchmarkDBConnPool(b *testing.B) {
+	cores := runtime.NumCPU()
+	lifeTime := time.Hour
+	cases := []struct {
+		name   string
+		config benchmarkConfig
+	}{
+		{
+			name: "default_unlimited",
+			config: benchmarkConfig{
+				maxOpenConns:    0,   // Use default value 0 (unlimited)
+				maxIdleConns:    2,   // Use default value 2
+				connMaxLifetime: nil, // Use default value 0 (unlimited)
+			},
+		},
+		{
+			name: "max_conns_equals_cores",
+			config: benchmarkConfig{
+				maxOpenConns:    cores,
+				maxIdleConns:    cores / 2,
+				connMaxLifetime: &lifeTime,
+			},
+		},
+		{
+			name: "max_conns_double_cores",
+			config: benchmarkConfig{
+				maxOpenConns:    cores * 2,
+				maxIdleConns:    cores,
+				connMaxLifetime: &lifeTime,
+			},
+		},
+		{
+			name: "max_conns_25",
+			config: benchmarkConfig{
+				maxOpenConns:    25,
+				maxIdleConns:    10,
+				connMaxLifetime: &lifeTime,
+			},
+		},
+		{
+			name: "max_conns_50",
+			config: benchmarkConfig{
+				maxOpenConns:    50,
+				maxIdleConns:    25,
+				connMaxLifetime: &lifeTime,
+			},
+		},
+		{
+			name: "max_conns_100",
+			config: benchmarkConfig{
+				maxOpenConns:    100,
+				maxIdleConns:    50,
+				connMaxLifetime: &lifeTime,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			ctx := context.Background()
+			ts := NewTestingStore(ctx, &testing.T{})
+			db := ts.GetDriver().GetDB()
+
+			db.SetMaxOpenConns(tc.config.maxOpenConns)
+			db.SetMaxIdleConns(tc.config.maxIdleConns)
+
+			if tc.config.connMaxLifetime != nil {
+				db.SetConnMaxLifetime(*tc.config.connMaxLifetime)
+			}
+
+			user, err := createTestingHostUser(ctx, ts)
+			if err != nil {
+				b.Logf("failed to create testing host user: %v", err)
+			}
+
+			// Set concurrency level
+			b.SetParallelism(100)
+			b.ResetTimer()
+
+			// Record initial stats
+			startStats := db.Stats()
+
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					// Execute database operation
+					memoCreate := &store.Memo{
+						UID:        shortuuid.New(),
+						CreatorID:  user.ID,
+						Content:    "test_content",
+						Visibility: store.Public,
+					}
+					_, err := ts.CreateMemo(ctx, memoCreate)
+					if err != nil {
+						b.Fatal("failed to create memo:", err)
+					}
+				}
+			})
+
+			// Collect and report connection pool statistics
+			endStats := db.Stats()
+			// b.ReportMetric(float64(endStats.MaxOpenConnections), "max_open_conns")
+			// b.ReportMetric(float64(endStats.InUse), "conns_in_use")
+			// b.ReportMetric(float64(endStats.Idle), "idle_conns")
+			b.ReportMetric(float64(endStats.WaitCount-startStats.WaitCount), "wait_count")
+			b.ReportMetric(float64((endStats.WaitDuration - startStats.WaitDuration).Milliseconds()), "wait_duration_ms")
+		})
+	}
+}

--- a/store/test/store_bench_test.go
+++ b/store/test/store_bench_test.go
@@ -7,15 +7,16 @@ import (
 	"time"
 
 	"github.com/lithammer/shortuuid/v4"
+
 	"github.com/usememos/memos/store"
 )
 
-// BenchmarkDB groups all database benchmarks
+// BenchmarkDB groups all database benchmarks.
 func BenchmarkDB(b *testing.B) {
 	b.Run("BenchmarkDBConnPool", BenchmarkDBConnPool)
 }
 
-// benchmarkConfig defines the configuration for benchmark testing
+// benchmarkConfig defines the configuration for benchmark testing.
 type benchmarkConfig struct {
 	maxOpenConns    int
 	maxIdleConns    int


### PR DESCRIPTION
### Description
Changed default connection pool configuration for all database drivers. 

### Implementation Details
Based on benchmark testing and research, I found setting max connections to twice the number of CPU cores provides an optimal balance between performance and resource utilization, as shown in the benchmark results. However, I'm open to discussion on these specific values:
```go
cores := runtime.NumCPU()
driver.GetDB().SetMaxOpenConns(cores * 2)      // **Should this be cores * 2?**
driver.GetDB().SetMaxIdleConns(cores)  // **Is half of max connections appropriate?**
driver.GetDB().SetConnMaxLifetime(time.Minute * 5)
```

###  Review Questions

1. Are these default values appropriate for most use cases?
2. Should we make these values configurable via config file?


### References
* [About-Pool-Sizing](https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing#the-formula)
* [sql.DB docs](https://pkg.go.dev/database/sql#DB.SetMaxOpenConns)
* [go-sql-driver/mysql docs](https://github.com/go-sql-driver/mysql/?tab=readme-ov-file#important-settings)

#### Benchmark 
Tested with SQLite driver on Linux (Intel i5-3230M @ 2.60GHz, 2 cores/4 threads):
```
goos: linux
goarch: amd64
pkg: github.com/usememos/memos/store/test
cpu: Intel(R) Core(TM) i5-3230M CPU @ 2.60GHz
BenchmarkDBConnPool/default_unlimited-4         	     100	  49079319 ns/op	         0 wait_count	         0 wait_duration_ms	   12509 B/op	      94 allocs/op
BenchmarkDBConnPool/max_conns_equals_cores-4    	     127	   9230205 ns/op	       123.0 wait_count	     54868 wait_duration_ms	    1963 B/op	      53 allocs/op
BenchmarkDBConnPool/max_conns_double_cores-4    	     100	  11410104 ns/op	        92.00 wait_count	     29387 wait_duration_ms	    3155 B/op	      55 allocs/op
BenchmarkDBConnPool/max_conns_25-4              	     100	  20643346 ns/op	        74.00 wait_count	     19161 wait_duration_ms	    3640 B/op	      60 allocs/op
BenchmarkDBConnPool/max_conns_50-4              	     100	  41783602 ns/op	        50.00 wait_count	      9294 wait_duration_ms	    4428 B/op	      68 allocs/op
BenchmarkDBConnPool/max_conns_100-4             	     100	  36894592 ns/op	         0 wait_count	         0 wait_duration_ms	    5111 B/op	      83 allocs/op
PASS
ok  	github.com/usememos/memos/store/test	20.815s
```