### PR TITLE
#4946 - remove call to db for parent memo name

### DIFF
--- a/server/router/api/v1/memo_service_converter.go
+++ b/server/router/api/v1/memo_service_converter.go
@@ -43,15 +43,9 @@ func (s *APIV1Service) convertMemoFromStore(ctx context.Context, memo *store.Mem
 		memoMessage.Property = convertMemoPropertyFromStore(memo.Payload.Property)
 		memoMessage.Location = convertLocationFromStore(memo.Payload.Location)
 	}
-	if memo.ParentID != nil {
-		parent, err := s.Store.GetMemo(ctx, &store.FindMemo{
-			ID:             memo.ParentID,
-			ExcludeContent: true,
-		})
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to get parent memo")
-		}
-		parentName := fmt.Sprintf("%s%s", MemoNamePrefix, parent.UID)
+
+	if memo.ParentUID != nil {
+		parentName := fmt.Sprintf("%s%s", MemoNamePrefix, *memo.ParentUID)
 		memoMessage.Parent = &parentName
 	}
 

--- a/store/db/postgres/memo.go
+++ b/store/db/postgres/memo.go
@@ -105,7 +105,7 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 		`memo.visibility AS visibility`,
 		`memo.pinned AS pinned`,
 		`memo.payload AS payload`,
-		`memo_relation.related_memo_id AS parent_id`,
+		`CASE WHEN parent_memo.uid IS NOT NULL THEN parent_memo.uid ELSE NULL END AS parent_uid`,
 	}
 	if !find.ExcludeContent {
 		fields = append(fields, `memo.content AS content`)
@@ -114,6 +114,7 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 	query := `SELECT ` + strings.Join(fields, ", ") + `
 		FROM memo
 		LEFT JOIN memo_relation ON memo.id = memo_relation.memo_id AND memo_relation.type = 'COMMENT'
+		LEFT JOIN memo AS parent_memo ON memo_relation.related_memo_id = parent_memo.id
 		WHERE ` + strings.Join(where, " AND ") + `
 		ORDER BY ` + strings.Join(orderBy, ", ")
 	if find.Limit != nil {
@@ -143,7 +144,7 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 			&memo.Visibility,
 			&memo.Pinned,
 			&payloadBytes,
-			&memo.ParentID,
+			&memo.ParentUID,
 		}
 		if !find.ExcludeContent {
 			dests = append(dests, &memo.Content)

--- a/store/db/sqlite/memo.go
+++ b/store/db/sqlite/memo.go
@@ -82,7 +82,7 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 		where = append(where, fmt.Sprintf("`memo`.`visibility` IN (%s)", strings.Join(placeholder, ",")))
 	}
 	if find.ExcludeComments {
-		where = append(where, "`parent_id` IS NULL")
+		where = append(where, "`parent_uid` IS NULL")
 	}
 
 	order := "DESC"
@@ -105,7 +105,7 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 		"`memo`.`visibility` AS `visibility`",
 		"`memo`.`pinned` AS `pinned`",
 		"`memo`.`payload` AS `payload`",
-		"`memo_relation`.`related_memo_id` AS `parent_id`",
+		"CASE WHEN `parent_memo`.`uid` IS NOT NULL THEN `parent_memo`.`uid` ELSE NULL END AS `parent_uid`",
 	}
 	if !find.ExcludeContent {
 		fields = append(fields, "`memo`.`content` AS `content`")
@@ -113,6 +113,7 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 
 	query := "SELECT " + strings.Join(fields, ", ") + "FROM `memo` " +
 		"LEFT JOIN `memo_relation` ON `memo`.`id` = `memo_relation`.`memo_id` AND `memo_relation`.`type` = \"COMMENT\" " +
+		"LEFT JOIN `memo` AS `parent_memo` ON `memo_relation`.`related_memo_id` = `parent_memo`.`id` " +
 		"WHERE " + strings.Join(where, " AND ") + " " +
 		"ORDER BY " + strings.Join(orderBy, ", ")
 	if find.Limit != nil {
@@ -142,7 +143,7 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 			&memo.Visibility,
 			&memo.Pinned,
 			&payloadBytes,
-			&memo.ParentID,
+			&memo.ParentUID,
 		}
 		if !find.ExcludeContent {
 			dests = append(dests, &memo.Content)

--- a/store/memo.go
+++ b/store/memo.go
@@ -52,7 +52,7 @@ type Memo struct {
 	Payload    *storepb.MemoPayload
 
 	// Composed fields
-	ParentID *int32
+	ParentUID *string
 }
 
 type FindMemo struct {


### PR DESCRIPTION
This PR partially addresses #4946 by removing an extra call to the database done per memo just to retrieve the parent memo's name. The ParentID field has been removed as it was only used to later get the parent memo's name so replacing it with a ParentUID field makes more sense.

Because refactoring the ListMemos and the database drivers is a large and risky change it's best to approach this in multiple stages and this change seems like an quick win.

I have tested the changes with sqlite, mysql 8, and postgres 17.