### PR TITLE
feat: highlight pinned memos

### DIFF
--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -136,7 +136,8 @@ const MemoView: React.FC<Props> = observer((props: Props) => {
   ) : (
     <div
       className={cn(
-        "group relative flex flex-col justify-start items-start w-full px-4 py-3 mb-2 gap-2 bg-card text-card-foreground rounded-lg border border-border transition-colors",
+        "group relative flex flex-col justify-start items-start w-full px-4 py-3 mb-2 gap-2 text-card-foreground rounded-lg border border-border transition-colors",
+        props.showPinned && memo.pinned ? "bg-accent" : "bg-card",
         className,
       )}
     >


### PR DESCRIPTION
If a note is pinned, it will be highlighted with a slightly brighter background colour.
This allows you to quickly visually separate pinned notes from regular notes.

samples:
![изображение](https://github.com/user-attachments/assets/8a5799fe-f35a-49b0-a31a-79692a872468)

![изображение](https://github.com/user-attachments/assets/319754e4-2833-4c83-aa5f-923bf58ae47d)

![изображение](https://github.com/user-attachments/assets/51d92d4a-7720-4dcf-aee5-520ee2b545cd)

![изображение](https://github.com/user-attachments/assets/f9670dc1-3a16-4a5f-8730-e44233740a08)
