### PR TITLE
fix: trim queryText and split by regex

### DIFF
--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -17,8 +17,9 @@ const SearchBar = observer(() => {
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       e.preventDefault();
-      if (queryText !== "") {
-        const words = queryText.split(" ");
+      const trimmedText = queryText.trim();
+      if (trimmedText !== "") {
+        const words = trimmedText.split(/\s+/);
         words.forEach((word) => {
           memoFilterStore.addFilter({
             factor: "contentSearch",


### PR DESCRIPTION
**Describe the bug**
After updating from version, an error occurs when searching.

**Steps to reproduce**
When entering text in the Search Bar, if there are leading/trailing spaces or multiple consecutive spaces between words, it causes an abnormal error in "ContentSearch" (as shown in the screenshot).

**The version of Memos you're using**
v0.24.4 (also in develop version)

**Screenshots or additional context**
![anime1](https://github.com/user-attachments/assets/b6a0d25c-7d63-4bda-a958-b326c4206fd6)
![anime2](https://github.com/user-attachments/assets/95552f9a-fe93-4b03-8c00-56c1d5f34ec9)
![anime3](https://github.com/user-attachments/assets/e0c9e084-11a1-4850-b962-31bec4bac469)

The submitted code has fixed this bug—please review and merge.