### PR TITLE
Use MEMOS_INSTANCE_URL for "Copy Link"

### DIFF
--- a/web/src/components/MemoActionMenu.tsx
+++ b/web/src/components/MemoActionMenu.tsx
@@ -17,6 +17,7 @@ import { markdownServiceClient } from "@/grpcweb";
 import useNavigateTo from "@/hooks/useNavigateTo";
 import { memoStore, userStore } from "@/store";
 import { State } from "@/types/proto/api/v1/common";
+import { workspaceStore } from "@/store";
 import { NodeType } from "@/types/proto/api/v1/markdown_service";
 import { Memo } from "@/types/proto/api/v1/memo_service";
 import { useTranslate } from "@/utils/i18n";
@@ -114,7 +115,8 @@ const MemoActionMenu = observer((props: Props) => {
   };
 
   const handleCopyLink = () => {
-    copy(`${window.location.origin}/${memo.name}`);
+    let instanceUrl = workspaceStore.state.profile.instanceUrl;
+    copy(`${instanceUrl}/${memo.name}`);
     toast.success(t("message.succeed-copy-link"));
   };
 

--- a/web/src/components/MemoActionMenu.tsx
+++ b/web/src/components/MemoActionMenu.tsx
@@ -16,8 +16,8 @@ import { useLocation } from "react-router-dom";
 import { markdownServiceClient } from "@/grpcweb";
 import useNavigateTo from "@/hooks/useNavigateTo";
 import { memoStore, userStore } from "@/store";
-import { State } from "@/types/proto/api/v1/common";
 import { workspaceStore } from "@/store";
+import { State } from "@/types/proto/api/v1/common";
 import { NodeType } from "@/types/proto/api/v1/markdown_service";
 import { Memo } from "@/types/proto/api/v1/memo_service";
 import { useTranslate } from "@/utils/i18n";
@@ -115,8 +115,11 @@ const MemoActionMenu = observer((props: Props) => {
   };
 
   const handleCopyLink = () => {
-    let instanceUrl = workspaceStore.state.profile.instanceUrl;
-    copy(`${instanceUrl}/${memo.name}`);
+    let host = workspaceStore.state.profile.instanceUrl;
+    if (host === "") {
+      host = window.location.origin;
+    }
+    copy(`${host}/${memo.name}`);
     toast.success(t("message.succeed-copy-link"));
   };
 


### PR DESCRIPTION
This relates to my question [here](https://github.com/usememos/memos/issues/4928). Basically I was wondering if memos could support an alternate host for the "Copy Link" button. I noticed a mention of the environment variable `MEMOS_INSTANCE_URL` and as far as I can tell it isn't really used for anything.. So in this PR I have used it for this purpose.

I don't usually work with typescript or go so please forgive me if I am making some egregious error (though this is a pretty simple change).

~I could see an argument that the behavior should be maintained to copy `window.location.origin` in the case that `MEMOS_INSTANCE_URL` is unset so I think I'll see if I can make that work, but as far as I can tell from my quick testing this does exactly what I want as is.~ --------------did this

Now.. if there is some reason that `MEMOS_INSTANCE_URL` should not be used for this I'm happy to try to figure out how to add a different variable for it.