### PR TITLE
fix: Inherits memo visibility for default comment visibility

### DIFF
--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -40,6 +40,8 @@ export interface Props {
   memoName?: string;
   // The name of the parent memo if the memo is a comment.
   parentMemoName?: string;
+  // The visibility of the parent memo for preset when commenting
+  parentMemoVisibility?: Visibility;
   autoFocus?: boolean;
   onConfirm?: (memoName: string) => void;
   onCancel?: () => void;
@@ -57,12 +59,12 @@ interface State {
 }
 
 const MemoEditor = observer((props: Props) => {
-  const { className, cacheKey, memoName, parentMemoName, autoFocus, onConfirm, onCancel } = props;
+  const { className, cacheKey, memoName, parentMemoName, parentMemoVisibility, autoFocus, onConfirm, onCancel } = props;
   const t = useTranslate();
   const { i18n } = useTranslation();
   const currentUser = useCurrentUser();
   const [state, setState] = useState<State>({
-    memoVisibility: Visibility.PRIVATE,
+    memoVisibility: parentMemoVisibility ?? Visibility.PRIVATE,
     resourceList: [],
     relationList: [],
     location: undefined,
@@ -96,7 +98,7 @@ const MemoEditor = observer((props: Props) => {
   }, [autoFocus]);
 
   useEffect(() => {
-    let visibility = userSetting.memoVisibility;
+    let visibility = parentMemoVisibility ?? userSetting.memoVisibility;
     if (workspaceMemoRelatedSetting.disallowPublicVisibility && visibility === "PUBLIC") {
       visibility = "PRIVATE";
     }
@@ -104,7 +106,7 @@ const MemoEditor = observer((props: Props) => {
       ...prevState,
       memoVisibility: convertVisibilityFromString(visibility),
     }));
-  }, [userSetting.memoVisibility, workspaceMemoRelatedSetting.disallowPublicVisibility]);
+  }, [parentMemoVisibility, userSetting.memoVisibility, workspaceMemoRelatedSetting.disallowPublicVisibility]);
 
   useAsyncEffect(async () => {
     if (!memoName) {

--- a/web/src/pages/MemoDetail.tsx
+++ b/web/src/pages/MemoDetail.tsx
@@ -160,6 +160,7 @@ const MemoDetail = observer(() => {
                   cacheKey={`${memo.name}-${memo.updateTime}-comment`}
                   placeholder={t("editor.add-your-comment-here")}
                   parentMemoName={memo.name}
+                  parentMemoVisibility={memo.visibility}
                   autoFocus
                   onConfirm={handleCommentCreated}
                   onCancel={() => setShowCommentEditor(false)}


### PR DESCRIPTION
Uses the parent memo visibility as default when creating comments. I find that kinda useful but feel free to close this one if it does not fit your idea of that default visibility 🙂 

https://github.com/user-attachments/assets/a6458786-f266-41ca-ad2e-933cace008bc

✌️ 