### PR TITLE
fix calendar filter?

### DIFF
--- a/plugin/filter/dialect.go
+++ b/plugin/filter/dialect.go
@@ -222,7 +222,7 @@ func (d *PostgreSQLDialect) GetBooleanCheck(path string) string {
 }
 
 func (d *PostgreSQLDialect) GetTimestampComparison(field string) string {
-	return fmt.Sprintf("EXTRACT(EPOCH FROM %s.%s)", d.GetTablePrefix(), field)
+	return fmt.Sprintf("EXTRACT(EPOCH FROM TO_TIMESTAMP(%s.%s))", d.GetTablePrefix(), field)
 }
 
 func (*PostgreSQLDialect) GetCurrentTimestamp() string {

--- a/store/db/postgres/memo_filter_test.go
+++ b/store/db/postgres/memo_filter_test.go
@@ -92,7 +92,7 @@ func TestConvertExprToSQL(t *testing.T) {
 		},
 		{
 			filter: `created_ts > now() - 60 * 60 * 24`,
-			want:   "EXTRACT(EPOCH FROM memo.created_ts) > $1",
+			want:   "EXTRACT(EPOCH FROM TO_TIMESTAMP(memo.created_ts)) > $1",
 			args:   []any{time.Now().Unix() - 60*60*24},
 		},
 		{


### PR DESCRIPTION
Seeing an error on main when trying to select a date filter when using postgres db (16.1):

```
Uncaught (in promise) ClientError: /memos.api.v1.MemoService/ListMemos INTERNAL: failed to list memos: pq: function pg_catalog.extract(unknown, bigint) does not exist
```

and the DB error:

```
2025-07-31 20:04:19.154 UTC [133] ERROR:  function pg_catalog.extract(unknown, bigint) does not exist at character 465
2025-07-31 20:04:19.154 UTC [133] HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
2025-07-31 20:04:19.154 UTC [133] STATEMENT:  SELECT memo.id AS id, memo.uid AS uid, memo.creator_id AS creator_id, memo.created_ts AS created_ts, memo.updated_ts AS updated_ts, memo.row_status AS row_status, memo.visibility AS visibility, memo.pinned AS pinned, memo.payload AS payload, memo_relation.related_memo_id AS parent_id, memo.content AS content
                        FROM memo
                        LEFT JOIN memo_relation ON memo.id = memo_relation.memo_id AND memo_relation.type = 'COMMENT'
                        WHERE 1 = 1 AND (((memo.creator_id = $1 AND EXTRACT(EPOCH FROM memo.created_ts) >= $2) AND EXTRACT(EPOCH FROM memo.created_ts) < $3)) AND ((memo.creator_id = $4 OR memo.visibility IN ($5,$6))) AND memo.row_status = $7 AND memo_relation.related_memo_id IS NULL
                        ORDER BY created_ts DESC LIMIT 17 OFFSET 0
```

Again not _really_ sure if this is the right way to fix it, but this does at least make the error go away. Open to suggestions.