### PR TITLE
fix: boolean filters

### DIFF
--- a/plugin/filter/dialect.go
+++ b/plugin/filter/dialect.go
@@ -205,9 +205,8 @@ func (d *PostgreSQLDialect) GetBooleanComparison(path string, _ bool) string {
 func (d *PostgreSQLDialect) GetBooleanCheck(path string) string {
 	// Special handling for standalone boolean identifiers
 	if strings.Contains(path, "hasLink") || strings.Contains(path, "hasCode") || strings.Contains(path, "hasIncompleteTasks") {
-		// Use memo-> instead of memo.payload-> for these fields
 		parts := strings.Split(strings.TrimPrefix(path, "$."), ".")
-		result := fmt.Sprintf("%s->'payload'", d.GetTablePrefix())
+		result := fmt.Sprintf("%s.payload", d.GetTablePrefix())
 		for i, part := range parts {
 			if i == len(parts)-1 {
 				result += fmt.Sprintf("->>'%s'", part)

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -50,7 +50,6 @@ const Home = observer(() => {
         conditions.push(`${factor} >= ${timestampAfter} && ${factor} < ${timestampAfter + 60 * 60 * 24}`);
       }
     }
-    console.log("conditions", conditions);
     return conditions.length > 0 ? conditions.join(" && ") : undefined;
   }, [memoFilterStore.filters, selectedShortcut?.filter]);
 


### PR DESCRIPTION
Seeing messages like

```
Uncaught (in promise) ClientError: /memos.api.v1.MemoService/ListMemos INTERNAL: failed to list memos: pq: operator does not exist: memo -> unknown
```

in the web console and 

```
2025-08-05 02:52:12.899 UTC [148] ERROR:  operator does not exist: memo -> unknown at character 595
2025-08-05 02:52:12.899 UTC [148] HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
2025-08-05 02:52:12.899 UTC [148] STATEMENT:  SELECT memo.id AS id, memo.uid AS uid, memo.creator_id AS creator_id, memo.created_ts AS created_ts, memo.updated_ts AS updated_ts, memo.row_status AS row_status, memo.visibility AS visibility, memo.pinned AS pinned, memo.payload AS payload, CASE WHEN parent_memo.uid IS NOT NULL THEN parent_memo.uid ELSE NULL END AS parent_uid, memo.content AS content
                        FROM memo
                        LEFT JOIN memo_relation ON memo.id = memo_relation.memo_id AND memo_relation.type = 'COMMENT'
                        LEFT JOIN memo AS parent_memo ON memo_relation.related_memo_id = parent_memo.id
                        WHERE 1 = 1 AND ((memo.creator_id = $1 AND (memo->'payload'->'property'->>'hasLink')::boolean = true)) AND ((memo.creator_id = $2 OR memo.visibility IN ($3,$4))) AND memo.row_status = $5 AND memo_relation.related_memo_id IS NULL
                        ORDER BY created_ts DESC LIMIT 17 OFFSET 0
```

in the database logs..

I'm not _positive_ on the fix here but it seems like undoing the comment

```
// Use memo-> instead of memo.payload-> for these fields
```

does the trick.