### PR TITLE
fix: dayjs - ISO 8601 compatible DATE_TIME_FORMAT

### DIFF
--- a/web/src/components/DateTimeInput.tsx
+++ b/web/src/components/DateTimeInput.tsx
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import toast from "react-hot-toast";
 import { cn } from "@/lib/utils";
 
-// ISO 8601 (almost)
+// must be compatible with JS Date.parse(), we use ISO 8601 (almost)
 const DATE_TIME_FORMAT = "YYYY-MM-DD HH:mm:ss";
 
 // convert Date to datetime string.
@@ -24,25 +24,13 @@ const DateTimeInput: React.FC<Props> = ({ value, onChange }) => {
       onBlur={(e) => {
         const inputValue = e.target.value;
         if (inputValue) {
+          // note: inputValue must be compatible with JS Date.parse()
           const date = dayjs(inputValue).toDate();
           // Check if the date is valid.
           if (!isNaN(date.getTime())) {
             onChange(date);
           } else {
-            toast.error(
-              <span>
-              Invalid datetime.<br/>
-              Use a{" "}
-              <a
-                class="underline text-primary hover:text-primary/80"
-                href="https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Date#datestring" target="_blank">
-                Date.parse()
-              </a>
-              -compatible format,<br/>
-              e.g., <code>2023-12-31 23:59:59</code><br/>
-              or <code>31/12/2023, 23:59:59</code>.
-              </span>
-            );
+            toast.error("Invalid datetime format. Use format: 2023-12-31 23:59:59");
             e.target.value = formatDate(value);
           }
         }

--- a/web/src/components/DateTimeInput.tsx
+++ b/web/src/components/DateTimeInput.tsx
@@ -2,7 +2,8 @@ import dayjs from "dayjs";
 import toast from "react-hot-toast";
 import { cn } from "@/lib/utils";
 
-const DATE_TIME_FORMAT = "M/D/YYYY, H:mm:ss";
+// ISO 8601 (almost)
+const DATE_TIME_FORMAT = "YYYY-MM-DD HH:mm:ss";
 
 // convert Date to datetime string.
 const formatDate = (date: Date): string => {
@@ -23,12 +24,25 @@ const DateTimeInput: React.FC<Props> = ({ value, onChange }) => {
       onBlur={(e) => {
         const inputValue = e.target.value;
         if (inputValue) {
-          const date = dayjs(inputValue, DATE_TIME_FORMAT, true).toDate();
+          const date = dayjs(inputValue).toDate();
           // Check if the date is valid.
           if (!isNaN(date.getTime())) {
             onChange(date);
           } else {
-            toast.error("Invalid datetime format. Use format: 12/31/2023, 23:59:59");
+            toast.error(
+              <span>
+              Invalid datetime.<br/>
+              Use a{" "}
+              <a
+                class="underline text-primary hover:text-primary/80"
+                href="https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Date#datestring" target="_blank">
+                Date.parse()
+              </a>
+              -compatible format,<br/>
+              e.g., <code>2023-12-31 23:59:59</code><br/>
+              or <code>31/12/2023, 23:59:59</code>.
+              </span>
+            );
             e.target.value = formatDate(value);
           }
         }


### PR DESCRIPTION
According to dayjs documentation
the `dayjs(inputValue, DATE_TIME_FORMAT, true)` construct does not work without `CustomParseFormat` plugin, [link](https://day.js.org/docs/en/parse/string-format),
so the code contains an error.

Also, according to the documentation, dayjs develloper recommended to use ISO 8601 [link](https://day.js.org/docs/en/parse/string)
is international and better readable for the default format.

It's a continuation of the bug #4746 

Using ISO 8601 without `T` is acceptable in JS. 
I suggest to make it the main one for `DATE_TIME_FORMAT`
It preserves readability when editing the date of records and uses the classic international "big-endian" date format.

It would be ideal to put the preferred date format in the settings, but this requires more resources.

