### PR TITLE
feat: set locale based on browser language when user is not logged in

### DIFF
--- a/web/src/store/v2/user.ts
+++ b/web/src/store/v2/user.ts
@@ -224,6 +224,7 @@ export const initialUserStore = async () => {
       appearance: userSetting.appearance,
     });
   } catch {
+    // find the nearest matched lang based on the `navigator.language` if the user is unauthenticated or settings retrieval fails.
     const locale = findNearestMatchedLanguage(navigator.language);
     workspaceStore.state.setPartial({
       locale: locale,

--- a/web/src/store/v2/user.ts
+++ b/web/src/store/v2/user.ts
@@ -3,6 +3,7 @@ import { makeAutoObservable } from "mobx";
 import { authServiceClient, inboxServiceClient, userServiceClient } from "@/grpcweb";
 import { Inbox } from "@/types/proto/api/v1/inbox_service";
 import { Shortcut, User, UserSetting, UserStats } from "@/types/proto/api/v1/user_service";
+import { findNearestMatchedLanguage } from "@/utils/i18n";
 import workspaceStore from "./workspace";
 
 class LocalState {
@@ -223,7 +224,10 @@ export const initialUserStore = async () => {
       appearance: userSetting.appearance,
     });
   } catch {
-    // Do nothing.
+    const locale = findNearestMatchedLanguage(navigator.language);
+    workspaceStore.state.setPartial({
+      locale: locale,
+    });
   }
 };
 


### PR DESCRIPTION
### Description
This PR adds functionality to detect and set the locale based on the browser's language settings (`navigator.language`) when the user is not logged in.
Let me know if anything else needs to be updated. Thanks!

### Related Issue
Closes #4557