### PR TITLE
feat: basic due date support

### DIFF
--- a/proto/api/v1/user_service.proto
+++ b/proto/api/v1/user_service.proto
@@ -336,6 +336,7 @@ message UserStats {
     int32 code_count = 2;
     int32 todo_count = 3;
     int32 undo_count = 4;
+    int32 due_date_count = 5;
   }
 }
 

--- a/proto/gen/api/v1/user_service.pb.go
+++ b/proto/gen/api/v1/user_service.pb.go
@@ -1769,6 +1769,7 @@ type UserStats_MemoTypeStats struct {
 	CodeCount     int32                  `protobuf:"varint,2,opt,name=code_count,json=codeCount,proto3" json:"code_count,omitempty"`
 	TodoCount     int32                  `protobuf:"varint,3,opt,name=todo_count,json=todoCount,proto3" json:"todo_count,omitempty"`
 	UndoCount     int32                  `protobuf:"varint,4,opt,name=undo_count,json=undoCount,proto3" json:"undo_count,omitempty"`
+	DueDateCount  int32                  `protobuf:"varint,5,opt,name=due_date_count,json=dueDateCount,proto3" json:"due_date_count,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1827,6 +1828,13 @@ func (x *UserStats_MemoTypeStats) GetTodoCount() int32 {
 func (x *UserStats_MemoTypeStats) GetUndoCount() int32 {
 	if x != nil {
 		return x.UndoCount
+	}
+	return 0
+}
+
+func (x *UserStats_MemoTypeStats) GetDueDateCount() int32 {
+	if x != nil {
+		return x.DueDateCount
 	}
 	return 0
 }
@@ -1982,7 +1990,7 @@ const file_api_v1_user_service_proto_rawDesc = "" +
 	"total_size\x18\x03 \x01(\x05R\ttotalSize\"E\n" +
 	"\x14GetUserAvatarRequest\x12-\n" +
 	"\x04name\x18\x01 \x01(\tB\x19\xe0A\x02\xfaA\x13\n" +
-	"\x11memos.api.v1/UserR\x04name\"\xe4\x04\n" +
+	"\x11memos.api.v1/UserR\x04name\"\x8a\x05\n" +
 	"\tUserStats\x12\x17\n" +
 	"\x04name\x18\x01 \x01(\tB\x03\xe0A\bR\x04name\x12R\n" +
 	"\x17memo_display_timestamps\x18\x02 \x03(\v2\x1a.google.protobuf.TimestampR\x15memoDisplayTimestamps\x12M\n" +
@@ -1992,7 +2000,7 @@ const file_api_v1_user_service_proto_rawDesc = "" +
 	"\x10total_memo_count\x18\x06 \x01(\x05R\x0etotalMemoCount\x1a;\n" +
 	"\rTagCountEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\x1a\x8b\x01\n" +
+	"\x05value\x18\x02 \x01(\x05R\x05value:\x028\x01\x1a\xb1\x01\n" +
 	"\rMemoTypeStats\x12\x1d\n" +
 	"\n" +
 	"link_count\x18\x01 \x01(\x05R\tlinkCount\x12\x1d\n" +
@@ -2001,7 +2009,8 @@ const file_api_v1_user_service_proto_rawDesc = "" +
 	"\n" +
 	"todo_count\x18\x03 \x01(\x05R\ttodoCount\x12\x1d\n" +
 	"\n" +
-	"undo_count\x18\x04 \x01(\x05R\tundoCount:?\xeaA<\n" +
+	"undo_count\x18\x04 \x01(\x05R\tundoCount\x12$\n" +
+	"\x0edue_date_count\x18\x05 \x01(\x05R\fdueDateCount:?\xeaA<\n" +
 	"\x16memos.api.v1/UserStats\x12\fusers/{user}*\tuserStats2\tuserStats\"D\n" +
 	"\x13GetUserStatsRequest\x12-\n" +
 	"\x04name\x18\x01 \x01(\tB\x19\xe0A\x02\xfaA\x13\n" +

--- a/proto/gen/apidocs.swagger.yaml
+++ b/proto/gen/apidocs.swagger.yaml
@@ -2561,6 +2561,9 @@ definitions:
       undoCount:
         type: integer
         format: int32
+      dueDateCount:
+        type: integer
+        format: int32
     description: Memo type statistics.
   WorkspaceStorageSettingS3Config:
     type: object

--- a/proto/gen/store/memo.pb.go
+++ b/proto/gen/store/memo.pb.go
@@ -90,6 +90,7 @@ type MemoPayload_Property struct {
 	HasIncompleteTasks bool                   `protobuf:"varint,4,opt,name=has_incomplete_tasks,json=hasIncompleteTasks,proto3" json:"has_incomplete_tasks,omitempty"`
 	// The references of the memo. Should be a list of uuid.
 	References    []string `protobuf:"bytes,5,rep,name=references,proto3" json:"references,omitempty"`
+	HasDueDate    bool     `protobuf:"varint,6,opt,name=has_due_date,json=hasDueDate,proto3" json:"has_due_date,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -159,6 +160,13 @@ func (x *MemoPayload_Property) GetReferences() []string {
 	return nil
 }
 
