### PR TITLE
feat(rss): Use server title and description for RSS feed, if configured

### DIFF
--- a/server/router/rss/rss.go
+++ b/server/router/rss/rss.go
@@ -26,6 +26,11 @@ type RSSService struct {
 	Store   *store.Store
 }
 
+type heading struct {
+	Title       string
+	Description string
+}
+
 func NewRSSService(profile *profile.Profile, store *store.Store) *RSSService {
 	return &RSSService{
 		Profile: profile,
@@ -93,10 +98,14 @@ func (s *RSSService) GetUserRSS(c echo.Context) error {
 }
 
 func (s *RSSService) generateRSSFromMemoList(ctx context.Context, memoList []*store.Memo, baseURL string) (string, error) {
+	rssHeading, err := getRSSHeading(s.Store, ctx)
+	if err != nil {
+		return "", err
+	}
 	feed := &feeds.Feed{
-		Title:       "Memos",
+		Title:       rssHeading.Title,
 		Link:        &feeds.Link{Href: baseURL},
-		Description: "An open source, lightweight note-taking service. Easily capture and share your great thoughts.",
+		Description: rssHeading.Description,
 		Created:     time.Now(),
 	}
 
@@ -149,4 +158,22 @@ func getRSSItemDescription(content string) (string, error) {
 	}
 	result := renderer.NewHTMLRenderer().Render(nodes)
 	return result, nil
+}
+
+func getRSSHeading(store *store.Store, ctx context.Context) (heading, error) {
+	settings, err := store.GetWorkspaceGeneralSetting(ctx)
+	if err != nil {
+		return heading{}, err
+	}
+	if settings == nil || settings.CustomProfile == nil {
+		return heading{
+			Title:       "Memos",
+			Description: "An open source, lightweight note-taking service. Easily capture and share your great thoughts.",
+		}, nil
+	}
+	customProfile := settings.CustomProfile
+	return heading{
+		Title:       customProfile.Title,
+		Description: customProfile.Description,
+	}, nil
 }


### PR DESCRIPTION
As much as I like memos, I think it's confusing for users if the title and description is different than the one which shown on the web ui.

This PR adds those in the meta of the RSS feed too:

![CleanShot 2025-05-23 at 15 17 02@2x](https://github.com/user-attachments/assets/1de20596-4874-4fe7-b152-dab547eda665)
