### PR TITLE
Fixes #4604: Support Child Tags in NSFW Blur Feature

### DIFF
--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -60,8 +60,12 @@ const MemoView: React.FC<Props> = (props: Props) => {
   const parentPage = props.parentPage || location.pathname;
   const nsfw =
     workspaceMemoRelatedSetting.enableBlurNsfwContent &&
-    memo.tags?.some((tag) => workspaceMemoRelatedSetting.nsfwTags.includes(tag.toLowerCase()));
-
+    memo.tags?.some((tag) => {
+      return (
+        tag.startsWith("nsfw") ||
+        workspaceMemoRelatedSetting.nsfwTags.includes(tag)
+      );
+    });
   // Initial related data: creator.
   useAsyncEffect(async () => {
     const user = await userStore.getOrFetchUserByName(memo.creator);

--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -59,13 +59,14 @@ const MemoView: React.FC<Props> = (props: Props) => {
   const isInMemoDetailPage = location.pathname.startsWith(`/${memo.name}`);
   const parentPage = props.parentPage || location.pathname;
   const nsfw =
-    workspaceMemoRelatedSetting.enableBlurNsfwContent &&
-    memo.tags?.some((tag) => {
-      return (
-        tag.startsWith("nsfw") ||
-        workspaceMemoRelatedSetting.nsfwTags.includes(tag)
-      );
-    });
+  workspaceMemoRelatedSetting.enableBlurNsfwContent &&
+  memo.tags?.some((tag) =>
+    workspaceMemoRelatedSetting.nsfwTags.some((nsfwTag) =>
+      tag === nsfwTag ||
+      tag.startsWith(`${nsfwTag}/`)
+    )
+  );
+
   // Initial related data: creator.
   useAsyncEffect(async () => {
     const user = await userStore.getOrFetchUserByName(memo.creator);

--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -59,13 +59,8 @@ const MemoView: React.FC<Props> = (props: Props) => {
   const isInMemoDetailPage = location.pathname.startsWith(`/${memo.name}`);
   const parentPage = props.parentPage || location.pathname;
   const nsfw =
-  workspaceMemoRelatedSetting.enableBlurNsfwContent &&
-  memo.tags?.some((tag) =>
-    workspaceMemoRelatedSetting.nsfwTags.some((nsfwTag) =>
-      tag === nsfwTag ||
-      tag.startsWith(`${nsfwTag}/`)
-    )
-  );
+    workspaceMemoRelatedSetting.enableBlurNsfwContent &&
+    memo.tags?.some((tag) => workspaceMemoRelatedSetting.nsfwTags.some((nsfwTag) => tag === nsfwTag || tag.startsWith(`${nsfwTag}/`)));
 
   // Initial related data: creator.
   useAsyncEffect(async () => {


### PR DESCRIPTION
My fix supports what is described in the issue, if tags like "#something/nsfw" or "#blabla-nsfw-blabla" are also supposed to be supported, a quick change can be made from this `tag.startsWith("nsfw")` to this `tag.includes("nsfw")`.