+func (x *MemoPayload_Property) GetHasDueDate() bool {
+	if x != nil {
+		return x.HasDueDate
+	}
+	return false
+}
+
 type MemoPayload_Location struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Placeholder   string                 `protobuf:"bytes,1,opt,name=placeholder,proto3" json:"placeholder,omitempty"`
@@ -223,11 +231,11 @@ var File_store_memo_proto protoreflect.FileDescriptor
 
 const file_store_memo_proto_rawDesc = "" +
 	"\n" +
-	"\x10store/memo.proto\x12\vmemos.store\"\xc0\x03\n" +
+	"\x10store/memo.proto\x12\vmemos.store\"\xe2\x03\n" +
 	"\vMemoPayload\x12=\n" +
 	"\bproperty\x18\x01 \x01(\v2!.memos.store.MemoPayload.PropertyR\bproperty\x12=\n" +
 	"\blocation\x18\x02 \x01(\v2!.memos.store.MemoPayload.LocationR\blocation\x12\x12\n" +
-	"\x04tags\x18\x03 \x03(\tR\x04tags\x1a\xb6\x01\n" +
+	"\x04tags\x18\x03 \x03(\tR\x04tags\x1a\xd8\x01\n" +
 	"\bProperty\x12\x19\n" +
 	"\bhas_link\x18\x01 \x01(\bR\ahasLink\x12\"\n" +
 	"\rhas_task_list\x18\x02 \x01(\bR\vhasTaskList\x12\x19\n" +
@@ -235,7 +243,9 @@ const file_store_memo_proto_rawDesc = "" +
 	"\x14has_incomplete_tasks\x18\x04 \x01(\bR\x12hasIncompleteTasks\x12\x1e\n" +
 	"\n" +
 	"references\x18\x05 \x03(\tR\n" +
-	"references\x1af\n" +
+	"references\x12 \n" +
+	"\fhas_due_date\x18\x06 \x01(\bR\n" +
+	"hasDueDate\x1af\n" +
 	"\bLocation\x12 \n" +
 	"\vplaceholder\x18\x01 \x01(\tR\vplaceholder\x12\x1a\n" +
 	"\blatitude\x18\x02 \x01(\x01R\blatitude\x12\x1c\n" +

--- a/proto/store/memo.proto
+++ b/proto/store/memo.proto
@@ -19,6 +19,7 @@ message MemoPayload {
     bool has_incomplete_tasks = 4;
     // The references of the memo. Should be a list of uuid.
     repeated string references = 5;
+    bool has_due_date = 6;
   }
 
   message Location {

--- a/server/router/api/v1/memo_service_filter.go
+++ b/server/router/api/v1/memo_service_filter.go
@@ -68,6 +68,9 @@ func (s *APIV1Service) buildMemoFindWithFilter(ctx context.Context, find *store.
 		if filterExpr.HasIncompleteTasks {
 			find.PayloadFind.HasIncompleteTasks = true
 		}
+		if filterExpr.HasDueDate {
+			find.PayloadFind.HasDueDate = true
+		}
 	}
 	return nil
 }
