### PR TITLE
Move memo filters component to the bottom of the sidebar

### DIFF
--- a/web/src/components/HomeSidebar/HomeSidebar.tsx
+++ b/web/src/components/HomeSidebar/HomeSidebar.tsx
@@ -90,12 +90,12 @@ const HomeSidebar = observer((props: Props) => {
           </NavLink>
         ))}
       </div>
-      <MemoFilters />
       <div className="px-2 w-full">
         <StatisticsView />
         {currentUser && <ShortcutsSection />}
         <TagsSection />
       </div>
+      <MemoFilters />
     </aside>
   );
 });


### PR DESCRIPTION
### **Optimized Layout Proposal for MemoFilter**  

We recommend relocating the **MemoFilter** beneath the **Tags** component for the following reasons:  

1. **Enhanced Usability**: The new positioning reduces the spatial distance between MemoFilter and Tags, improving operational efficiency.  
2. **Layout Consistency**: This adjustment ensures the Sidebar’s structure remains unaffected by the presence or absence of filters, maintaining a stable and uniform interface.  


https://github.com/user-attachments/assets/252a30fd-4115-42e6-b764-91c9c9687a7e

