### PR TITLE
fix: resolve gRPC Gateway connection issue when server address is empty

### DIFF
--- a/server/router/api/v1/v1.go
+++ b/server/router/api/v1/v1.go
@@ -67,7 +67,11 @@ func NewAPIV1Service(secret string, profile *profile.Profile, store *store.Store
 func (s *APIV1Service) RegisterGateway(ctx context.Context, echoServer *echo.Echo) error {
 	var target string
 	if len(s.Profile.UNIXSock) == 0 {
-		target = fmt.Sprintf("%s:%d", s.Profile.Addr, s.Profile.Port)
+		addr := s.Profile.Addr
+		if addr == "" {
+			addr = "localhost"
+		}
+		target = fmt.Sprintf("%s:%d", addr, s.Profile.Port)
 	} else {
 		target = fmt.Sprintf("unix:%s", s.Profile.UNIXSock)
 	}


### PR DESCRIPTION
Fix gRPC Gateway connection issue on macOS when server address is empty

# Problem

 When starting memos without specifying the --addr parameter (default configuration),
 all /api/v1/* endpoints fail on macOS with the following error:

```
{"code":14, "message":"connection error: desc = \"transport: Error while dialing:
reading server HTTP response: unexpected EOF\"", "details":[]}
```

The /healthz endpoint works correctly, indicating the HTTP server is running, but the
gRPC Gateway cannot communicate with the gRPC server.

# Root Cause Analysis

Cross-Platform gRPC Connection Behavior Difference:

When `Profile.Addr` is empty (default case), the gRPC Gateway attempts to connect using
the `:port` format. Our testing reveals platform-specific behavior:

Linux (✅ Works):

:8083 → ✅ Successfully connected
:8083 → ✅ Health check succeeded: SERVING

macOS (❌ Fails):

:8083 → ✅ Successfully connected
:8083 → ❌ Health check failed: transport: Error while dialing: reading server HTTP
response: unexpected EOF

Key Finding: While both platforms can establish the initial gRPC connection to :port,
only Linux can successfully complete gRPC calls. On macOS, the connection fails at the
protocol level.

# Impact

  - Affected Platform: macOS (Darwin) - all development environments
  - Affected Scope: All `/api/v1/*` REST API endpoints fail
  - Workaround: Start server with `--addr localhost` or `--addr 127.0.0.1`
  - Production Impact: None (Docker/Linux environments work correctly)

# Solution

When `Profile.Addr` is empty, explicitly default to "localhost" instead of relying on
the empty string behavior:

Before:
```
target = fmt.Sprintf("%s:%d", s.Profile.Addr, s.Profile.Port)
// When s.Profile.Addr = "", target becomes ":8081"
```

After:
```
addr := s.Profile.Addr
if addr == "" {
    addr = "localhost"  // Explicit fallback for cross-platform compatibility
}
target = fmt.Sprintf("%s:%d", addr, s.Profile.Port)
// Now target becomes "localhost:8081"
```

# Testing Evidence

Cross-platform gRPC connection test results:

| Platform | :port Connection | :port gRPC Call | localhost:port | 127.0.0.1:port |
|----------|------------------|-----------------|----------------|----------------|
| Linux    | ✅ Success        | ✅ Success       | ✅ Success      | ✅ Success |
| macOS    | ✅ Success        | ❌ Fails         | ✅ Success      | ✅ Success |

This confirms the issue is specific to macOS gRPC protocol handling of the `:port`
address format.

# Architecture Notes

This fix maintains the correct server architecture:
- Server binding: Can still bind to all interfaces (`0.0.0.0`) for external access
- Gateway connection: Uses explicit loopback address for internal process
communication
- Cross-platform: Ensures consistent behavior across Linux, macOS, and potentially
Windows

# Verification

1. Before fix: Start server on macOS → API endpoints fail
2. After fix: All API endpoints work correctly on both macOS and Linux
3. Regression test: Explicit --addr configurations continue working as before