@@ -83,6 +86,7 @@ var MemoFilterCELAttributes = []cel.EnvOption{
 	cel.Variable("has_task_list", cel.BoolType),
 	cel.Variable("has_code", cel.BoolType),
 	cel.Variable("has_incomplete_tasks", cel.BoolType),
+	cel.Variable("has_due_date", cel.BoolType),
 }
 
 type MemoFilter struct {
@@ -95,6 +99,7 @@ type MemoFilter struct {
 	HasTaskList        bool
 	HasCode            bool
 	HasIncompleteTasks bool
+	HasDueDate         bool
 }
 
 func parseMemoFilter(expression string) (*MemoFilter, error) {
@@ -155,6 +160,9 @@ func findMemoField(callExpr *exprv1.Expr_Call, filter *MemoFilter) {
 			} else if idExpr.Name == "has_incomplete_tasks" {
 				value := callExpr.Args[1].GetConstExpr().GetBoolValue()
 				filter.HasIncompleteTasks = value
+			} else if idExpr.Name == "has_due_date" {
+				value := callExpr.Args[1].GetConstExpr().GetBoolValue()
+				filter.HasDueDate = value
 			}
 			return
 		}

--- a/server/router/api/v1/user_service_stats.go
+++ b/server/router/api/v1/user_service_stats.go
@@ -117,6 +117,7 @@ func (s *APIV1Service) GetUserStats(ctx context.Context, request *v1pb.GetUserSt
 	codeCount := int32(0)
 	todoCount := int32(0)
 	undoCount := int32(0)
+	dueDateCount := int32(0)
 	pinnedMemos := []string{}
 
 	for _, memo := range memos {
@@ -143,6 +144,9 @@ func (s *APIV1Service) GetUserStats(ctx context.Context, request *v1pb.GetUserSt
 				if memo.Payload.Property.HasIncompleteTasks {
 					undoCount++
 				}
+				if memo.Payload.Property.HasDueDate {
+					dueDateCount++
+				}
 			}
 		}
 		if memo.Pinned {
@@ -157,10 +161,11 @@ func (s *APIV1Service) GetUserStats(ctx context.Context, request *v1pb.GetUserSt
 		PinnedMemos:           pinnedMemos,
 		TotalMemoCount:        int32(len(memos)),
 		MemoTypeStats: &v1pb.UserStats_MemoTypeStats{
-			LinkCount: linkCount,
-			CodeCount: codeCount,
-			TodoCount: todoCount,
-			UndoCount: undoCount,
+			LinkCount:    linkCount,
+			CodeCount:    codeCount,
+			TodoCount:    todoCount,
+			UndoCount:    undoCount,
+			DueDateCount: dueDateCount,
 		},
 	}
 

--- a/server/runner/memopayload/runner.go
+++ b/server/runner/memopayload/runner.go
@@ -3,6 +3,7 @@ package memopayload
 import (
 	"context"
 	"log/slog"
+	"regexp"
 	"slices"
 
 	"github.com/pkg/errors"
@@ -104,6 +105,10 @@ func RebuildMemoPayload(memo *store.Memo) error {
 			property.References = append(property.References, n.ResourceName)
 		}
 	})
+
+	// Check for patterns in raw content
+	property.HasDueDate = hasDueDate(memo.Content)
+
 	memo.Payload.Tags = tags
 	memo.Payload.Property = property
 	return nil
@@ -131,4 +136,49 @@ func TraverseASTNodes(nodes []ast.Node, fn func(ast.Node)) {
 			TraverseASTNodes(n.Children, fn)
 		}
 	}
+}
+
+// hasDueDate checks if the content contains a valid due date pattern @due(YYYY-MM-DD).
+func hasDueDate(content string) bool {
+	// Regular expression to match @due(YYYY-MM-DD) format
+	// This pattern ensures:
+	// - @due( prefix
+	// - 4 digit year
+	// - - separator
+	// - 2 digit month (01-12)
+	// - - separator
+	// - 2 digit day (01-31)
+	// - ) suffix
+	dueDatePattern := regexp.MustCompile(`@due\((\d{4})-(\d{2})-(\d{2})\)`)
+	matches := dueDatePattern.FindAllStringSubmatch(content, -1)
+
+	if len(matches) == 0 {
+		return false
+	}
+
+	// Validate each match to ensure it's a reasonable date
+	for _, match := range matches {
+		if len(match) < 4 {
+			continue
+		}
+		year := match[1]
+		month := match[2]
+		day := match[3]
+
+		// Basic validation for reasonable date ranges
+		if year < "1900" || year > "2100" {
+			continue
+		}
+		if month < "01" || month > "12" {
+			continue
+		}
+		if day < "01" || day > "31" {
+			continue
+		}
+
+		// Found at least one valid due date
+		return true
+	}
+
+	return false
 }

--- a/server/runner/memopayload/runner_test.go
+++ b/server/runner/memopayload/runner_test.go
@@ -1,0 +1,111 @@
+package memopayload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/usememos/memos/store"
+)
+
+func TestDueDateDetection(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		wantDueDate bool
+	}{
+		{
+			name:        "memo with due date",
+			content:     "This is a memo with due date @due(2025-01-15)",
+			wantDueDate: true,
+		},
+		{
+			name:        "memo with due date at beginning",
+			content:     "@due(2025-12-31) This memo has a due date at the beginning",
+			wantDueDate: true,
+		},
+		{
+			name:        "memo with due date in middle",
+			content:     "Meeting prep @due(2025-01-15) for the quarterly review",
+			wantDueDate: true,
+		},
+		{
+			name:        "memo with task and due date",
+			content:     "- [ ] Complete project @due(2025-01-10)",
+			wantDueDate: true,
+		},
+		{
+			name:        "memo with multiple due dates",
+			content:     "Task 1 @due(2025-01-10) and Task 2 @due(2025-01-15)",
+			wantDueDate: true,
+		},
+		{
+			name:        "memo without due date",
+			content:     "This is a regular memo without any due date",
+			wantDueDate: false,
+		},
+		{
+			name:        "memo with malformed due date",
+			content:     "This has a malformed @due(not-a-date) pattern",
+			wantDueDate: false,
+		},
+		{
+			name:        "memo with partial due date pattern",
+			content:     "This mentions @due but not complete pattern",
+			wantDueDate: false,
+		},
+		{
+			name:        "memo with due date in code block",
+			content:     "```\n@due(2025-01-15)\n```",
+			wantDueDate: true, // Should still detect even in code blocks
+		},
+		{
+			name:        "empty memo",
+			content:     "",
+			wantDueDate: false,
+		},
+		{
+			name:        "memo with invalid date format",
+			content:     "Invalid date @due(25-01-15)",
+			wantDueDate: false,
+		},
+		{
+			name:        "memo with valid date formats",
+			content:     "Valid dates @due(2025-01-15) and @due(2025-12-31)",
+			wantDueDate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			memo := &store.Memo{
+				Content: tt.content,
+			}
+
+			err := RebuildMemoPayload(memo)
+			require.NoError(t, err)
+			require.NotNil(t, memo.Payload)
+			require.NotNil(t, memo.Payload.Property)
+
+			require.Equal(t, tt.wantDueDate, memo.Payload.Property.HasDueDate,
+				"Expected HasDueDate to be %v for content: %s", tt.wantDueDate, tt.content)
+		})
+	}
+}
+
+func TestDueDateDetectionWithOtherProperties(t *testing.T) {
+	memo := &store.Memo{
+		Content: "Check out https://example.com and complete task @due(2025-01-15)\n\n- [ ] incomplete task",
+	}
+
+	err := RebuildMemoPayload(memo)
+	require.NoError(t, err)
+	require.NotNil(t, memo.Payload)
+	require.NotNil(t, memo.Payload.Property)
+
+	// Should detect due date along with other properties
+	require.True(t, memo.Payload.Property.HasDueDate)
+	require.True(t, memo.Payload.Property.HasLink)
+	require.True(t, memo.Payload.Property.HasTaskList)
+	require.True(t, memo.Payload.Property.HasIncompleteTasks)
+}

