### PR TITLE
fix(editor): Prevent race condition and ensure correct list continuation on Enter

### DIFF
--- a/web/src/components/MemoEditor/Editor/index.tsx
+++ b/web/src/components/MemoEditor/Editor/index.tsx
@@ -169,6 +169,10 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
       if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) {
         return;
       }
+      // Prevent a newline from being inserted, so that we can insert it manually later.
+      // This prevents a race condition that occurs between the newline insertion and
+      // inserting the insertText.
+      event.preventDefault()
 
       const cursorPosition = editorActions.getCursorPosition();
       const prevContent = editorActions.getContent().substring(0, cursorPosition);
@@ -206,7 +210,7 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
       }
 
       if (insertText) {
-        editorActions.insertText(insertText);
+        editorActions.insertText("\n" + insertText);
       }
     }
   };

--- a/web/src/components/MemoEditor/Editor/index.tsx
+++ b/web/src/components/MemoEditor/Editor/index.tsx
@@ -172,7 +172,8 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
       // Prevent a newline from being inserted, so that we can insert it manually later.
       // This prevents a race condition that occurs between the newline insertion and
       // inserting the insertText.
-      event.preventDefault()
+      // Needs to be called before any async call.
+      event.preventDefault();
 
       const cursorPosition = editorActions.getCursorPosition();
       const prevContent = editorActions.getContent().substring(0, cursorPosition);
@@ -209,9 +210,7 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
         insertText += " |";
       }
 
-      if (insertText) {
-        editorActions.insertText("\n" + insertText);
-      }
+      editorActions.insertText("\n" + insertText);
     }
   };
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/c029120f-956e-4384-9b0e-5e97e45dfb5a

I am not always able to reproduce it. But this often happens on iOS Safari on my iPhone 13 Pro and iPad Pro M2. 

From what I can tell, it seems there is a race condition between the default behaviour of the event handler and the `insertText` to be inserted. It only seems to happen with the task list continuation, maybe because it is slightly longer than the other list continuations.

This fix removes the race condition and inserts the newline manually before the `insertText`. 
After implementing this fix, I don't see this occurring on my devices anymore.

Thanks for considering the fix.