### PR TITLE
fix: remove duplicated “Enable” in settings label

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -280,7 +280,7 @@
     "memo-related": "Memo",
     "memo-related-settings": {
       "content-lenght-limit": "Content length limit (Byte)",
-      "enable-blur-nsfw-content": "Enable Enable sensitive content(NSFW) blurring",
+      "enable-blur-nsfw-content": "Enable sensitive content (NSFW) blurring",
       "enable-link-preview": "Enable link preview",
       "enable-memo-comments": "Enable memo comments",
       "enable-memo-location": "Enable memo location",


### PR DESCRIPTION
Remove duplicated word "Enable" and add a space

Follow-up to cd5abd9 and [this discussion](https://github.com/orgs/usememos/discussions/4627)