### PR TITLE
Improve visual feedback in MemoEditor for drag/drop file uploads 

### DIFF
--- a/web/src/components/MemoEditor/ActionButton/UploadResourceButton.tsx
+++ b/web/src/components/MemoEditor/ActionButton/UploadResourceButton.tsx
@@ -6,11 +6,15 @@ import { useResourceStore } from "@/store/v1";
 import { Resource } from "@/types/proto/api/v1/resource_service";
 import { MemoEditorContext } from "../types";
 
+interface Props {
+  isUploadingResource?: boolean;
+}
+
 interface State {
   uploadingFlag: boolean;
 }
 
-const UploadResourceButton = () => {
+const UploadResourceButton = (props: Props) => {
   const context = useContext(MemoEditorContext);
   const resourceStore = useResourceStore();
   const [state, setState] = useState<State>({
@@ -65,13 +69,15 @@ const UploadResourceButton = () => {
     });
   };
 
+  const isUploading = state.uploadingFlag || props.isUploadingResource;
+
   return (
-    <Button className="relative" size="sm" variant="plain" disabled={state.uploadingFlag}>
-      {state.uploadingFlag ? <LoaderIcon className="w-5 h-5 mx-auto animate-spin" /> : <PaperclipIcon className="w-5 h-5 mx-auto" />}
+    <Button className="relative" size="sm" variant="plain" disabled={isUploading}>
+      {isUploading ? <LoaderIcon className="w-5 h-5 mx-auto animate-spin" /> : <PaperclipIcon className="w-5 h-5 mx-auto" />}
       <input
         className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
         ref={fileInputRef}
-        disabled={state.uploadingFlag}
+        disabled={isUploading}
         onChange={handleFileInputChange}
         type="file"
         id="files"

--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -472,7 +472,9 @@ const MemoEditor = observer((props: Props) => {
         className={`${
           className ?? ""
         } relative w-full flex flex-col justify-start items-start bg-white dark:bg-zinc-800 px-4 pt-4 rounded-lg border ${
-          state.isDraggingFile ? "border-dashed border-gray-400 dark:border-primary-400 cursor-copy" : "border-gray-200 dark:border-zinc-700 cursor-auto"
+          state.isDraggingFile
+            ? "border-dashed border-gray-400 dark:border-primary-400 cursor-copy"
+            : "border-gray-200 dark:border-zinc-700 cursor-auto"
         }`}
         tabIndex={0}
         onKeyDown={handleKeyDown}

--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -472,7 +472,7 @@ const MemoEditor = observer((props: Props) => {
         className={`${
           className ?? ""
         } relative w-full flex flex-col justify-start items-start bg-white dark:bg-zinc-800 px-4 pt-4 rounded-lg border ${
-          state.isDraggingFile ? "border-dashed border-gray-400 dark:border-primary-400" : "border-gray-200 dark:border-zinc-700"
+          state.isDraggingFile ? "border-dashed border-gray-400 dark:border-primary-400 cursor-copy" : "border-gray-200 dark:border-zinc-700 cursor-auto"
         }`}
         tabIndex={0}
         onKeyDown={handleKeyDown}
@@ -482,9 +482,6 @@ const MemoEditor = observer((props: Props) => {
         onFocus={handleEditorFocus}
         onCompositionStart={handleCompositionStart}
         onCompositionEnd={handleCompositionEnd}
-        style={{
-          cursor: state.isDraggingFile ? "copy" : "auto",
-        }}
       >
         {memoName && displayTime && (
           <DatePicker

--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -201,7 +201,7 @@ const MemoEditor = observer((props: Props) => {
         isUploadingResource: true,
       };
     });
-    
+
     const { name: filename, size, type } = file;
     const buffer = new Uint8Array(await file.arrayBuffer());
 
@@ -265,7 +265,7 @@ const MemoEditor = observer((props: Props) => {
         ...prevState,
         isDraggingFile: false,
       }));
-      
+
       await uploadMultiFiles(event.dataTransfer.files);
     }
   };
@@ -482,8 +482,8 @@ const MemoEditor = observer((props: Props) => {
         onFocus={handleEditorFocus}
         onCompositionStart={handleCompositionStart}
         onCompositionEnd={handleCompositionEnd}
-        style={{ 
-          cursor: state.isDraggingFile ? "copy" : "auto" 
+        style={{
+          cursor: state.isDraggingFile ? "copy" : "auto",
         }}
       >
         {memoName && displayTime && (

--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -54,6 +54,7 @@ interface State {
   isUploadingResource: boolean;
   isRequesting: boolean;
   isComposing: boolean;
+  isDraggingFile: boolean;
 }
 
 const MemoEditor = observer((props: Props) => {
@@ -71,6 +72,7 @@ const MemoEditor = observer((props: Props) => {
     isUploadingResource: false,
     isRequesting: false,
     isComposing: false,
+    isDraggingFile: false,
   });
   const [displayTime, setDisplayTime] = useState<Date | undefined>();
   const [hasContent, setHasContent] = useState<boolean>(false);
@@ -199,7 +201,7 @@ const MemoEditor = observer((props: Props) => {
         isUploadingResource: true,
       };
     });
-
+    
     const { name: filename, size, type } = file;
     const buffer = new Uint8Array(await file.arrayBuffer());
 
@@ -222,6 +224,12 @@ const MemoEditor = observer((props: Props) => {
     } catch (error: any) {
       console.error(error);
       toast.error(error.details);
+      setState((state) => {
+        return {
+          ...state,
+          isUploadingResource: false,
+        };
+      });
     }
   };
 
@@ -253,8 +261,34 @@ const MemoEditor = observer((props: Props) => {
   const handleDropEvent = async (event: React.DragEvent) => {
     if (event.dataTransfer && event.dataTransfer.files.length > 0) {
       event.preventDefault();
+      setState((prevState) => ({
+        ...prevState,
+        isDraggingFile: false,
+      }));
+      
       await uploadMultiFiles(event.dataTransfer.files);
     }
+  };
+
+  const handleDragOver = (event: React.DragEvent) => {
+    if (event.dataTransfer && event.dataTransfer.types.includes("Files")) {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "copy";
+      if (!state.isDraggingFile) {
+        setState((prevState) => ({
+          ...prevState,
+          isDraggingFile: true,
+        }));
+      }
+    }
+  };
+
+  const handleDragLeave = (event: React.DragEvent) => {
+    event.preventDefault();
+    setState((prevState) => ({
+      ...prevState,
+      isDraggingFile: false,
+    }));
   };
 
   const handlePasteEvent = async (event: React.ClipboardEvent) => {
@@ -384,6 +418,7 @@ const MemoEditor = observer((props: Props) => {
         resourceList: [],
         relationList: [],
         location: undefined,
+        isDraggingFile: false,
       };
     });
   };
@@ -436,13 +471,20 @@ const MemoEditor = observer((props: Props) => {
       <div
         className={`${
           className ?? ""
-        } relative w-full flex flex-col justify-start items-start bg-white dark:bg-zinc-800 px-4 pt-4 rounded-lg border border-gray-200 dark:border-zinc-700`}
+        } relative w-full flex flex-col justify-start items-start bg-white dark:bg-zinc-800 px-4 pt-4 rounded-lg border ${
+          state.isDraggingFile ? "border-dashed border-gray-400 dark:border-primary-400" : "border-gray-200 dark:border-zinc-700"
+        }`}
         tabIndex={0}
         onKeyDown={handleKeyDown}
         onDrop={handleDropEvent}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
         onFocus={handleEditorFocus}
         onCompositionStart={handleCompositionStart}
         onCompositionEnd={handleCompositionEnd}
+        style={{ 
+          cursor: state.isDraggingFile ? "copy" : "auto" 
+        }}
       >
         {memoName && displayTime && (
           <DatePicker
@@ -464,7 +506,7 @@ const MemoEditor = observer((props: Props) => {
           <div className="flex flex-row justify-start items-center opacity-80 dark:opacity-60 -space-x-1">
             <TagSelector editorRef={editorRef} />
             <MarkdownMenu editorRef={editorRef} />
-            <UploadResourceButton />
+            <UploadResourceButton isUploadingResource={state.isUploadingResource} />
             <AddMemoRelationPopover editorRef={editorRef} />
             {workspaceMemoRelatedSetting.enableLocation && (
               <LocationSelector


### PR DESCRIPTION
Improve drag/drop file upload experience with better visual feedback and state management. This enhances clarity and usability.

**Changes:**
- Allow file drop on entire area of `MemoEditor`
- Add clear drag/drop visual feedback with dashed border, cursor: copy, and loading spinner
- Pass `isUploadingResource` from `MemoEditor` to `UploadResourceButton` as a prop to always display spinner during active uploads
- Add `isDraggingFile` state in `MemoEditor` to track drag UI state


https://github.com/user-attachments/assets/76b7d85a-2ba7-45e9-b5bf-7da941470ee9

