### PR TITLE
Enhance site.webmanifest in firefox

### DIFF
--- a/web/public/site.webmanifest
+++ b/web/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
   "name": "Memos",
-  "short_name": "",
+  "short_name": "Memos",
   "icons": [
     { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }


### PR DESCRIPTION
Previously, the `short_name` field in site.webmanifest was empty. This caused Firefox (e.g., on Android) to display a generic name like "Website" when adding the app to the home screen. The field now correctly uses "Memos" as the short name, improving user experience.