### PR TITLE
set HasCode only for CodeBlock

### DIFF
--- a/server/runner/memopayload/runner.go
+++ b/server/runner/memopayload/runner.go
@@ -97,7 +97,7 @@ func RebuildMemoPayload(memo *store.Memo) error {
 			if !n.Complete {
 				property.HasIncompleteTasks = true
 			}
-		case *ast.Code, *ast.CodeBlock:
+		case *ast.CodeBlock:
 			property.HasCode = true
 		case *ast.EmbeddedContent:
 			// TODO: validate references.


### PR DESCRIPTION
The reason is that the `HasCode` property is now set by the presence of `Code` or `CodeBlock` elements in the note, but the `Code` block is mostly (almost always) used to highlight important words in the text (e.g. variables) that are not code, but such notes are mistakenly caught in the `HasCode` filter. The new behaviour marks notes with the `HasCode` flag only if they contain a `CodeBlock`.

I think this behaviour of the system is more correct.

PS: Due to the fact that the `HasCode` property is only updated when the note is saved, the new logic will only be applied when modifying old/creating new notes.
![изображение](https://github.com/user-attachments/assets/76a10195-9f8c-4ee9-9502-202f86d6cbf1)

![изображение](https://github.com/user-attachments/assets/c703a5f0-bfee-44e5-a4ef-9d3948ef832c)
