### PR TITLE
fix(tags): ensure JSON array elements are properly formatted in SQL queries

### DIFF
--- a/plugin/filter/common_converter.go
+++ b/plugin/filter/common_converter.go
@@ -266,7 +266,7 @@ func (c *CommonSQLConverter) handleTagInList(ctx *ConvertContext, values []any) 
 			template := c.dialect.GetJSONContains("$.tags", "element")
 			sql := strings.Replace(template, "?", c.dialect.GetParameterPlaceholder(c.paramIndex), 1)
 			subconditions = append(subconditions, sql)
-			args = append(args, v)
+			args = append(args, fmt.Sprintf(`"%s"`, v))
 		}
 		c.paramIndex++
 	}

--- a/plugin/filter/dialect.go
+++ b/plugin/filter/dialect.go
@@ -185,12 +185,12 @@ func (d *PostgreSQLDialect) GetJSONArrayLength(path string) string {
 
 func (d *PostgreSQLDialect) GetJSONContains(path, _ string) string {
 	jsonPath := strings.Replace(path, "$.tags", "payload->'tags'", 1)
-	return fmt.Sprintf("%s.%s @> jsonb_build_array(?)", d.GetTablePrefix(), jsonPath)
+	return fmt.Sprintf("%s.%s @> jsonb_build_array(?::json)", d.GetTablePrefix(), jsonPath)
 }
 
 func (d *PostgreSQLDialect) GetJSONLike(path, _ string) string {
 	jsonPath := strings.Replace(path, "$.tags", "payload->'tags'", 1)
-	return fmt.Sprintf("%s.%s @> jsonb_build_array(?)", d.GetTablePrefix(), jsonPath)
+	return fmt.Sprintf("%s.%s @> jsonb_build_array(?::json)", d.GetTablePrefix(), jsonPath)
 }
 
 func (*PostgreSQLDialect) GetBooleanValue(value bool) interface{} {

--- a/store/db/mysql/memo_filter_test.go
+++ b/store/db/mysql/memo_filter_test.go
@@ -18,12 +18,12 @@ func TestConvertExprToSQL(t *testing.T) {
 		{
 			filter: `tag in ["tag1", "tag2"]`,
 			want:   "(JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.tags'), ?) OR JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.tags'), ?))",
-			args:   []any{"tag1", "tag2"},
+			args:   []any{`"tag1"`, `"tag2"`},
 		},
 		{
 			filter: `!(tag in ["tag1", "tag2"])`,
 			want:   "NOT ((JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.tags'), ?) OR JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.tags'), ?)))",
-			args:   []any{"tag1", "tag2"},
+			args:   []any{`"tag1"`, `"tag2"`},
 		},
 		{
 			filter: `content.contains("memos")`,
@@ -43,7 +43,7 @@ func TestConvertExprToSQL(t *testing.T) {
 		{
 			filter: `tag in ['tag1'] || content.contains('hello')`,
 			want:   "(JSON_CONTAINS(JSON_EXTRACT(`memo`.`payload`, '$.tags'), ?) OR `memo`.`content` LIKE ?)",
-			args:   []any{"tag1", "%hello%"},
+			args:   []any{`"tag1"`, "%hello%"},
 		},
 		{
 			filter: `1`,

--- a/store/db/postgres/memo_filter_test.go
+++ b/store/db/postgres/memo_filter_test.go
@@ -17,13 +17,13 @@ func TestConvertExprToSQL(t *testing.T) {
 	}{
 		{
 			filter: `tag in ["tag1", "tag2"]`,
-			want:   "(memo.payload->'tags' @> jsonb_build_array($1) OR memo.payload->'tags' @> jsonb_build_array($2))",
-			args:   []any{"tag1", "tag2"},
+			want:   "(memo.payload->'tags' @> jsonb_build_array($1::json) OR memo.payload->'tags' @> jsonb_build_array($2::json))",
+			args:   []any{`"tag1"`, `"tag2"`},
 		},
 		{
 			filter: `!(tag in ["tag1", "tag2"])`,
-			want:   "NOT ((memo.payload->'tags' @> jsonb_build_array($1) OR memo.payload->'tags' @> jsonb_build_array($2)))",
-			args:   []any{"tag1", "tag2"},
+			want:   "NOT ((memo.payload->'tags' @> jsonb_build_array($1::json) OR memo.payload->'tags' @> jsonb_build_array($2::json)))",
+			args:   []any{`"tag1"`, `"tag2"`},
 		},
 		{
 			filter: `content.contains("memos")`,
@@ -42,8 +42,8 @@ func TestConvertExprToSQL(t *testing.T) {
 		},
 		{
 			filter: `tag in ['tag1'] || content.contains('hello')`,
-			want:   "(memo.payload->'tags' @> jsonb_build_array($1) OR memo.content ILIKE $2)",
-			args:   []any{"tag1", "%hello%"},
+			want:   "(memo.payload->'tags' @> jsonb_build_array($1::json) OR memo.content ILIKE $2)",
+			args:   []any{`"tag1"`, "%hello%"},
 		},
 		{
 			filter: `1`,
@@ -107,7 +107,7 @@ func TestConvertExprToSQL(t *testing.T) {
 		},
 		{
 			filter: `"work" in tags`,
-			want:   "memo.payload->'tags' @> jsonb_build_array($1)",
+			want:   "memo.payload->'tags' @> jsonb_build_array($1::json)",
 			args:   []any{"work"},
 		},
 		{


### PR DESCRIPTION
The tag filter was broken for MySql and Postgres Drivers since 0.25.0. 

MySql error:
```
2025/08/01 08:50:38 ERROR server error method=/memos.api.v1.MemoService/ListMemos error="rpc error: code = Internal desc = failed to list memos: Error 3141 (22032): Invalid JSON text in argument 1 to function json_contains: \"Invalid value.\" at position 0."
```

Postges error:
```
2025/08/01 09:07:47 ERROR server error method=/memos.api.v1.MemoService/ListMemos error="rpc error: code = Internal desc = failed to list memos: pq: could not determine data type of parameter $2"
```

Problem was for MySql was that the tag needs to be a valid json string which can be achieved by adding quotes. For Postgres it was required to also add the `::json` type to the query.


Closes #4937