### PR TITLE
Hyperlinks in README Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,9 @@ For detailed installation instructions, refer to the [comprehensive installation
 
 ### Prerequisites
 
-- Go 1.24 or later
-- Node.js 22+ and pnpm
-- Git for version control
+- [Go 1.24](https://go.dev/) or later
+- [Node.js 22+](https://nodejs.org/en) and [pnpm](https://pnpm.io/)
+- [Git](https://git-scm.com/) for version control
 
 ### Backend Development
 


### PR DESCRIPTION
## Hyperlinks in README Prerequisites

Fixes #4847

This adds hyperlinks to the prerequisites in the README file on GitHub, as discussed in #4847.

Let me know what you think!