### PR TITLE
feat: add infinite scrolling for memos

### DIFF
--- a/proto/api/v1/user_service.proto
+++ b/proto/api/v1/user_service.proto
@@ -122,6 +122,11 @@ service UserService {
   }
 }
 
+enum ScrollMode {
+  BUTTON = 0;
+  INFINITE = 1;
+}
+
 message User {
   // The name of the user.
   // Format: users/{id}, id is the system generated auto-incremented id.
@@ -244,6 +249,8 @@ message UserSetting {
   string appearance = 3;
   // The default visibility of the memo.
   string memo_visibility = 4;
+  // Whether infinite scroll should be enabled
+  ScrollMode scroll_mode = 5;
 }
 
 message GetUserSettingRequest {

--- a/proto/gen/api/v1/user_service.pb.go
+++ b/proto/gen/api/v1/user_service.pb.go
@@ -26,6 +26,52 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type ScrollMode int32
+
+const (
+	ScrollMode_BUTTON   ScrollMode = 0
+	ScrollMode_INFINITE ScrollMode = 1
+)
+
+// Enum value maps for ScrollMode.
+var (
+	ScrollMode_name = map[int32]string{
+		0: "BUTTON",
+		1: "INFINITE",
+	}
+	ScrollMode_value = map[string]int32{
+		"BUTTON":   0,
+		"INFINITE": 1,
+	}
+)
+
+func (x ScrollMode) Enum() *ScrollMode {
+	p := new(ScrollMode)
+	*p = x
+	return p
+}
+
+func (x ScrollMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ScrollMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_v1_user_service_proto_enumTypes[0].Descriptor()
+}
+
+func (ScrollMode) Type() protoreflect.EnumType {
+	return &file_api_v1_user_service_proto_enumTypes[0]
+}
+
+func (x ScrollMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ScrollMode.Descriptor instead.
+func (ScrollMode) EnumDescriptor() ([]byte, []int) {
+	return file_api_v1_user_service_proto_rawDescGZIP(), []int{0}
+}
+
 type User_Role int32
 
 const (
@@ -62,11 +108,11 @@ func (x User_Role) String() string {
 }
 
 func (User_Role) Descriptor() protoreflect.EnumDescriptor {
-	return file_api_v1_user_service_proto_enumTypes[0].Descriptor()
+	return file_api_v1_user_service_proto_enumTypes[1].Descriptor()
 }
 
 func (User_Role) Type() protoreflect.EnumType {
-	return &file_api_v1_user_service_proto_enumTypes[0]
+	return &file_api_v1_user_service_proto_enumTypes[1]
 }
 
 func (x User_Role) Number() protoreflect.EnumNumber {
@@ -795,8 +841,10 @@ type UserSetting struct {
 	Appearance string `protobuf:"bytes,3,opt,name=appearance,proto3" json:"appearance,omitempty"`
 	// The default visibility of the memo.
 	MemoVisibility string `protobuf:"bytes,4,opt,name=memo_visibility,json=memoVisibility,proto3" json:"memo_visibility,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Whether infinite scroll should be enabled
+	ScrollMode    ScrollMode `protobuf:"varint,5,opt,name=scroll_mode,json=scrollMode,proto3,enum=memos.api.v1.ScrollMode" json:"scroll_mode,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *UserSetting) Reset() {
@@ -855,6 +903,13 @@ func (x *UserSetting) GetMemoVisibility() string {
 		return x.MemoVisibility
 	}
 	return ""
+}
+
+func (x *UserSetting) GetScrollMode() ScrollMode {
+	if x != nil {
+		return x.ScrollMode
+	}
+	return ScrollMode_BUTTON
 }
 
 type GetUserSettingRequest struct {
@@ -1687,14 +1742,16 @@ const file_api_v1_user_service_proto_rawDesc = "" +
 	"\n" +
 	"user_stats\x18\x01 \x03(\v2\x17.memos.api.v1.UserStatsR\tuserStats\")\n" +
 	"\x13GetUserStatsRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"\x82\x01\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"\xbd\x01\n" +
 	"\vUserSetting\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
 	"\x06locale\x18\x02 \x01(\tR\x06locale\x12\x1e\n" +
 	"\n" +
 	"appearance\x18\x03 \x01(\tR\n" +
 	"appearance\x12'\n" +
-	"\x0fmemo_visibility\x18\x04 \x01(\tR\x0ememoVisibility\"+\n" +
+	"\x0fmemo_visibility\x18\x04 \x01(\tR\x0ememoVisibility\x129\n" +
+	"\vscroll_mode\x18\x05 \x01(\x0e2\x18.memos.api.v1.ScrollModeR\n" +
+	"scrollMode\"+\n" +
 	"\x15GetUserSettingRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"\x91\x01\n" +
 	"\x18UpdateUserSettingRequest\x128\n" +
@@ -1739,7 +1796,12 @@ const file_api_v1_user_service_proto_rawDesc = "" +
 	"updateMask\"?\n" +
 	"\x15DeleteShortcutRequest\x12\x16\n" +
 	"\x06parent\x18\x01 \x01(\tR\x06parent\x12\x0e\n" +
-	"\x02id\x18\x02 \x01(\tR\x02id2\xa9\x13\n" +
+	"\x02id\x18\x02 \x01(\tR\x02id*&\n" +
+	"\n" +
+	"ScrollMode\x12\n" +
+	"\n" +
+	"\x06BUTTON\x10\x00\x12\f\n" +
+	"\bINFINITE\x10\x012\xa9\x13\n" +
 	"\vUserService\x12c\n" +
 	"\tListUsers\x12\x1e.memos.api.v1.ListUsersRequest\x1a\x1f.memos.api.v1.ListUsersResponse\"\x15\x82\xd3\xe4\x93\x02\x0f\x12\r/api/v1/users\x12b\n" +
 	"\aGetUser\x12\x1c.memos.api.v1.GetUserRequest\x1a\x12.memos.api.v1.User\"%\xdaA\x04name\x82\xd3\xe4\x93\x02\x18\x12\x16/api/v1/{name=users/*}\x12z\n" +
@@ -1776,110 +1838,112 @@ func file_api_v1_user_service_proto_rawDescGZIP() []byte {
 	return file_api_v1_user_service_proto_rawDescData
 }
 
-var file_api_v1_user_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_api_v1_user_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_api_v1_user_service_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
 var file_api_v1_user_service_proto_goTypes = []any{
-	(User_Role)(0),                       // 0: memos.api.v1.User.Role
-	(*User)(nil),                         // 1: memos.api.v1.User
-	(*ListUsersRequest)(nil),             // 2: memos.api.v1.ListUsersRequest
-	(*ListUsersResponse)(nil),            // 3: memos.api.v1.ListUsersResponse
-	(*GetUserRequest)(nil),               // 4: memos.api.v1.GetUserRequest
-	(*GetUserByUsernameRequest)(nil),     // 5: memos.api.v1.GetUserByUsernameRequest
-	(*GetUserAvatarBinaryRequest)(nil),   // 6: memos.api.v1.GetUserAvatarBinaryRequest
-	(*CreateUserRequest)(nil),            // 7: memos.api.v1.CreateUserRequest
-	(*UpdateUserRequest)(nil),            // 8: memos.api.v1.UpdateUserRequest
-	(*DeleteUserRequest)(nil),            // 9: memos.api.v1.DeleteUserRequest
-	(*UserStats)(nil),                    // 10: memos.api.v1.UserStats
-	(*ListAllUserStatsRequest)(nil),      // 11: memos.api.v1.ListAllUserStatsRequest
-	(*ListAllUserStatsResponse)(nil),     // 12: memos.api.v1.ListAllUserStatsResponse
-	(*GetUserStatsRequest)(nil),          // 13: memos.api.v1.GetUserStatsRequest
-	(*UserSetting)(nil),                  // 14: memos.api.v1.UserSetting
-	(*GetUserSettingRequest)(nil),        // 15: memos.api.v1.GetUserSettingRequest
-	(*UpdateUserSettingRequest)(nil),     // 16: memos.api.v1.UpdateUserSettingRequest
-	(*UserAccessToken)(nil),              // 17: memos.api.v1.UserAccessToken
-	(*ListUserAccessTokensRequest)(nil),  // 18: memos.api.v1.ListUserAccessTokensRequest
-	(*ListUserAccessTokensResponse)(nil), // 19: memos.api.v1.ListUserAccessTokensResponse
-	(*CreateUserAccessTokenRequest)(nil), // 20: memos.api.v1.CreateUserAccessTokenRequest
-	(*DeleteUserAccessTokenRequest)(nil), // 21: memos.api.v1.DeleteUserAccessTokenRequest
-	(*Shortcut)(nil),                     // 22: memos.api.v1.Shortcut
-	(*ListShortcutsRequest)(nil),         // 23: memos.api.v1.ListShortcutsRequest
-	(*ListShortcutsResponse)(nil),        // 24: memos.api.v1.ListShortcutsResponse
-	(*CreateShortcutRequest)(nil),        // 25: memos.api.v1.CreateShortcutRequest
-	(*UpdateShortcutRequest)(nil),        // 26: memos.api.v1.UpdateShortcutRequest
-	(*DeleteShortcutRequest)(nil),        // 27: memos.api.v1.DeleteShortcutRequest
-	nil,                                  // 28: memos.api.v1.UserStats.TagCountEntry
-	(*UserStats_MemoTypeStats)(nil),      // 29: memos.api.v1.UserStats.MemoTypeStats
-	(State)(0),                           // 30: memos.api.v1.State
-	(*timestamppb.Timestamp)(nil),        // 31: google.protobuf.Timestamp
-	(*httpbody.HttpBody)(nil),            // 32: google.api.HttpBody
-	(*fieldmaskpb.FieldMask)(nil),        // 33: google.protobuf.FieldMask
-	(*emptypb.Empty)(nil),                // 34: google.protobuf.Empty
+	(ScrollMode)(0),                      // 0: memos.api.v1.ScrollMode
+	(User_Role)(0),                       // 1: memos.api.v1.User.Role
+	(*User)(nil),                         // 2: memos.api.v1.User
+	(*ListUsersRequest)(nil),             // 3: memos.api.v1.ListUsersRequest
+	(*ListUsersResponse)(nil),            // 4: memos.api.v1.ListUsersResponse
+	(*GetUserRequest)(nil),               // 5: memos.api.v1.GetUserRequest
+	(*GetUserByUsernameRequest)(nil),     // 6: memos.api.v1.GetUserByUsernameRequest
+	(*GetUserAvatarBinaryRequest)(nil),   // 7: memos.api.v1.GetUserAvatarBinaryRequest
+	(*CreateUserRequest)(nil),            // 8: memos.api.v1.CreateUserRequest
+	(*UpdateUserRequest)(nil),            // 9: memos.api.v1.UpdateUserRequest
+	(*DeleteUserRequest)(nil),            // 10: memos.api.v1.DeleteUserRequest
+	(*UserStats)(nil),                    // 11: memos.api.v1.UserStats
+	(*ListAllUserStatsRequest)(nil),      // 12: memos.api.v1.ListAllUserStatsRequest
+	(*ListAllUserStatsResponse)(nil),     // 13: memos.api.v1.ListAllUserStatsResponse
+	(*GetUserStatsRequest)(nil),          // 14: memos.api.v1.GetUserStatsRequest
+	(*UserSetting)(nil),                  // 15: memos.api.v1.UserSetting
+	(*GetUserSettingRequest)(nil),        // 16: memos.api.v1.GetUserSettingRequest
+	(*UpdateUserSettingRequest)(nil),     // 17: memos.api.v1.UpdateUserSettingRequest
+	(*UserAccessToken)(nil),              // 18: memos.api.v1.UserAccessToken
+	(*ListUserAccessTokensRequest)(nil),  // 19: memos.api.v1.ListUserAccessTokensRequest
+	(*ListUserAccessTokensResponse)(nil), // 20: memos.api.v1.ListUserAccessTokensResponse
+	(*CreateUserAccessTokenRequest)(nil), // 21: memos.api.v1.CreateUserAccessTokenRequest
+	(*DeleteUserAccessTokenRequest)(nil), // 22: memos.api.v1.DeleteUserAccessTokenRequest
+	(*Shortcut)(nil),                     // 23: memos.api.v1.Shortcut
+	(*ListShortcutsRequest)(nil),         // 24: memos.api.v1.ListShortcutsRequest
+	(*ListShortcutsResponse)(nil),        // 25: memos.api.v1.ListShortcutsResponse
+	(*CreateShortcutRequest)(nil),        // 26: memos.api.v1.CreateShortcutRequest
+	(*UpdateShortcutRequest)(nil),        // 27: memos.api.v1.UpdateShortcutRequest
+	(*DeleteShortcutRequest)(nil),        // 28: memos.api.v1.DeleteShortcutRequest
+	nil,                                  // 29: memos.api.v1.UserStats.TagCountEntry
+	(*UserStats_MemoTypeStats)(nil),      // 30: memos.api.v1.UserStats.MemoTypeStats
+	(State)(0),                           // 31: memos.api.v1.State
+	(*timestamppb.Timestamp)(nil),        // 32: google.protobuf.Timestamp
+	(*httpbody.HttpBody)(nil),            // 33: google.api.HttpBody
+	(*fieldmaskpb.FieldMask)(nil),        // 34: google.protobuf.FieldMask
+	(*emptypb.Empty)(nil),                // 35: google.protobuf.Empty
 }
 var file_api_v1_user_service_proto_depIdxs = []int32{
-	0,  // 0: memos.api.v1.User.role:type_name -> memos.api.v1.User.Role
-	30, // 1: memos.api.v1.User.state:type_name -> memos.api.v1.State
-	31, // 2: memos.api.v1.User.create_time:type_name -> google.protobuf.Timestamp
-	31, // 3: memos.api.v1.User.update_time:type_name -> google.protobuf.Timestamp
-	1,  // 4: memos.api.v1.ListUsersResponse.users:type_name -> memos.api.v1.User
-	32, // 5: memos.api.v1.GetUserAvatarBinaryRequest.http_body:type_name -> google.api.HttpBody
-	1,  // 6: memos.api.v1.CreateUserRequest.user:type_name -> memos.api.v1.User
-	1,  // 7: memos.api.v1.UpdateUserRequest.user:type_name -> memos.api.v1.User
-	33, // 8: memos.api.v1.UpdateUserRequest.update_mask:type_name -> google.protobuf.FieldMask
-	31, // 9: memos.api.v1.UserStats.memo_display_timestamps:type_name -> google.protobuf.Timestamp
-	29, // 10: memos.api.v1.UserStats.memo_type_stats:type_name -> memos.api.v1.UserStats.MemoTypeStats
-	28, // 11: memos.api.v1.UserStats.tag_count:type_name -> memos.api.v1.UserStats.TagCountEntry
-	10, // 12: memos.api.v1.ListAllUserStatsResponse.user_stats:type_name -> memos.api.v1.UserStats
-	14, // 13: memos.api.v1.UpdateUserSettingRequest.setting:type_name -> memos.api.v1.UserSetting
-	33, // 14: memos.api.v1.UpdateUserSettingRequest.update_mask:type_name -> google.protobuf.FieldMask
-	31, // 15: memos.api.v1.UserAccessToken.issued_at:type_name -> google.protobuf.Timestamp
-	31, // 16: memos.api.v1.UserAccessToken.expires_at:type_name -> google.protobuf.Timestamp
-	17, // 17: memos.api.v1.ListUserAccessTokensResponse.access_tokens:type_name -> memos.api.v1.UserAccessToken
-	31, // 18: memos.api.v1.CreateUserAccessTokenRequest.expires_at:type_name -> google.protobuf.Timestamp
-	22, // 19: memos.api.v1.ListShortcutsResponse.shortcuts:type_name -> memos.api.v1.Shortcut
-	22, // 20: memos.api.v1.CreateShortcutRequest.shortcut:type_name -> memos.api.v1.Shortcut
-	22, // 21: memos.api.v1.UpdateShortcutRequest.shortcut:type_name -> memos.api.v1.Shortcut
-	33, // 22: memos.api.v1.UpdateShortcutRequest.update_mask:type_name -> google.protobuf.FieldMask
-	2,  // 23: memos.api.v1.UserService.ListUsers:input_type -> memos.api.v1.ListUsersRequest
-	4,  // 24: memos.api.v1.UserService.GetUser:input_type -> memos.api.v1.GetUserRequest
-	5,  // 25: memos.api.v1.UserService.GetUserByUsername:input_type -> memos.api.v1.GetUserByUsernameRequest
-	6,  // 26: memos.api.v1.UserService.GetUserAvatarBinary:input_type -> memos.api.v1.GetUserAvatarBinaryRequest
-	7,  // 27: memos.api.v1.UserService.CreateUser:input_type -> memos.api.v1.CreateUserRequest
-	8,  // 28: memos.api.v1.UserService.UpdateUser:input_type -> memos.api.v1.UpdateUserRequest
-	9,  // 29: memos.api.v1.UserService.DeleteUser:input_type -> memos.api.v1.DeleteUserRequest
-	11, // 30: memos.api.v1.UserService.ListAllUserStats:input_type -> memos.api.v1.ListAllUserStatsRequest
-	13, // 31: memos.api.v1.UserService.GetUserStats:input_type -> memos.api.v1.GetUserStatsRequest
-	15, // 32: memos.api.v1.UserService.GetUserSetting:input_type -> memos.api.v1.GetUserSettingRequest
-	16, // 33: memos.api.v1.UserService.UpdateUserSetting:input_type -> memos.api.v1.UpdateUserSettingRequest
-	18, // 34: memos.api.v1.UserService.ListUserAccessTokens:input_type -> memos.api.v1.ListUserAccessTokensRequest
-	20, // 35: memos.api.v1.UserService.CreateUserAccessToken:input_type -> memos.api.v1.CreateUserAccessTokenRequest
-	21, // 36: memos.api.v1.UserService.DeleteUserAccessToken:input_type -> memos.api.v1.DeleteUserAccessTokenRequest
-	23, // 37: memos.api.v1.UserService.ListShortcuts:input_type -> memos.api.v1.ListShortcutsRequest
-	25, // 38: memos.api.v1.UserService.CreateShortcut:input_type -> memos.api.v1.CreateShortcutRequest
-	26, // 39: memos.api.v1.UserService.UpdateShortcut:input_type -> memos.api.v1.UpdateShortcutRequest
-	27, // 40: memos.api.v1.UserService.DeleteShortcut:input_type -> memos.api.v1.DeleteShortcutRequest
-	3,  // 41: memos.api.v1.UserService.ListUsers:output_type -> memos.api.v1.ListUsersResponse
-	1,  // 42: memos.api.v1.UserService.GetUser:output_type -> memos.api.v1.User
-	1,  // 43: memos.api.v1.UserService.GetUserByUsername:output_type -> memos.api.v1.User
-	32, // 44: memos.api.v1.UserService.GetUserAvatarBinary:output_type -> google.api.HttpBody
-	1,  // 45: memos.api.v1.UserService.CreateUser:output_type -> memos.api.v1.User
-	1,  // 46: memos.api.v1.UserService.UpdateUser:output_type -> memos.api.v1.User
-	34, // 47: memos.api.v1.UserService.DeleteUser:output_type -> google.protobuf.Empty
-	12, // 48: memos.api.v1.UserService.ListAllUserStats:output_type -> memos.api.v1.ListAllUserStatsResponse
-	10, // 49: memos.api.v1.UserService.GetUserStats:output_type -> memos.api.v1.UserStats
-	14, // 50: memos.api.v1.UserService.GetUserSetting:output_type -> memos.api.v1.UserSetting
-	14, // 51: memos.api.v1.UserService.UpdateUserSetting:output_type -> memos.api.v1.UserSetting
-	19, // 52: memos.api.v1.UserService.ListUserAccessTokens:output_type -> memos.api.v1.ListUserAccessTokensResponse
-	17, // 53: memos.api.v1.UserService.CreateUserAccessToken:output_type -> memos.api.v1.UserAccessToken
-	34, // 54: memos.api.v1.UserService.DeleteUserAccessToken:output_type -> google.protobuf.Empty
-	24, // 55: memos.api.v1.UserService.ListShortcuts:output_type -> memos.api.v1.ListShortcutsResponse
-	22, // 56: memos.api.v1.UserService.CreateShortcut:output_type -> memos.api.v1.Shortcut
-	22, // 57: memos.api.v1.UserService.UpdateShortcut:output_type -> memos.api.v1.Shortcut
-	34, // 58: memos.api.v1.UserService.DeleteShortcut:output_type -> google.protobuf.Empty
-	41, // [41:59] is the sub-list for method output_type
-	23, // [23:41] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	1,  // 0: memos.api.v1.User.role:type_name -> memos.api.v1.User.Role
+	31, // 1: memos.api.v1.User.state:type_name -> memos.api.v1.State
+	32, // 2: memos.api.v1.User.create_time:type_name -> google.protobuf.Timestamp
+	32, // 3: memos.api.v1.User.update_time:type_name -> google.protobuf.Timestamp
+	2,  // 4: memos.api.v1.ListUsersResponse.users:type_name -> memos.api.v1.User
+	33, // 5: memos.api.v1.GetUserAvatarBinaryRequest.http_body:type_name -> google.api.HttpBody
+	2,  // 6: memos.api.v1.CreateUserRequest.user:type_name -> memos.api.v1.User
+	2,  // 7: memos.api.v1.UpdateUserRequest.user:type_name -> memos.api.v1.User
+	34, // 8: memos.api.v1.UpdateUserRequest.update_mask:type_name -> google.protobuf.FieldMask
+	32, // 9: memos.api.v1.UserStats.memo_display_timestamps:type_name -> google.protobuf.Timestamp
+	30, // 10: memos.api.v1.UserStats.memo_type_stats:type_name -> memos.api.v1.UserStats.MemoTypeStats
+	29, // 11: memos.api.v1.UserStats.tag_count:type_name -> memos.api.v1.UserStats.TagCountEntry
+	11, // 12: memos.api.v1.ListAllUserStatsResponse.user_stats:type_name -> memos.api.v1.UserStats
+	0,  // 13: memos.api.v1.UserSetting.scroll_mode:type_name -> memos.api.v1.ScrollMode
+	15, // 14: memos.api.v1.UpdateUserSettingRequest.setting:type_name -> memos.api.v1.UserSetting
+	34, // 15: memos.api.v1.UpdateUserSettingRequest.update_mask:type_name -> google.protobuf.FieldMask
+	32, // 16: memos.api.v1.UserAccessToken.issued_at:type_name -> google.protobuf.Timestamp
+	32, // 17: memos.api.v1.UserAccessToken.expires_at:type_name -> google.protobuf.Timestamp
+	18, // 18: memos.api.v1.ListUserAccessTokensResponse.access_tokens:type_name -> memos.api.v1.UserAccessToken
+	32, // 19: memos.api.v1.CreateUserAccessTokenRequest.expires_at:type_name -> google.protobuf.Timestamp
+	23, // 20: memos.api.v1.ListShortcutsResponse.shortcuts:type_name -> memos.api.v1.Shortcut
+	23, // 21: memos.api.v1.CreateShortcutRequest.shortcut:type_name -> memos.api.v1.Shortcut
+	23, // 22: memos.api.v1.UpdateShortcutRequest.shortcut:type_name -> memos.api.v1.Shortcut
+	34, // 23: memos.api.v1.UpdateShortcutRequest.update_mask:type_name -> google.protobuf.FieldMask
+	3,  // 24: memos.api.v1.UserService.ListUsers:input_type -> memos.api.v1.ListUsersRequest
+	5,  // 25: memos.api.v1.UserService.GetUser:input_type -> memos.api.v1.GetUserRequest
+	6,  // 26: memos.api.v1.UserService.GetUserByUsername:input_type -> memos.api.v1.GetUserByUsernameRequest
+	7,  // 27: memos.api.v1.UserService.GetUserAvatarBinary:input_type -> memos.api.v1.GetUserAvatarBinaryRequest
+	8,  // 28: memos.api.v1.UserService.CreateUser:input_type -> memos.api.v1.CreateUserRequest
+	9,  // 29: memos.api.v1.UserService.UpdateUser:input_type -> memos.api.v1.UpdateUserRequest
+	10, // 30: memos.api.v1.UserService.DeleteUser:input_type -> memos.api.v1.DeleteUserRequest
+	12, // 31: memos.api.v1.UserService.ListAllUserStats:input_type -> memos.api.v1.ListAllUserStatsRequest
+	14, // 32: memos.api.v1.UserService.GetUserStats:input_type -> memos.api.v1.GetUserStatsRequest
+	16, // 33: memos.api.v1.UserService.GetUserSetting:input_type -> memos.api.v1.GetUserSettingRequest
+	17, // 34: memos.api.v1.UserService.UpdateUserSetting:input_type -> memos.api.v1.UpdateUserSettingRequest
+	19, // 35: memos.api.v1.UserService.ListUserAccessTokens:input_type -> memos.api.v1.ListUserAccessTokensRequest
+	21, // 36: memos.api.v1.UserService.CreateUserAccessToken:input_type -> memos.api.v1.CreateUserAccessTokenRequest
+	22, // 37: memos.api.v1.UserService.DeleteUserAccessToken:input_type -> memos.api.v1.DeleteUserAccessTokenRequest
+	24, // 38: memos.api.v1.UserService.ListShortcuts:input_type -> memos.api.v1.ListShortcutsRequest
+	26, // 39: memos.api.v1.UserService.CreateShortcut:input_type -> memos.api.v1.CreateShortcutRequest
+	27, // 40: memos.api.v1.UserService.UpdateShortcut:input_type -> memos.api.v1.UpdateShortcutRequest
+	28, // 41: memos.api.v1.UserService.DeleteShortcut:input_type -> memos.api.v1.DeleteShortcutRequest
+	4,  // 42: memos.api.v1.UserService.ListUsers:output_type -> memos.api.v1.ListUsersResponse
+	2,  // 43: memos.api.v1.UserService.GetUser:output_type -> memos.api.v1.User
+	2,  // 44: memos.api.v1.UserService.GetUserByUsername:output_type -> memos.api.v1.User
+	33, // 45: memos.api.v1.UserService.GetUserAvatarBinary:output_type -> google.api.HttpBody
+	2,  // 46: memos.api.v1.UserService.CreateUser:output_type -> memos.api.v1.User
+	2,  // 47: memos.api.v1.UserService.UpdateUser:output_type -> memos.api.v1.User
+	35, // 48: memos.api.v1.UserService.DeleteUser:output_type -> google.protobuf.Empty
+	13, // 49: memos.api.v1.UserService.ListAllUserStats:output_type -> memos.api.v1.ListAllUserStatsResponse
+	11, // 50: memos.api.v1.UserService.GetUserStats:output_type -> memos.api.v1.UserStats
+	15, // 51: memos.api.v1.UserService.GetUserSetting:output_type -> memos.api.v1.UserSetting
+	15, // 52: memos.api.v1.UserService.UpdateUserSetting:output_type -> memos.api.v1.UserSetting
+	20, // 53: memos.api.v1.UserService.ListUserAccessTokens:output_type -> memos.api.v1.ListUserAccessTokensResponse
+	18, // 54: memos.api.v1.UserService.CreateUserAccessToken:output_type -> memos.api.v1.UserAccessToken
+	35, // 55: memos.api.v1.UserService.DeleteUserAccessToken:output_type -> google.protobuf.Empty
+	25, // 56: memos.api.v1.UserService.ListShortcuts:output_type -> memos.api.v1.ListShortcutsResponse
+	23, // 57: memos.api.v1.UserService.CreateShortcut:output_type -> memos.api.v1.Shortcut
+	23, // 58: memos.api.v1.UserService.UpdateShortcut:output_type -> memos.api.v1.Shortcut
+	35, // 59: memos.api.v1.UserService.DeleteShortcut:output_type -> google.protobuf.Empty
+	42, // [42:60] is the sub-list for method output_type
+	24, // [24:42] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_api_v1_user_service_proto_init() }
@@ -1894,7 +1958,7 @@ func file_api_v1_user_service_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v1_user_service_proto_rawDesc), len(file_api_v1_user_service_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/proto/gen/apidocs.swagger.yaml
+++ b/proto/gen/apidocs.swagger.yaml
@@ -1780,6 +1780,9 @@ paths:
               memoVisibility:
                 type: string
                 description: The default visibility of the memo.
+              scrollMode:
+                $ref: '#/definitions/apiv1ScrollMode'
+                title: Whether infinite scroll should be enabled
             required:
               - setting
       tags:
@@ -2218,6 +2221,12 @@ definitions:
           type: string
       fieldMapping:
         $ref: '#/definitions/apiv1FieldMapping'
+  apiv1ScrollMode:
+    type: string
+    enum:
+      - BUTTON
+      - INFINITE
+    default: BUTTON
   apiv1Shortcut:
     type: object
     properties:
@@ -2242,6 +2251,9 @@ definitions:
       memoVisibility:
         type: string
         description: The default visibility of the memo.
+      scrollMode:
+        $ref: '#/definitions/apiv1ScrollMode'
+        title: Whether infinite scroll should be enabled
   apiv1WorkspaceCustomProfile:
     type: object
     properties:

--- a/proto/gen/store/user_setting.pb.go
+++ b/proto/gen/store/user_setting.pb.go
@@ -35,6 +35,8 @@ const (
 	UserSettingKey_MEMO_VISIBILITY UserSettingKey = 4
 	// The shortcuts of the user.
 	UserSettingKey_SHORTCUTS UserSettingKey = 5
+	// Whether infinite scroll should be enabled
+	UserSettingKey_SCROLL_MODE UserSettingKey = 6
 )
 
 // Enum value maps for UserSettingKey.
@@ -46,6 +48,7 @@ var (
 		3: "APPEARANCE",
 		4: "MEMO_VISIBILITY",
 		5: "SHORTCUTS",
+		6: "SCROLL_MODE",
 	}
 	UserSettingKey_value = map[string]int32{
 		"USER_SETTING_KEY_UNSPECIFIED": 0,
@@ -54,6 +57,7 @@ var (
 		"APPEARANCE":                   3,
 		"MEMO_VISIBILITY":              4,
 		"SHORTCUTS":                    5,
+		"SCROLL_MODE":                  6,
 	}
 )
 
@@ -84,6 +88,52 @@ func (UserSettingKey) EnumDescriptor() ([]byte, []int) {
 	return file_store_user_setting_proto_rawDescGZIP(), []int{0}
 }
 
+type ScrollMode int32
+
+const (
+	ScrollMode_BUTTON   ScrollMode = 0
+	ScrollMode_INFINITE ScrollMode = 1
+)
+
+// Enum value maps for ScrollMode.
+var (
+	ScrollMode_name = map[int32]string{
+		0: "BUTTON",
+		1: "INFINITE",
+	}
+	ScrollMode_value = map[string]int32{
+		"BUTTON":   0,
+		"INFINITE": 1,
+	}
+)
+
+func (x ScrollMode) Enum() *ScrollMode {
+	p := new(ScrollMode)
+	*p = x
+	return p
+}
+
+func (x ScrollMode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ScrollMode) Descriptor() protoreflect.EnumDescriptor {
+	return file_store_user_setting_proto_enumTypes[1].Descriptor()
+}
+
+func (ScrollMode) Type() protoreflect.EnumType {
+	return &file_store_user_setting_proto_enumTypes[1]
+}
+
+func (x ScrollMode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ScrollMode.Descriptor instead.
+func (ScrollMode) EnumDescriptor() ([]byte, []int) {
+	return file_store_user_setting_proto_rawDescGZIP(), []int{1}
+}
+
 type UserSetting struct {
 	state  protoimpl.MessageState `protogen:"open.v1"`
 	UserId int32                  `protobuf:"varint,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
@@ -95,6 +145,7 @@ type UserSetting struct {
 	//	*UserSetting_Appearance
 	//	*UserSetting_MemoVisibility
 	//	*UserSetting_Shortcuts
+	//	*UserSetting_ScrollMode
 	Value         isUserSetting_Value `protobuf_oneof:"value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -196,6 +247,15 @@ func (x *UserSetting) GetShortcuts() *ShortcutsUserSetting {
 	return nil
 }
 
+func (x *UserSetting) GetScrollMode() ScrollMode {
+	if x != nil {
+		if x, ok := x.Value.(*UserSetting_ScrollMode); ok {
+			return x.ScrollMode
+		}
+	}
+	return ScrollMode_BUTTON
+}
+
 type isUserSetting_Value interface {
 	isUserSetting_Value()
 }
@@ -220,6 +280,10 @@ type UserSetting_Shortcuts struct {
 	Shortcuts *ShortcutsUserSetting `protobuf:"bytes,7,opt,name=shortcuts,proto3,oneof"`
 }
 
+type UserSetting_ScrollMode struct {
+	ScrollMode ScrollMode `protobuf:"varint,8,opt,name=scroll_mode,json=scrollMode,proto3,enum=memos.store.ScrollMode,oneof"`
+}
+
 func (*UserSetting_AccessTokens) isUserSetting_Value() {}
 
 func (*UserSetting_Locale) isUserSetting_Value() {}
@@ -229,6 +293,8 @@ func (*UserSetting_Appearance) isUserSetting_Value() {}
 func (*UserSetting_MemoVisibility) isUserSetting_Value() {}
 
 func (*UserSetting_Shortcuts) isUserSetting_Value() {}
+
+func (*UserSetting_ScrollMode) isUserSetting_Value() {}
 
 type AccessTokensUserSetting struct {
 	state         protoimpl.MessageState                 `protogen:"open.v1"`
@@ -437,7 +503,7 @@ var File_store_user_setting_proto protoreflect.FileDescriptor
 
 const file_store_user_setting_proto_rawDesc = "" +
 	"\n" +
-	"\x18store/user_setting.proto\x12\vmemos.store\"\xd5\x02\n" +
+	"\x18store/user_setting.proto\x12\vmemos.store\"\x91\x03\n" +
 	"\vUserSetting\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\x05R\x06userId\x12-\n" +
 	"\x03key\x18\x02 \x01(\x0e2\x1b.memos.store.UserSettingKeyR\x03key\x12K\n" +
@@ -447,7 +513,9 @@ const file_store_user_setting_proto_rawDesc = "" +
 	"appearance\x18\x05 \x01(\tH\x00R\n" +
 	"appearance\x12)\n" +
 	"\x0fmemo_visibility\x18\x06 \x01(\tH\x00R\x0ememoVisibility\x12A\n" +
-	"\tshortcuts\x18\a \x01(\v2!.memos.store.ShortcutsUserSettingH\x00R\tshortcutsB\a\n" +
+	"\tshortcuts\x18\a \x01(\v2!.memos.store.ShortcutsUserSettingH\x00R\tshortcuts\x12:\n" +
+	"\vscroll_mode\x18\b \x01(\x0e2\x17.memos.store.ScrollModeH\x00R\n" +
+	"scrollModeB\a\n" +
 	"\x05value\"\xc4\x01\n" +
 	"\x17AccessTokensUserSetting\x12U\n" +
 	"\raccess_tokens\x18\x01 \x03(\v20.memos.store.AccessTokensUserSetting.AccessTokenR\faccessTokens\x1aR\n" +
@@ -459,7 +527,7 @@ const file_store_user_setting_proto_rawDesc = "" +
 	"\bShortcut\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05title\x18\x02 \x01(\tR\x05title\x12\x16\n" +
-	"\x06filter\x18\x03 \x01(\tR\x06filter*\x85\x01\n" +
+	"\x06filter\x18\x03 \x01(\tR\x06filter*\x96\x01\n" +
 	"\x0eUserSettingKey\x12 \n" +
 	"\x1cUSER_SETTING_KEY_UNSPECIFIED\x10\x00\x12\x11\n" +
 	"\rACCESS_TOKENS\x10\x01\x12\n" +
@@ -468,7 +536,13 @@ const file_store_user_setting_proto_rawDesc = "" +
 	"\n" +
 	"APPEARANCE\x10\x03\x12\x13\n" +
 	"\x0fMEMO_VISIBILITY\x10\x04\x12\r\n" +
-	"\tSHORTCUTS\x10\x05B\x9b\x01\n" +
+	"\tSHORTCUTS\x10\x05\x12\x0f\n" +
+	"\vSCROLL_MODE\x10\x06*&\n" +
+	"\n" +
+	"ScrollMode\x12\n" +
+	"\n" +
+	"\x06BUTTON\x10\x00\x12\f\n" +
+	"\bINFINITE\x10\x01B\x9b\x01\n" +
 	"\x0fcom.memos.storeB\x10UserSettingProtoP\x01Z)github.com/usememos/memos/proto/gen/store\xa2\x02\x03MSX\xaa\x02\vMemos.Store\xca\x02\vMemos\\Store\xe2\x02\x17Memos\\Store\\GPBMetadata\xea\x02\fMemos::Storeb\x06proto3"
 
 var (
@@ -483,27 +557,29 @@ func file_store_user_setting_proto_rawDescGZIP() []byte {
 	return file_store_user_setting_proto_rawDescData
 }
 
-var file_store_user_setting_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_store_user_setting_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_store_user_setting_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_store_user_setting_proto_goTypes = []any{
 	(UserSettingKey)(0),                         // 0: memos.store.UserSettingKey
-	(*UserSetting)(nil),                         // 1: memos.store.UserSetting
-	(*AccessTokensUserSetting)(nil),             // 2: memos.store.AccessTokensUserSetting
-	(*ShortcutsUserSetting)(nil),                // 3: memos.store.ShortcutsUserSetting
-	(*AccessTokensUserSetting_AccessToken)(nil), // 4: memos.store.AccessTokensUserSetting.AccessToken
-	(*ShortcutsUserSetting_Shortcut)(nil),       // 5: memos.store.ShortcutsUserSetting.Shortcut
+	(ScrollMode)(0),                             // 1: memos.store.ScrollMode
+	(*UserSetting)(nil),                         // 2: memos.store.UserSetting
+	(*AccessTokensUserSetting)(nil),             // 3: memos.store.AccessTokensUserSetting
+	(*ShortcutsUserSetting)(nil),                // 4: memos.store.ShortcutsUserSetting
+	(*AccessTokensUserSetting_AccessToken)(nil), // 5: memos.store.AccessTokensUserSetting.AccessToken
+	(*ShortcutsUserSetting_Shortcut)(nil),       // 6: memos.store.ShortcutsUserSetting.Shortcut
 }
 var file_store_user_setting_proto_depIdxs = []int32{
 	0, // 0: memos.store.UserSetting.key:type_name -> memos.store.UserSettingKey
-	2, // 1: memos.store.UserSetting.access_tokens:type_name -> memos.store.AccessTokensUserSetting
-	3, // 2: memos.store.UserSetting.shortcuts:type_name -> memos.store.ShortcutsUserSetting
-	4, // 3: memos.store.AccessTokensUserSetting.access_tokens:type_name -> memos.store.AccessTokensUserSetting.AccessToken
-	5, // 4: memos.store.ShortcutsUserSetting.shortcuts:type_name -> memos.store.ShortcutsUserSetting.Shortcut
-	5, // [5:5] is the sub-list for method output_type
-	5, // [5:5] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	3, // 1: memos.store.UserSetting.access_tokens:type_name -> memos.store.AccessTokensUserSetting
+	4, // 2: memos.store.UserSetting.shortcuts:type_name -> memos.store.ShortcutsUserSetting
+	1, // 3: memos.store.UserSetting.scroll_mode:type_name -> memos.store.ScrollMode
+	5, // 4: memos.store.AccessTokensUserSetting.access_tokens:type_name -> memos.store.AccessTokensUserSetting.AccessToken
+	6, // 5: memos.store.ShortcutsUserSetting.shortcuts:type_name -> memos.store.ShortcutsUserSetting.Shortcut
+	6, // [6:6] is the sub-list for method output_type
+	6, // [6:6] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_store_user_setting_proto_init() }
@@ -517,13 +593,14 @@ func file_store_user_setting_proto_init() {
 		(*UserSetting_Appearance)(nil),
 		(*UserSetting_MemoVisibility)(nil),
 		(*UserSetting_Shortcuts)(nil),
+		(*UserSetting_ScrollMode)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_store_user_setting_proto_rawDesc), len(file_store_user_setting_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/proto/store/user_setting.proto
+++ b/proto/store/user_setting.proto
@@ -16,6 +16,13 @@ enum UserSettingKey {
   MEMO_VISIBILITY = 4;
   // The shortcuts of the user.
   SHORTCUTS = 5;
+  // Whether infinite scroll should be enabled
+  SCROLL_MODE = 6;
+}
+
+enum ScrollMode {
+  BUTTON = 0;
+  INFINITE = 1;
 }
 
 message UserSetting {
@@ -27,6 +34,7 @@ message UserSetting {
     string appearance = 5;
     string memo_visibility = 6;
     ShortcutsUserSetting shortcuts = 7;
+    ScrollMode scroll_mode = 8;
   }
 }
 

--- a/server/router/api/v1/user_service.go
+++ b/server/router/api/v1/user_service.go
@@ -287,6 +287,8 @@ func (s *APIV1Service) GetUserSetting(ctx context.Context, _ *v1pb.GetUserSettin
 			userSettingMessage.Appearance = setting.GetAppearance()
 		} else if setting.Key == storepb.UserSettingKey_MEMO_VISIBILITY {
 			userSettingMessage.MemoVisibility = setting.GetMemoVisibility()
+		} else if setting.Key == storepb.UserSettingKey_SCROLL_MODE {
+			userSettingMessage.ScrollMode = v1pb.ScrollMode(int32(setting.GetScrollMode()))
 		}
 	}
 	return userSettingMessage, nil
@@ -329,6 +331,16 @@ func (s *APIV1Service) UpdateUserSetting(ctx context.Context, request *v1pb.Upda
 				Key:    storepb.UserSettingKey_MEMO_VISIBILITY,
 				Value: &storepb.UserSetting_MemoVisibility{
 					MemoVisibility: request.Setting.MemoVisibility,
+				},
+			}); err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to upsert user setting: %v", err)
+			}
+		} else if field == "scroll_mode" {
+			if _, err := s.Store.UpsertUserSetting(ctx, &storepb.UserSetting{
+				UserId: user.ID,
+				Key:    storepb.UserSettingKey_SCROLL_MODE,
+				Value: &storepb.UserSetting_ScrollMode{
+					ScrollMode: storepb.ScrollMode(int32(request.Setting.ScrollMode)),
 				},
 			}); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to upsert user setting: %v", err)

--- a/store/user_setting.go
+++ b/store/user_setting.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -157,6 +158,14 @@ func convertUserSettingFromRaw(raw *UserSetting) (*storepb.UserSetting, error) {
 		userSetting.Value = &storepb.UserSetting_Appearance{Appearance: raw.Value}
 	case storepb.UserSettingKey_MEMO_VISIBILITY:
 		userSetting.Value = &storepb.UserSetting_MemoVisibility{MemoVisibility: raw.Value}
+	case storepb.UserSettingKey_SCROLL_MODE:
+		modeValue, ok := storepb.ScrollMode_value[raw.Value]
+		if !ok {
+			return nil, fmt.Errorf("invalid scroll_mode name: %s", raw.Value)
+		}
+		userSetting.Value = &storepb.UserSetting_ScrollMode{
+			ScrollMode: storepb.ScrollMode(modeValue),
+		}
 	default:
 		return nil, nil
 	}
@@ -190,6 +199,8 @@ func convertUserSettingToRaw(userSetting *storepb.UserSetting) (*UserSetting, er
 		raw.Value = userSetting.GetAppearance()
 	case storepb.UserSettingKey_MEMO_VISIBILITY:
 		raw.Value = userSetting.GetMemoVisibility()
+	case storepb.UserSettingKey_SCROLL_MODE:
+		raw.Value = storepb.ScrollMode_name[int32(userSetting.GetScrollMode())]
 	default:
 		return nil, errors.Errorf("unsupported user setting key: %v", userSetting.Key)
 	}

--- a/web/src/components/PagedMemoList/PagedMemoList.tsx
+++ b/web/src/components/PagedMemoList/PagedMemoList.tsx
@@ -25,6 +25,7 @@ interface Props {
   filter?: string;
   oldFilter?: string;
   pageSize?: number;
+  enableInfiniteScroll?: boolean;
 }
 
 interface LocalState {
@@ -71,6 +72,23 @@ const PagedMemoList = observer((props: Props) => {
     refreshList();
   }, [props.owner, props.state, props.direction, props.filter, props.oldFilter, props.pageSize]);
 
+  useEffect(() => {
+    if (!props.enableInfiniteScroll || !state.nextPageToken) return;
+  
+    const handleScroll = () => {
+      const nearBottom =
+        window.innerHeight + window.scrollY >= document.body.offsetHeight - 300;
+  
+      if (nearBottom && !state.isRequesting) {
+        fetchMoreMemos(state.nextPageToken);
+      }
+    };
+  
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [props.enableInfiniteScroll, state.nextPageToken, state.isRequesting]);
+  
+
   const children = (
     <div className="flex flex-col justify-start items-start w-full max-w-full">
       <MasonryView
@@ -93,7 +111,7 @@ const PagedMemoList = observer((props: Props) => {
             </div>
           ) : (
             <div className="w-full opacity-70 flex flex-row justify-center items-center my-4">
-              {state.nextPageToken && (
+              {state.nextPageToken && !props.enableInfiniteScroll && (
                 <Button variant="plain" onClick={() => fetchMoreMemos(state.nextPageToken)}>
                   {t("memo.load-more")}
                   <ArrowDownIcon className="ml-1 w-4 h-auto" />

--- a/web/src/components/Settings/PreferencesSection.tsx
+++ b/web/src/components/Settings/PreferencesSection.tsx
@@ -1,4 +1,4 @@
-import { Divider, Option, Select } from "@mui/joy";
+import { Divider, Option, Select, Switch } from "@mui/joy";
 import { observer } from "mobx-react-lite";
 import { userStore } from "@/store/v2";
 import { Visibility } from "@/types/proto/api/v1/memo_service";
@@ -15,44 +15,37 @@ const PreferencesSection = observer(() => {
   const setting = userStore.state.userSetting as UserSetting;
 
   const handleLocaleSelectChange = async (locale: Locale) => {
-    await userStore.updateUserSetting(
-      {
-        locale,
-      },
-      ["locale"],
-    );
+    await userStore.updateUserSetting({ locale }, ["locale"]);
   };
 
   const handleAppearanceSelectChange = async (appearance: Appearance) => {
-    await userStore.updateUserSetting(
-      {
-        appearance,
-      },
-      ["appearance"],
-    );
+    await userStore.updateUserSetting({ appearance }, ["appearance"]);
   };
 
   const handleDefaultMemoVisibilityChanged = async (value: string) => {
-    await userStore.updateUserSetting(
-      {
-        memoVisibility: value,
-      },
-      ["memo_visibility"],
-    );
+    await userStore.updateUserSetting({ memoVisibility: value }, ["memo_visibility"]);
+  };
+
+  const handleInfiniteScrollingToggle = async (checked: boolean) => {
+    await userStore.updateUserSetting({ infiniteScrollingEnabled: checked }, ["infinite_scrolling_enabled"]);
   };
 
   return (
     <div className="w-full flex flex-col gap-2 pt-2 pb-4">
       <p className="font-medium text-gray-700 dark:text-gray-500">{t("common.basic")}</p>
+
       <div className="w-full flex flex-row justify-between items-center">
         <span>{t("common.language")}</span>
         <LocaleSelect value={setting.locale} onChange={handleLocaleSelectChange} />
       </div>
+
       <div className="w-full flex flex-row justify-between items-center">
         <span>{t("setting.preference-section.theme")}</span>
         <AppearanceSelect value={setting.appearance as Appearance} onChange={handleAppearanceSelectChange} />
       </div>
+
       <p className="font-medium text-gray-700 dark:text-gray-500">{t("setting.preference")}</p>
+
       <div className="w-full flex flex-row justify-between items-center">
         <span className="truncate">{t("setting.preference-section.default-memo-visibility")}</span>
         <Select
@@ -73,6 +66,15 @@ const PreferencesSection = observer(() => {
               </Option>
             ))}
         </Select>
+      </div>
+      <div className="w-full flex flex-row justify-between items-center">
+        <span className="truncate flex items-center gap-2">
+          {t("setting.preference-section.scrolling-infinite")}
+        </span>
+        <Switch
+          checked={setting.infiniteScrollingEnabled ?? false}
+          onChange={(e) => handleInfiniteScrollingToggle(e.target.checked)}
+        />
       </div>
 
       <Divider className="!my-3" />

--- a/web/src/components/Settings/PreferencesSection.tsx
+++ b/web/src/components/Settings/PreferencesSection.tsx
@@ -1,4 +1,4 @@
-import { Divider, Option, Select, Switch } from "@mui/joy";
+import { Box, Divider, Option, Select } from "@mui/joy";
 import { observer } from "mobx-react-lite";
 import { userStore } from "@/store/v2";
 import { Visibility } from "@/types/proto/api/v1/memo_service";
@@ -9,6 +9,8 @@ import AppearanceSelect from "../AppearanceSelect";
 import LocaleSelect from "../LocaleSelect";
 import VisibilityIcon from "../VisibilityIcon";
 import WebhookSection from "./WebhookSection";
+import { ArrowDownIcon, InfinityIcon } from "lucide-react";
+import { ScrollMode } from "@/types/proto/store/user_setting";
 
 const PreferencesSection = observer(() => {
   const t = useTranslate();
@@ -26,8 +28,8 @@ const PreferencesSection = observer(() => {
     await userStore.updateUserSetting({ memoVisibility: value }, ["memo_visibility"]);
   };
 
-  const handleInfiniteScrollingToggle = async (checked: boolean) => {
-    await userStore.updateUserSetting({ infiniteScrollingEnabled: checked }, ["infinite_scrolling_enabled"]);
+  const handleScrollModeChanged = async (value: ScrollMode) => {
+    await userStore.updateUserSetting({ scrollMode: value }, ["scroll_mode"])
   };
 
   return (
@@ -68,13 +70,36 @@ const PreferencesSection = observer(() => {
         </Select>
       </div>
       <div className="w-full flex flex-row justify-between items-center">
-        <span className="truncate flex items-center gap-2">
-          {t("setting.preference-section.scrolling-infinite")}
-        </span>
-        <Switch
-          checked={setting.infiniteScrollingEnabled ?? false}
-          onChange={(e) => handleInfiniteScrollingToggle(e.target.checked)}
-        />
+        <span className="truncate">{t("setting.preference-section.scroll-mode")}</span>
+        <Select
+          className="!min-w-fit"
+          value={setting.scrollMode}
+          startDecorator={
+            setting.scrollMode === ScrollMode.INFINITE ? (
+              <InfinityIcon />
+            ) : (
+              <ArrowDownIcon />
+            )
+          }
+          onChange={(_, value) => {
+            if (value && value in ScrollMode) {
+              handleScrollModeChanged(value);
+            }
+          }}
+        >
+          <Option value={ScrollMode.BUTTON}>
+            <Box className="flex items-center gap-2">
+              <ArrowDownIcon />
+              {t("setting.preference-section.scroll-with-button")}
+            </Box>
+          </Option>
+          <Option value={ScrollMode.INFINITE}>
+            <Box className="flex items-center gap-2">
+              <InfinityIcon />
+              {t("setting.preference-section.scroll-infinitely")}
+            </Box>
+          </Option>
+        </Select>
       </div>
 
       <Divider className="!my-3" />

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -294,8 +294,9 @@
       "default-memo-sort-option": "Memo display time",
       "default-memo-visibility": "Default memo visibility",
       "theme": "Theme",
-      "scrolling-infinite": "Enable infinite scroll",
-      "scrolling-button": "Load more button"
+      "scroll-mode": "Default scroll mode",
+      "scroll-with-button": "Use load more button",
+      "scroll-infinitely": "Use infinite scrolling"
     },
     "sso": "SSO",
     "sso-section": {

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -293,7 +293,9 @@
     "preference-section": {
       "default-memo-sort-option": "Memo display time",
       "default-memo-visibility": "Default memo visibility",
-      "theme": "Theme"
+      "theme": "Theme",
+      "scrolling-infinite": "Enable infinite scroll",
+      "scrolling-button": "Load more button"
     },
     "sso": "SSO",
     "sso-section": {

--- a/web/src/pages/Archived.tsx
+++ b/web/src/pages/Archived.tsx
@@ -48,6 +48,7 @@ const Archived = () => {
       state={State.ARCHIVED}
       direction={viewStore.state.orderByTimeAsc ? Direction.ASC : Direction.DESC}
       oldFilter={memoListFilter}
+      enableInfiniteScroll
     />
   );
 };

--- a/web/src/pages/Archived.tsx
+++ b/web/src/pages/Archived.tsx
@@ -4,13 +4,15 @@ import MemoView from "@/components/MemoView";
 import PagedMemoList from "@/components/PagedMemoList";
 import useCurrentUser from "@/hooks/useCurrentUser";
 import { useMemoFilterStore } from "@/store/v1";
-import { viewStore } from "@/store/v2";
+import { userStore, viewStore } from "@/store/v2";
 import { Direction, State } from "@/types/proto/api/v1/common";
 import { Memo } from "@/types/proto/api/v1/memo_service";
+import { ScrollMode } from "@/types/proto/store/user_setting";
 
 const Archived = () => {
   const user = useCurrentUser();
   const memoFilterStore = useMemoFilterStore();
+  const enableInfiniteScroll = userStore.state.userSetting?.scrollMode == ScrollMode.INFINITE;
 
   const memoListFilter = useMemo(() => {
     const conditions = [];
@@ -48,7 +50,7 @@ const Archived = () => {
       state={State.ARCHIVED}
       direction={viewStore.state.orderByTimeAsc ? Direction.ASC : Direction.DESC}
       oldFilter={memoListFilter}
-      enableInfiniteScroll
+      enableInfiniteScroll={enableInfiniteScroll}
     />
   );
 };

--- a/web/src/pages/Explore.tsx
+++ b/web/src/pages/Explore.tsx
@@ -58,6 +58,7 @@ const Explore = () => {
       }
       direction={viewStore.state.orderByTimeAsc ? Direction.ASC : Direction.DESC}
       oldFilter={memoListFilter}
+      enableInfiniteScroll
     />
   );
 };

--- a/web/src/pages/Explore.tsx
+++ b/web/src/pages/Explore.tsx
@@ -4,13 +4,15 @@ import MemoView from "@/components/MemoView";
 import PagedMemoList from "@/components/PagedMemoList";
 import useCurrentUser from "@/hooks/useCurrentUser";
 import { useMemoFilterStore } from "@/store/v1";
-import { viewStore } from "@/store/v2";
+import { userStore, viewStore } from "@/store/v2";
 import { Direction, State } from "@/types/proto/api/v1/common";
 import { Memo } from "@/types/proto/api/v1/memo_service";
+import { ScrollMode } from "@/types/proto/store/user_setting";
 
 const Explore = () => {
   const user = useCurrentUser();
   const memoFilterStore = useMemoFilterStore();
+  const enableInfiniteScroll = userStore.state.userSetting?.scrollMode == ScrollMode.INFINITE;
 
   const memoListFilter = useMemo(() => {
     const conditions = [];
@@ -58,7 +60,7 @@ const Explore = () => {
       }
       direction={viewStore.state.orderByTimeAsc ? Direction.ASC : Direction.DESC}
       oldFilter={memoListFilter}
-      enableInfiniteScroll
+      enableInfiniteScroll={enableInfiniteScroll}
     />
   );
 };

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -65,6 +65,7 @@ const Home = observer(() => {
       direction={viewStore.state.orderByTimeAsc ? Direction.ASC : Direction.DESC}
       filter={selectedShortcut?.filter || ""}
       oldFilter={memoListFilter}
+      enableInfiniteScroll
     />
   );
 });

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -8,11 +8,13 @@ import { useMemoFilterStore } from "@/store/v1";
 import { viewStore, userStore } from "@/store/v2";
 import { Direction, State } from "@/types/proto/api/v1/common";
 import { Memo } from "@/types/proto/api/v1/memo_service";
+import { ScrollMode } from "@/types/proto/store/user_setting";
 
 const Home = observer(() => {
   const user = useCurrentUser();
   const memoFilterStore = useMemoFilterStore();
   const selectedShortcut = userStore.state.shortcuts.find((shortcut) => shortcut.id === memoFilterStore.shortcut);
+  const enableInfiniteScroll = userStore.state.userSetting?.scrollMode == ScrollMode.INFINITE;
 
   const memoListFilter = useMemo(() => {
     const conditions = [];
@@ -65,7 +67,7 @@ const Home = observer(() => {
       direction={viewStore.state.orderByTimeAsc ? Direction.ASC : Direction.DESC}
       filter={selectedShortcut?.filter || ""}
       oldFilter={memoListFilter}
-      enableInfiniteScroll
+      enableInfiniteScroll={enableInfiniteScroll}
     />
   );
 });

--- a/web/src/pages/UserProfile.tsx
+++ b/web/src/pages/UserProfile.tsx
@@ -16,6 +16,7 @@ import { Direction, State } from "@/types/proto/api/v1/common";
 import { Memo } from "@/types/proto/api/v1/memo_service";
 import { User } from "@/types/proto/api/v1/user_service";
 import { useTranslate } from "@/utils/i18n";
+import { ScrollMode } from "@/types/proto/store/user_setting";
 
 const UserProfile = observer(() => {
   const t = useTranslate();
@@ -23,6 +24,7 @@ const UserProfile = observer(() => {
   const loadingState = useLoading();
   const [user, setUser] = useState<User>();
   const memoFilterStore = useMemoFilterStore();
+  const enableInfiniteScroll = userStore.state.userSetting?.scrollMode == ScrollMode.INFINITE;
 
   useEffect(() => {
     const username = params.username;
@@ -115,7 +117,7 @@ const UserProfile = observer(() => {
                 owner={user.name}
                 direction={viewStore.state.orderByTimeAsc ? Direction.ASC : Direction.DESC}
                 oldFilter={memoListFilter}
-                enableInfiniteScroll
+                enableInfiniteScroll={enableInfiniteScroll}
               />
             </>
           ) : (

--- a/web/src/pages/UserProfile.tsx
+++ b/web/src/pages/UserProfile.tsx
@@ -115,6 +115,7 @@ const UserProfile = observer(() => {
                 owner={user.name}
                 direction={viewStore.state.orderByTimeAsc ? Direction.ASC : Direction.DESC}
                 oldFilter={memoListFilter}
+                enableInfiniteScroll
               />
             </>
           ) : (

--- a/web/src/types/proto/api/v1/user_service.ts
+++ b/web/src/types/proto/api/v1/user_service.ts
@@ -14,6 +14,39 @@ import { State, stateFromJSON, stateToNumber } from "./common";
 
 export const protobufPackage = "memos.api.v1";
 
+export enum ScrollMode {
+  BUTTON = "BUTTON",
+  INFINITE = "INFINITE",
+  UNRECOGNIZED = "UNRECOGNIZED",
+}
+
+export function scrollModeFromJSON(object: any): ScrollMode {
+  switch (object) {
+    case 0:
+    case "BUTTON":
+      return ScrollMode.BUTTON;
+    case 1:
+    case "INFINITE":
+      return ScrollMode.INFINITE;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return ScrollMode.UNRECOGNIZED;
+  }
+}
+
+export function scrollModeToNumber(object: ScrollMode): number {
+  switch (object) {
+    case ScrollMode.BUTTON:
+      return 0;
+    case ScrollMode.INFINITE:
+      return 1;
+    case ScrollMode.UNRECOGNIZED:
+    default:
+      return -1;
+  }
+}
+
 export interface User {
   /**
    * The name of the user.
@@ -170,6 +203,8 @@ export interface UserSetting {
   appearance: string;
   /** The default visibility of the memo. */
   memoVisibility: string;
+  /** Whether infinite scroll should be enabled */
+  scrollMode: ScrollMode;
 }
 
 export interface GetUserSettingRequest {
@@ -1198,7 +1233,7 @@ export const GetUserStatsRequest: MessageFns<GetUserStatsRequest> = {
 };
 
 function createBaseUserSetting(): UserSetting {
-  return { name: "", locale: "", appearance: "", memoVisibility: "" };
+  return { name: "", locale: "", appearance: "", memoVisibility: "", scrollMode: ScrollMode.BUTTON };
 }
 
 export const UserSetting: MessageFns<UserSetting> = {
@@ -1214,6 +1249,9 @@ export const UserSetting: MessageFns<UserSetting> = {
     }
     if (message.memoVisibility !== "") {
       writer.uint32(34).string(message.memoVisibility);
+    }
+    if (message.scrollMode !== ScrollMode.BUTTON) {
+      writer.uint32(40).int32(scrollModeToNumber(message.scrollMode));
     }
     return writer;
   },
@@ -1257,6 +1295,14 @@ export const UserSetting: MessageFns<UserSetting> = {
           message.memoVisibility = reader.string();
           continue;
         }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.scrollMode = scrollModeFromJSON(reader.int32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1275,6 +1321,7 @@ export const UserSetting: MessageFns<UserSetting> = {
     message.locale = object.locale ?? "";
     message.appearance = object.appearance ?? "";
     message.memoVisibility = object.memoVisibility ?? "";
+    message.scrollMode = object.scrollMode ?? ScrollMode.BUTTON;
     return message;
   },
 };

--- a/web/src/types/proto/google/protobuf/descriptor.ts
+++ b/web/src/types/proto/google/protobuf/descriptor.ts
@@ -35,7 +35,7 @@ export enum Edition {
   EDITION_2024 = "EDITION_2024",
   /**
    * EDITION_1_TEST_ONLY - Placeholder editions for testing feature resolution.  These should not be
-   * used or relyed on outside of tests.
+   * used or relied on outside of tests.
    */
   EDITION_1_TEST_ONLY = "EDITION_1_TEST_ONLY",
   EDITION_2_TEST_ONLY = "EDITION_2_TEST_ONLY",
@@ -177,11 +177,19 @@ export interface FileDescriptorProto {
    * The supported values are "proto2", "proto3", and "editions".
    *
    * If `edition` is present, this value must be "editions".
+   * WARNING: This field should only be used by protobuf plugins or special
+   * cases like the proto compiler. Other uses are discouraged and
+   * developers should rely on the protoreflect APIs for their client language.
    */
   syntax?:
     | string
     | undefined;
-  /** The edition of the proto file. */
+  /**
+   * The edition of the proto file.
+   * WARNING: This field should only be used by protobuf plugins or special
+   * cases like the proto compiler. Other uses are discouraged and
+   * developers should rely on the protoreflect APIs for their client language.
+   */
   edition?: Edition | undefined;
 }
 
@@ -828,7 +836,12 @@ export interface FileOptions {
   rubyPackage?:
     | string
     | undefined;
-  /** Any features defined in the specific edition. */
+  /**
+   * Any features defined in the specific edition.
+   * WARNING: This field should only be used by protobuf plugins or special
+   * cases like the proto compiler. Other uses are discouraged and
+   * developers should rely on the protoreflect APIs for their client language.
+   */
   features?:
     | FeatureSet
     | undefined;
@@ -966,7 +979,12 @@ export interface MessageOptions {
   deprecatedLegacyJsonFieldConflicts?:
     | boolean
     | undefined;
-  /** Any features defined in the specific edition. */
+  /**
+   * Any features defined in the specific edition.
+   * WARNING: This field should only be used by protobuf plugins or special
+   * cases like the proto compiler. Other uses are discouraged and
+   * developers should rely on the protoreflect APIs for their client language.
+   */
   features?:
     | FeatureSet
     | undefined;
@@ -976,12 +994,13 @@ export interface MessageOptions {
 
 export interface FieldOptions {
   /**
+   * NOTE: ctype is deprecated. Use `features.(pb.cpp).string_type` instead.
    * The ctype option instructs the C++ code generator to use a different
    * representation of the field than it normally would.  See the specific
    * options below.  This option is only implemented to support use of
    * [ctype=CORD] and [ctype=STRING] (the default) on non-repeated fields of
-   * type "bytes" in the open source release -- sorry, we'll try to include
-   * other types in a future version!
+   * type "bytes" in the open source release.
+   * TODO: make ctype actually deprecated.
    */
   ctype?:
     | FieldOptions_CType
@@ -1070,7 +1089,12 @@ export interface FieldOptions {
   retention?: FieldOptions_OptionRetention | undefined;
   targets: FieldOptions_OptionTargetType[];
   editionDefaults: FieldOptions_EditionDefault[];
-  /** Any features defined in the specific edition. */
+  /**
+   * Any features defined in the specific edition.
+   * WARNING: This field should only be used by protobuf plugins or special
+   * cases like the proto compiler. Other uses are discouraged and
+   * developers should rely on the protoreflect APIs for their client language.
+   */
   features?: FeatureSet | undefined;
   featureSupport?:
     | FieldOptions_FeatureSupport
@@ -1169,11 +1193,7 @@ export function fieldOptions_JSTypeToNumber(object: FieldOptions_JSType): number
   }
 }
 
-/**
- * If set to RETENTION_SOURCE, the option will be omitted from the binary.
- * Note: as of January 2023, support for this is in progress and does not yet
- * have an effect (b/264593489).
- */
+/** If set to RETENTION_SOURCE, the option will be omitted from the binary. */
 export enum FieldOptions_OptionRetention {
   RETENTION_UNKNOWN = "RETENTION_UNKNOWN",
   RETENTION_RUNTIME = "RETENTION_RUNTIME",
@@ -1216,8 +1236,7 @@ export function fieldOptions_OptionRetentionToNumber(object: FieldOptions_Option
 /**
  * This indicates the types of entities that the field may apply to when used
  * as an option. If it is unset, then the field may be freely used as an
- * option on any kind of entity. Note: as of January 2023, support for this is
- * in progress and does not yet have an effect (b/264593489).
+ * option on any kind of entity.
  */
 export enum FieldOptions_OptionTargetType {
   TARGET_TYPE_UNKNOWN = "TARGET_TYPE_UNKNOWN",
@@ -1341,7 +1360,12 @@ export interface FieldOptions_FeatureSupport {
 }
 
 export interface OneofOptions {
-  /** Any features defined in the specific edition. */
+  /**
+   * Any features defined in the specific edition.
+   * WARNING: This field should only be used by protobuf plugins or special
+   * cases like the proto compiler. Other uses are discouraged and
+   * developers should rely on the protoreflect APIs for their client language.
+   */
   features?:
     | FeatureSet
     | undefined;
@@ -1379,7 +1403,12 @@ export interface EnumOptions {
   deprecatedLegacyJsonFieldConflicts?:
     | boolean
     | undefined;
-  /** Any features defined in the specific edition. */
+  /**
+   * Any features defined in the specific edition.
+   * WARNING: This field should only be used by protobuf plugins or special
+   * cases like the proto compiler. Other uses are discouraged and
+   * developers should rely on the protoreflect APIs for their client language.
+   */
   features?:
     | FeatureSet
     | undefined;
@@ -1397,7 +1426,12 @@ export interface EnumValueOptions {
   deprecated?:
     | boolean
     | undefined;
-  /** Any features defined in the specific edition. */
+  /**
+   * Any features defined in the specific edition.
+   * WARNING: This field should only be used by protobuf plugins or special
+   * cases like the proto compiler. Other uses are discouraged and
+   * developers should rely on the protoreflect APIs for their client language.
+   */
   features?:
     | FeatureSet
     | undefined;
@@ -1418,7 +1452,12 @@ export interface EnumValueOptions {
 }
 
 export interface ServiceOptions {
-  /** Any features defined in the specific edition. */
+  /**
+   * Any features defined in the specific edition.
+   * WARNING: This field should only be used by protobuf plugins or special
+   * cases like the proto compiler. Other uses are discouraged and
+   * developers should rely on the protoreflect APIs for their client language.
+   */
   features?:
     | FeatureSet
     | undefined;
@@ -1446,7 +1485,12 @@ export interface MethodOptions {
   idempotencyLevel?:
     | MethodOptions_IdempotencyLevel
     | undefined;
-  /** Any features defined in the specific edition. */
+  /**
+   * Any features defined in the specific edition.
+   * WARNING: This field should only be used by protobuf plugins or special
+   * cases like the proto compiler. Other uses are discouraged and
+   * developers should rely on the protoreflect APIs for their client language.
+   */
   features?:
     | FeatureSet
     | undefined;
@@ -1549,6 +1593,7 @@ export interface FeatureSet {
   utf8Validation?: FeatureSet_Utf8Validation | undefined;
   messageEncoding?: FeatureSet_MessageEncoding | undefined;
   jsonFormat?: FeatureSet_JsonFormat | undefined;
+  enforceNamingStyle?: FeatureSet_EnforceNamingStyle | undefined;
 }
 
 export enum FeatureSet_FieldPresence {
@@ -1786,6 +1831,45 @@ export function featureSet_JsonFormatToNumber(object: FeatureSet_JsonFormat): nu
     case FeatureSet_JsonFormat.LEGACY_BEST_EFFORT:
       return 2;
     case FeatureSet_JsonFormat.UNRECOGNIZED:
+    default:
+      return -1;
+  }
+}
+
+export enum FeatureSet_EnforceNamingStyle {
+  ENFORCE_NAMING_STYLE_UNKNOWN = "ENFORCE_NAMING_STYLE_UNKNOWN",
+  STYLE2024 = "STYLE2024",
+  STYLE_LEGACY = "STYLE_LEGACY",
+  UNRECOGNIZED = "UNRECOGNIZED",
+}
+
+export function featureSet_EnforceNamingStyleFromJSON(object: any): FeatureSet_EnforceNamingStyle {
+  switch (object) {
+    case 0:
+    case "ENFORCE_NAMING_STYLE_UNKNOWN":
+      return FeatureSet_EnforceNamingStyle.ENFORCE_NAMING_STYLE_UNKNOWN;
+    case 1:
+    case "STYLE2024":
+      return FeatureSet_EnforceNamingStyle.STYLE2024;
+    case 2:
+    case "STYLE_LEGACY":
+      return FeatureSet_EnforceNamingStyle.STYLE_LEGACY;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return FeatureSet_EnforceNamingStyle.UNRECOGNIZED;
+  }
+}
+
+export function featureSet_EnforceNamingStyleToNumber(object: FeatureSet_EnforceNamingStyle): number {
+  switch (object) {
+    case FeatureSet_EnforceNamingStyle.ENFORCE_NAMING_STYLE_UNKNOWN:
+      return 0;
+    case FeatureSet_EnforceNamingStyle.STYLE2024:
+      return 1;
+    case FeatureSet_EnforceNamingStyle.STYLE_LEGACY:
+      return 2;
+    case FeatureSet_EnforceNamingStyle.UNRECOGNIZED:
     default:
       return -1;
   }
@@ -4914,6 +4998,7 @@ function createBaseFeatureSet(): FeatureSet {
     utf8Validation: FeatureSet_Utf8Validation.UTF8_VALIDATION_UNKNOWN,
     messageEncoding: FeatureSet_MessageEncoding.MESSAGE_ENCODING_UNKNOWN,
     jsonFormat: FeatureSet_JsonFormat.JSON_FORMAT_UNKNOWN,
+    enforceNamingStyle: FeatureSet_EnforceNamingStyle.ENFORCE_NAMING_STYLE_UNKNOWN,
   };
 }
 
@@ -4947,6 +5032,12 @@ export const FeatureSet: MessageFns<FeatureSet> = {
     }
     if (message.jsonFormat !== undefined && message.jsonFormat !== FeatureSet_JsonFormat.JSON_FORMAT_UNKNOWN) {
       writer.uint32(48).int32(featureSet_JsonFormatToNumber(message.jsonFormat));
+    }
+    if (
+      message.enforceNamingStyle !== undefined &&
+      message.enforceNamingStyle !== FeatureSet_EnforceNamingStyle.ENFORCE_NAMING_STYLE_UNKNOWN
+    ) {
+      writer.uint32(56).int32(featureSet_EnforceNamingStyleToNumber(message.enforceNamingStyle));
     }
     return writer;
   },
@@ -5006,6 +5097,14 @@ export const FeatureSet: MessageFns<FeatureSet> = {
           message.jsonFormat = featureSet_JsonFormatFromJSON(reader.int32());
           continue;
         }
+        case 7: {
+          if (tag !== 56) {
+            break;
+          }
+
+          message.enforceNamingStyle = featureSet_EnforceNamingStyleFromJSON(reader.int32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -5027,6 +5126,8 @@ export const FeatureSet: MessageFns<FeatureSet> = {
     message.utf8Validation = object.utf8Validation ?? FeatureSet_Utf8Validation.UTF8_VALIDATION_UNKNOWN;
     message.messageEncoding = object.messageEncoding ?? FeatureSet_MessageEncoding.MESSAGE_ENCODING_UNKNOWN;
     message.jsonFormat = object.jsonFormat ?? FeatureSet_JsonFormat.JSON_FORMAT_UNKNOWN;
+    message.enforceNamingStyle = object.enforceNamingStyle ??
+      FeatureSet_EnforceNamingStyle.ENFORCE_NAMING_STYLE_UNKNOWN;
     return message;
   },
 };


### PR DESCRIPTION
## Overview

For users with too many notes, it feels unintuitive to keep pressing the "Load More" button. This PR aims to ease navigation by allowing the user to opt in to infinite scrolling, whereby the next posts (if any) are fetched as soon as the user reaches the bottom of the screen.

References: #4683 

### Changes

- Implemented infinite scrolling for memos in the home, archive, explore and profile pages
- Added a dropdown under user preferences (in settings) for users to opt in or out of this feature
- Persistence on the backend

### Demo

https://github.com/user-attachments/assets/3b04f8ec-58c2-4ed5-9f3f-fc9a69c0dfa6