### PR TITLE
Allow underscores and periods in usernames

### DIFF
--- a/internal/base/resource_name.go
+++ b/internal/base/resource_name.go
@@ -3,5 +3,5 @@ package base
 import "regexp"
 
 var (
-	UIDMatcher = regexp.MustCompile("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,30}[a-zA-Z0-9])?$")
+	UIDMatcher = regexp.MustCompile("^[a-zA-Z0-9]([a-zA-Z0-9-_\.]{0,30}[a-zA-Z0-9])?$")
 )

--- a/internal/base/resource_name.go
+++ b/internal/base/resource_name.go
@@ -3,5 +3,5 @@ package base
 import "regexp"
 
 var (
-	UIDMatcher = regexp.MustCompile("^[a-zA-Z0-9]([a-zA-Z0-9-_\.]{0,30}[a-zA-Z0-9])?$")
+	UIDMatcher = regexp.MustCompile("^[a-zA-Z0-9]([a-zA-Z0-9-_\\.]{0,30}[a-zA-Z0-9])?$")
 )


### PR DESCRIPTION
Super simple PR. Just extends the username validation a little by allowing underscores and periods anywhere except the ends of the username field. This stemmed from my desire for underscores and finding that [some people would also like to be able to use dots/periods](https://github.com/usememos/memos/issues/3095#issuecomment-1996040843) in their usernames as well so I tossed that in there too.

Is there any reason that they were excluded and only hyphens allowed? From my very brief testing they seem to work without issue.