--- a/store/db/mysql/memo.go
+++ b/store/db/mysql/memo.go
@@ -111,6 +111,9 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 		if v.HasIncompleteTasks {
 			where = append(where, "JSON_EXTRACT(`memo`.`payload`, '$.property.hasIncompleteTasks') IS TRUE")
 		}
+		if v.HasDueDate {
+			where = append(where, "JSON_EXTRACT(`memo`.`payload`, '$.property.hasDueDate') IS TRUE")
+		}
 	}
 	if v := find.Filter; v != nil {
 		// Parse filter string and return the parsed expression.

--- a/store/db/postgres/memo.go
+++ b/store/db/postgres/memo.go
@@ -102,6 +102,9 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 		if v.HasIncompleteTasks {
 			where = append(where, "(memo.payload->'property'->>'hasIncompleteTasks')::BOOLEAN IS TRUE")
 		}
+		if v.HasDueDate {
+			where = append(where, "(memo.payload->'property'->>'hasDueDate')::BOOLEAN IS TRUE")
+		}
 	}
 	if v := find.Filter; v != nil {
 		// Parse filter string and return the parsed expression.

--- a/store/db/sqlite/memo.go
+++ b/store/db/sqlite/memo.go
@@ -103,6 +103,9 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 		if v.HasIncompleteTasks {
 			where = append(where, "JSON_EXTRACT(`memo`.`payload`, '$.property.hasIncompleteTasks') IS TRUE")
 		}
+		if v.HasDueDate {
+			where = append(where, "JSON_EXTRACT(`memo`.`payload`, '$.property.hasDueDate') IS TRUE")
+		}
 	}
 	if v := find.Filter; v != nil {
 		// Parse filter string and return the parsed expression.

--- a/store/memo.go
+++ b/store/memo.go
@@ -93,6 +93,7 @@ type FindMemoPayload struct {
 	HasTaskList        bool
 	HasCode            bool
 	HasIncompleteTasks bool
+	HasDueDate         bool
 }
 
 type UpdateMemo struct {

--- a/web/src/components/MemoFilters.tsx
+++ b/web/src/components/MemoFilters.tsx
@@ -37,6 +37,9 @@ const MemoFilters = observer(() => {
           return factorLabel;
       }
     }
+    if (filter.factor === "dueDate") {
+      return "hasDueDate";
+    }
     return filter.factor;
   };
 
@@ -69,6 +72,7 @@ const FactorIcon = ({ factor, className }: { factor: FilterFactor; className?: s
     visibility: <EyeIcon className={className} />,
     contentSearch: <SearchIcon className={className} />,
     displayTime: <CalendarIcon className={className} />,
+    dueDate: <CalendarIcon className={className} />,
     pinned: <BookmarkIcon className={className} />,
     "property.hasLink": <LinkIcon className={className} />,
     "property.hasTaskList": <CheckCircleIcon className={className} />,

--- a/web/src/components/StatisticsView/StatisticsView.tsx
+++ b/web/src/components/StatisticsView/StatisticsView.tsx
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import { CheckCircleIcon, Code2Icon, LinkIcon, ListTodoIcon, BookmarkIcon } from "lucide-react";
+import { CheckCircleIcon, Code2Icon, LinkIcon, ListTodoIcon, BookmarkIcon, CalendarIcon } from "lucide-react";
 import { observer } from "mobx-react-lite";
 import { useState, useCallback } from "react";
 import { matchPath, useLocation } from "react-router-dom";
@@ -55,6 +55,13 @@ const StatisticsView = observer(() => {
             onClick={() => handleFilterClick("pinned")}
           />
         )}
+
+        <StatCard
+          icon={<CalendarIcon className="w-4 h-auto mr-1 opacity-70" />}
+          label="Due"
+          count={memoTypeStats.dueDateCount || 0}
+          onClick={() => handleFilterClick("dueDate")}
+        />
 
         <StatCard
           icon={<LinkIcon className="w-4 h-auto mr-1 opacity-70" />}

--- a/web/src/hooks/useStatisticsData.ts
+++ b/web/src/hooks/useStatisticsData.ts
@@ -17,6 +17,7 @@ export const useStatisticsData = (): StatisticsData => {
         memoTypeStats.linkCount += stats.memoTypeStats.linkCount;
         memoTypeStats.todoCount += stats.memoTypeStats.todoCount;
         memoTypeStats.undoCount += stats.memoTypeStats.undoCount;
+        memoTypeStats.dueDateCount += stats.memoTypeStats.dueDateCount || 0;
       }
     }
 

--- a/web/src/pages/Archived.tsx
+++ b/web/src/pages/Archived.tsx
@@ -21,6 +21,8 @@ const Archived = observer(() => {
         contentSearch.push(`"${filter.value}"`);
       } else if (filter.factor === "tagSearch") {
         tagSearch.push(`"${filter.value}"`);
+      } else if (filter.factor === "dueDate") {
+        conditions.push(`has_due_date == true`);
       }
     }
     if (contentSearch.length > 0) {

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -43,6 +43,8 @@ const Home = observer(() => {
         const timestampAfter = filterUtcTimestamp / 1000;
         conditions.push(`display_time_after == ${timestampAfter}`);
         conditions.push(`display_time_before == ${timestampAfter + 60 * 60 * 24}`);
+      } else if (filter.factor === "dueDate") {
+        conditions.push(`has_due_date == true`);
       }
     }
     if (contentSearch.length > 0) {

--- a/web/src/pages/UserProfile.tsx
+++ b/web/src/pages/UserProfile.tsx
@@ -54,6 +54,8 @@ const UserProfile = observer(() => {
         contentSearch.push(`"${filter.value}"`);
       } else if (filter.factor === "tagSearch") {
         tagSearch.push(`"${filter.value}"`);
+      } else if (filter.factor === "dueDate") {
+        conditions.push(`has_due_date == true`);
       }
     }
     if (contentSearch.length > 0) {

--- a/web/src/store/memoFilter.ts
+++ b/web/src/store/memoFilter.ts
@@ -6,6 +6,7 @@ export type FilterFactor =
   | "visibility"
   | "contentSearch"
   | "displayTime"
+  | "dueDate"
   | "pinned"
   | "property.hasLink"
   | "property.hasTaskList"

--- a/web/src/types/proto/api/v1/user_service.ts
+++ b/web/src/types/proto/api/v1/user_service.ts
@@ -249,6 +249,7 @@ export interface UserStats_MemoTypeStats {
   codeCount: number;
   todoCount: number;
   undoCount: number;
+  dueDateCount: number;
 }
 
 export interface GetUserStatsRequest {
@@ -1404,7 +1405,7 @@ export const UserStats_TagCountEntry: MessageFns<UserStats_TagCountEntry> = {
 };
 
 function createBaseUserStats_MemoTypeStats(): UserStats_MemoTypeStats {
-  return { linkCount: 0, codeCount: 0, todoCount: 0, undoCount: 0 };
+  return { linkCount: 0, codeCount: 0, todoCount: 0, undoCount: 0, dueDateCount: 0 };
 }
 
 export const UserStats_MemoTypeStats: MessageFns<UserStats_MemoTypeStats> = {
@@ -1420,6 +1421,9 @@ export const UserStats_MemoTypeStats: MessageFns<UserStats_MemoTypeStats> = {
     }
     if (message.undoCount !== 0) {
       writer.uint32(32).int32(message.undoCount);
+    }
+    if (message.dueDateCount !== 0) {
+      writer.uint32(40).int32(message.dueDateCount);
     }
     return writer;
   },
@@ -1463,6 +1467,14 @@ export const UserStats_MemoTypeStats: MessageFns<UserStats_MemoTypeStats> = {
           message.undoCount = reader.int32();
           continue;
         }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.dueDateCount = reader.int32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1481,6 +1493,7 @@ export const UserStats_MemoTypeStats: MessageFns<UserStats_MemoTypeStats> = {
     message.codeCount = object.codeCount ?? 0;
     message.todoCount = object.todoCount ?? 0;
     message.undoCount = object.undoCount ?? 0;
+    message.dueDateCount = object.dueDateCount ?? 0;
     return message;
   },
 };

--- a/web/src/types/proto/google/protobuf/descriptor.ts
+++ b/web/src/types/proto/google/protobuf/descriptor.ts
@@ -129,6 +129,52 @@ export function editionToNumber(object: Edition): number {
 }
 
 /**
+ * Describes the 'visibility' of a symbol with respect to the proto import
+ * system. Symbols can only be imported when the visibility rules do not prevent
+ * it (ex: local symbols cannot be imported).  Visibility modifiers can only set
+ * on `message` and `enum` as they are the only types available to be referenced
+ * from other files.
+ */
+export enum SymbolVisibility {
+  VISIBILITY_UNSET = "VISIBILITY_UNSET",
+  VISIBILITY_LOCAL = "VISIBILITY_LOCAL",
+  VISIBILITY_EXPORT = "VISIBILITY_EXPORT",
+  UNRECOGNIZED = "UNRECOGNIZED",
+}
+
+export function symbolVisibilityFromJSON(object: any): SymbolVisibility {
+  switch (object) {
+    case 0:
+    case "VISIBILITY_UNSET":
+      return SymbolVisibility.VISIBILITY_UNSET;
+    case 1:
+    case "VISIBILITY_LOCAL":
+      return SymbolVisibility.VISIBILITY_LOCAL;
+    case 2:
+    case "VISIBILITY_EXPORT":
+      return SymbolVisibility.VISIBILITY_EXPORT;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return SymbolVisibility.UNRECOGNIZED;
+  }
+}
+
+export function symbolVisibilityToNumber(object: SymbolVisibility): number {
+  switch (object) {
+    case SymbolVisibility.VISIBILITY_UNSET:
+      return 0;
+    case SymbolVisibility.VISIBILITY_LOCAL:
+      return 1;
+    case SymbolVisibility.VISIBILITY_EXPORT:
+      return 2;
+    case SymbolVisibility.UNRECOGNIZED:
+    default:
+      return -1;
+  }
+}
+
+/**
  * The protocol compiler can output a FileDescriptorSet containing the .proto
  * files it parses.
  */
@@ -155,6 +201,11 @@ export interface FileDescriptorProto {
    * For Google-internal migration only. Do not use.
    */
   weakDependency: number[];
+  /**
+   * Names of files imported by this file purely for the purpose of providing
+   * option extensions. These are excluded from the dependency list above.
+   */
+  optionDependency: string[];
   /** All top-level definitions in this file. */
   messageType: DescriptorProto[];
   enumType: EnumDescriptorProto[];
@@ -209,6 +260,8 @@ export interface DescriptorProto {
    * A given name may only be reserved once.
    */
   reservedName: string[];
+  /** Support for `export` and `local` keywords on enums. */
+  visibility?: SymbolVisibility | undefined;
 }
 
 export interface DescriptorProto_ExtensionRange {
@@ -632,6 +685,8 @@ export interface EnumDescriptorProto {
    * be reserved once.
    */
   reservedName: string[];
+  /** Support for `export` and `local` keywords on enums. */
+  visibility?: SymbolVisibility | undefined;
 }
 
 /**
@@ -1594,6 +1649,7 @@ export interface FeatureSet {
   messageEncoding?: FeatureSet_MessageEncoding | undefined;
   jsonFormat?: FeatureSet_JsonFormat | undefined;
   enforceNamingStyle?: FeatureSet_EnforceNamingStyle | undefined;
+  defaultSymbolVisibility?: FeatureSet_VisibilityFeature_DefaultSymbolVisibility | undefined;
 }
 
 export enum FeatureSet_FieldPresence {
@@ -1870,6 +1926,72 @@ export function featureSet_EnforceNamingStyleToNumber(object: FeatureSet_Enforce
     case FeatureSet_EnforceNamingStyle.STYLE_LEGACY:
       return 2;
     case FeatureSet_EnforceNamingStyle.UNRECOGNIZED:
+    default:
+      return -1;
+  }
+}
+
+export interface FeatureSet_VisibilityFeature {
+}
+
+export enum FeatureSet_VisibilityFeature_DefaultSymbolVisibility {
+  DEFAULT_SYMBOL_VISIBILITY_UNKNOWN = "DEFAULT_SYMBOL_VISIBILITY_UNKNOWN",
+  /** EXPORT_ALL - Default pre-EDITION_2024, all UNSET visibility are export. */
+  EXPORT_ALL = "EXPORT_ALL",
+  /** EXPORT_TOP_LEVEL - All top-level symbols default to export, nested default to local. */
+  EXPORT_TOP_LEVEL = "EXPORT_TOP_LEVEL",
+  /** LOCAL_ALL - All symbols default to local. */
+  LOCAL_ALL = "LOCAL_ALL",
+  /**
+   * STRICT - All symbols local by default. Nested types cannot be exported.
+   * With special case caveat for message { enum {} reserved 1 to max; }
+   * This is the recommended setting for new protos.
+   */
+  STRICT = "STRICT",
+  UNRECOGNIZED = "UNRECOGNIZED",
+}
+
+export function featureSet_VisibilityFeature_DefaultSymbolVisibilityFromJSON(
+  object: any,
+): FeatureSet_VisibilityFeature_DefaultSymbolVisibility {
+  switch (object) {
+    case 0:
+    case "DEFAULT_SYMBOL_VISIBILITY_UNKNOWN":
+      return FeatureSet_VisibilityFeature_DefaultSymbolVisibility.DEFAULT_SYMBOL_VISIBILITY_UNKNOWN;
+    case 1:
+    case "EXPORT_ALL":
+      return FeatureSet_VisibilityFeature_DefaultSymbolVisibility.EXPORT_ALL;
+    case 2:
+    case "EXPORT_TOP_LEVEL":
+      return FeatureSet_VisibilityFeature_DefaultSymbolVisibility.EXPORT_TOP_LEVEL;
+    case 3:
+    case "LOCAL_ALL":
+      return FeatureSet_VisibilityFeature_DefaultSymbolVisibility.LOCAL_ALL;
+    case 4:
+    case "STRICT":
+      return FeatureSet_VisibilityFeature_DefaultSymbolVisibility.STRICT;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return FeatureSet_VisibilityFeature_DefaultSymbolVisibility.UNRECOGNIZED;
+  }
+}
+
+export function featureSet_VisibilityFeature_DefaultSymbolVisibilityToNumber(
+  object: FeatureSet_VisibilityFeature_DefaultSymbolVisibility,
+): number {
+  switch (object) {
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.DEFAULT_SYMBOL_VISIBILITY_UNKNOWN:
+      return 0;
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.EXPORT_ALL:
+      return 1;
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.EXPORT_TOP_LEVEL:
+      return 2;
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.LOCAL_ALL:
+      return 3;
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.STRICT:
+      return 4;
+    case FeatureSet_VisibilityFeature_DefaultSymbolVisibility.UNRECOGNIZED:
     default:
       return -1;
   }
@@ -2195,6 +2317,7 @@ function createBaseFileDescriptorProto(): FileDescriptorProto {
     dependency: [],
     publicDependency: [],
     weakDependency: [],
+    optionDependency: [],
     messageType: [],
     enumType: [],
     service: [],
@@ -2227,6 +2350,9 @@ export const FileDescriptorProto: MessageFns<FileDescriptorProto> = {
       writer.int32(v);
     }
     writer.join();
+    for (const v of message.optionDependency) {
+      writer.uint32(122).string(v!);
+    }
     for (const v of message.messageType) {
       DescriptorProto.encode(v!, writer.uint32(34).fork()).join();
     }
@@ -2321,6 +2447,14 @@ export const FileDescriptorProto: MessageFns<FileDescriptorProto> = {
 
           break;
         }
+        case 15: {
+          if (tag !== 122) {
+            break;
+          }
+
+          message.optionDependency.push(reader.string());
+          continue;
+        }
         case 4: {
           if (tag !== 34) {
             break;
@@ -2404,6 +2538,7 @@ export const FileDescriptorProto: MessageFns<FileDescriptorProto> = {
     message.dependency = object.dependency?.map((e) => e) || [];
     message.publicDependency = object.publicDependency?.map((e) => e) || [];
     message.weakDependency = object.weakDependency?.map((e) => e) || [];
+    message.optionDependency = object.optionDependency?.map((e) => e) || [];
     message.messageType = object.messageType?.map((e) => DescriptorProto.fromPartial(e)) || [];
     message.enumType = object.enumType?.map((e) => EnumDescriptorProto.fromPartial(e)) || [];
     message.service = object.service?.map((e) => ServiceDescriptorProto.fromPartial(e)) || [];
@@ -2432,6 +2567,7 @@ function createBaseDescriptorProto(): DescriptorProto {
     options: undefined,
     reservedRange: [],
     reservedName: [],
+    visibility: SymbolVisibility.VISIBILITY_UNSET,
   };
 }
 
@@ -2466,6 +2602,9 @@ export const DescriptorProto: MessageFns<DescriptorProto> = {
     }
     for (const v of message.reservedName) {
       writer.uint32(82).string(v!);
+    }
+    if (message.visibility !== undefined && message.visibility !== SymbolVisibility.VISIBILITY_UNSET) {
+      writer.uint32(88).int32(symbolVisibilityToNumber(message.visibility));
     }
     return writer;
   },
@@ -2557,6 +2696,14 @@ export const DescriptorProto: MessageFns<DescriptorProto> = {
           message.reservedName.push(reader.string());
           continue;
         }
+        case 11: {
+          if (tag !== 88) {
+            break;
+          }
+
+          message.visibility = symbolVisibilityFromJSON(reader.int32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -2583,6 +2730,7 @@ export const DescriptorProto: MessageFns<DescriptorProto> = {
       : undefined;
     message.reservedRange = object.reservedRange?.map((e) => DescriptorProto_ReservedRange.fromPartial(e)) || [];
     message.reservedName = object.reservedName?.map((e) => e) || [];
+    message.visibility = object.visibility ?? SymbolVisibility.VISIBILITY_UNSET;
     return message;
   },
 };
@@ -3143,7 +3291,14 @@ export const OneofDescriptorProto: MessageFns<OneofDescriptorProto> = {
 };
 
 function createBaseEnumDescriptorProto(): EnumDescriptorProto {
-  return { name: "", value: [], options: undefined, reservedRange: [], reservedName: [] };
+  return {
+    name: "",
+    value: [],
+    options: undefined,
+    reservedRange: [],
+    reservedName: [],
+    visibility: SymbolVisibility.VISIBILITY_UNSET,
+  };
 }
 
 export const EnumDescriptorProto: MessageFns<EnumDescriptorProto> = {
@@ -3162,6 +3317,9 @@ export const EnumDescriptorProto: MessageFns<EnumDescriptorProto> = {
     }
     for (const v of message.reservedName) {
       writer.uint32(42).string(v!);
+    }
+    if (message.visibility !== undefined && message.visibility !== SymbolVisibility.VISIBILITY_UNSET) {
+      writer.uint32(48).int32(symbolVisibilityToNumber(message.visibility));
     }
     return writer;
   },
@@ -3213,6 +3371,14 @@ export const EnumDescriptorProto: MessageFns<EnumDescriptorProto> = {
           message.reservedName.push(reader.string());
           continue;
         }
+        case 6: {
+          if (tag !== 48) {
+            break;
+          }
+
+          message.visibility = symbolVisibilityFromJSON(reader.int32());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -3235,6 +3401,7 @@ export const EnumDescriptorProto: MessageFns<EnumDescriptorProto> = {
     message.reservedRange = object.reservedRange?.map((e) => EnumDescriptorProto_EnumReservedRange.fromPartial(e)) ||
       [];
     message.reservedName = object.reservedName?.map((e) => e) || [];
+    message.visibility = object.visibility ?? SymbolVisibility.VISIBILITY_UNSET;
     return message;
   },
 };
@@ -4999,6 +5166,7 @@ function createBaseFeatureSet(): FeatureSet {
     messageEncoding: FeatureSet_MessageEncoding.MESSAGE_ENCODING_UNKNOWN,
     jsonFormat: FeatureSet_JsonFormat.JSON_FORMAT_UNKNOWN,
     enforceNamingStyle: FeatureSet_EnforceNamingStyle.ENFORCE_NAMING_STYLE_UNKNOWN,
+    defaultSymbolVisibility: FeatureSet_VisibilityFeature_DefaultSymbolVisibility.DEFAULT_SYMBOL_VISIBILITY_UNKNOWN,
   };
 }
 
@@ -5038,6 +5206,15 @@ export const FeatureSet: MessageFns<FeatureSet> = {
       message.enforceNamingStyle !== FeatureSet_EnforceNamingStyle.ENFORCE_NAMING_STYLE_UNKNOWN
     ) {
       writer.uint32(56).int32(featureSet_EnforceNamingStyleToNumber(message.enforceNamingStyle));
+    }
+    if (
+      message.defaultSymbolVisibility !== undefined &&
+      message.defaultSymbolVisibility !==
+        FeatureSet_VisibilityFeature_DefaultSymbolVisibility.DEFAULT_SYMBOL_VISIBILITY_UNKNOWN
+    ) {
+      writer.uint32(64).int32(
+        featureSet_VisibilityFeature_DefaultSymbolVisibilityToNumber(message.defaultSymbolVisibility),
+      );
     }
     return writer;
   },
@@ -5105,6 +5282,16 @@ export const FeatureSet: MessageFns<FeatureSet> = {
           message.enforceNamingStyle = featureSet_EnforceNamingStyleFromJSON(reader.int32());
           continue;
         }
+        case 8: {
+          if (tag !== 64) {
+            break;
+          }
+
+          message.defaultSymbolVisibility = featureSet_VisibilityFeature_DefaultSymbolVisibilityFromJSON(
+            reader.int32(),
+          );
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -5128,6 +5315,42 @@ export const FeatureSet: MessageFns<FeatureSet> = {
     message.jsonFormat = object.jsonFormat ?? FeatureSet_JsonFormat.JSON_FORMAT_UNKNOWN;
     message.enforceNamingStyle = object.enforceNamingStyle ??
       FeatureSet_EnforceNamingStyle.ENFORCE_NAMING_STYLE_UNKNOWN;
+    message.defaultSymbolVisibility = object.defaultSymbolVisibility ??
+      FeatureSet_VisibilityFeature_DefaultSymbolVisibility.DEFAULT_SYMBOL_VISIBILITY_UNKNOWN;
+    return message;
+  },
+};
+
+function createBaseFeatureSet_VisibilityFeature(): FeatureSet_VisibilityFeature {
+  return {};
+}
+
+export const FeatureSet_VisibilityFeature: MessageFns<FeatureSet_VisibilityFeature> = {
+  encode(_: FeatureSet_VisibilityFeature, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): FeatureSet_VisibilityFeature {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseFeatureSet_VisibilityFeature();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  create(base?: DeepPartial<FeatureSet_VisibilityFeature>): FeatureSet_VisibilityFeature {
+    return FeatureSet_VisibilityFeature.fromPartial(base ?? {});
+  },
+  fromPartial(_: DeepPartial<FeatureSet_VisibilityFeature>): FeatureSet_VisibilityFeature {
+    const message = createBaseFeatureSet_VisibilityFeature();
     return message;
   },
 };


### PR DESCRIPTION
# Add due date support to memos

(first part of #4823 )

![image](https://github.com/user-attachments/assets/a3ef62c3-53e1-46d2-950e-cf8cd2e97482)


Adds basic due date functionality for memos using `@due(YYYY-MM-DD)` syntax

**Features:**
- **Due date detection**: Automatically detects `@due(YYYY-MM-DD)` patterns in memo content
- **Filtering**: New `has_due_date` filter to show only memos with due dates
- **Statistics**: Added due date count to filter button (like code, tasks etc)
- **Database support**: Updated all database drivers (SQLite, MySQL, PostgreSQL) for due date queries

**Implementation:**
- Added `has_due_date` field to `MemoPayload.Property` protobuf
- Updated memo payload runner with regex validation for due date patterns
- Enhanced frontend with due date filter button and statistics card
- Added extended test coverage for due date detection

**Usage:**
- Write `@due(2025-01-15)` in memo content to set due date
- Click "Due" filter button to show only memos with due dates


**Note:** this is the very minimal functionality to add due dates to memos. **NOT included yet are**

* color-coded badge rendering
* sorting by due date for filtered results


