### PR TITLE
fix(syntax-highlighting): Adds missing CSS imports to CodeBlock.tsx

### DIFF
--- a/web/src/components/MemoContent/CodeBlock.tsx
+++ b/web/src/components/MemoContent/CodeBlock.tsx
@@ -6,6 +6,8 @@ import toast from "react-hot-toast";
 import { cn } from "@/lib/utils";
 import MermaidBlock from "./MermaidBlock";
 import { BaseProps } from "./types";
+import "highlight.js/styles/atom-one-dark.css";
+import "highlight.js/styles/github.css";
 
 // Special languages that are rendered differently.
 enum SpecialLanguage {


### PR DESCRIPTION
<img width="1384" height="652" alt="CleanShot 2025-07-17 at 09 10 01@2x" src="https://github.com/user-attachments/assets/31787d4e-e71c-4182-9dee-1b4facd0ff27" />

Fixes #4888 
