### PR TITLE
feat: filter/method for reactions by content_id

### DIFF
--- a/plugin/filter/filter.go
+++ b/plugin/filter/filter.go
@@ -36,6 +36,11 @@ var MemoFilterCELAttributes = []cel.EnvOption{
 	),
 }
 
+// ReactionFilterCELAttributes are the CEL attributes for reaction.
+var ReactionFilterCELAttributes = []cel.EnvOption{
+	cel.Variable("content_id", cel.StringType),
+}
+
 // UserFilterCELAttributes are the CEL attributes for user.
 var UserFilterCELAttributes = []cel.EnvOption{
 	cel.Variable("username", cel.StringType),

--- a/store/db/mysql/reaction.go
+++ b/store/db/mysql/reaction.go
@@ -2,10 +2,12 @@ package mysql
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
 
+	"github.com/usememos/memos/plugin/filter"
 	"github.com/usememos/memos/store"
 )
 
@@ -36,6 +38,27 @@ func (d *DB) UpsertReaction(ctx context.Context, upsert *store.Reaction) (*store
 
 func (d *DB) ListReactions(ctx context.Context, find *store.FindReaction) ([]*store.Reaction, error) {
 	where, args := []string{"1 = 1"}, []interface{}{}
+
+	for _, filterStr := range find.Filters {
+		// Parse filter string and return the parsed expression.
+		// The filter string should be a CEL expression.
+		parsedExpr, err := filter.Parse(filterStr, filter.ReactionFilterCELAttributes...)
+		if err != nil {
+			return nil, err
+		}
+		convertCtx := filter.NewConvertContext()
+		// ConvertExprToSQL converts the parsed expression to a SQL condition string.
+		converter := filter.NewCommonSQLConverter(&filter.MySQLDialect{})
+		if err := converter.ConvertExprToSQL(convertCtx, parsedExpr.GetExpr()); err != nil {
+			return nil, err
+		}
+		condition := convertCtx.Buffer.String()
+		if condition != "" {
+			where = append(where, fmt.Sprintf("(%s)", condition))
+			args = append(args, convertCtx.Args...)
+		}
+	}
+
 	if find.ID != nil {
 		where, args = append(where, "`id` = ?"), append(args, *find.ID)
 	}

--- a/store/db/mysql/reaction_filter_test.go
+++ b/store/db/mysql/reaction_filter_test.go
@@ -1,0 +1,39 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/usememos/memos/plugin/filter"
+)
+
+func TestReactionConvertExprToSQL(t *testing.T) {
+	tests := []struct {
+		filter string
+		want   string
+		args   []any
+	}{
+		{
+			filter: `content_id in ["memos/5atZAj8GcvkSuUA3X2KLaY"]`,
+			want:   "`reaction`.`content_id` IN (?)",
+			args:   []any{"memos/5atZAj8GcvkSuUA3X2KLaY"},
+		},
+		{
+			filter: `content_id in ["memos/5atZAj8GcvkSuUA3X2KLaY", "memos/4EN8aEpcJ3MaK4ExHTpiTE"]`,
+			want:   "`reaction`.`content_id` IN (?,?)",
+			args:   []any{"memos/5atZAj8GcvkSuUA3X2KLaY", "memos/4EN8aEpcJ3MaK4ExHTpiTE"},
+		},
+	}
+
+	for _, tt := range tests {
+		parsedExpr, err := filter.Parse(tt.filter, filter.ReactionFilterCELAttributes...)
+		require.NoError(t, err)
+		convertCtx := filter.NewConvertContext()
+		converter := filter.NewCommonSQLConverter(&filter.MySQLDialect{})
+		err = converter.ConvertExprToSQL(convertCtx, parsedExpr.GetExpr())
+		require.NoError(t, err)
+		require.Equal(t, tt.want, convertCtx.Buffer.String())
+		require.Equal(t, tt.args, convertCtx.Args)
+	}
+}

--- a/store/db/postgres/reaction.go
+++ b/store/db/postgres/reaction.go
@@ -2,8 +2,10 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	"github.com/usememos/memos/plugin/filter"
 	"github.com/usememos/memos/store"
 )
 
@@ -24,6 +26,27 @@ func (d *DB) UpsertReaction(ctx context.Context, upsert *store.Reaction) (*store
 
 func (d *DB) ListReactions(ctx context.Context, find *store.FindReaction) ([]*store.Reaction, error) {
 	where, args := []string{"1 = 1"}, []interface{}{}
+
+	for _, filterStr := range find.Filters {
+		// Parse filter string and return the parsed expression.
+		// The filter string should be a CEL expression.
+		parsedExpr, err := filter.Parse(filterStr, filter.ReactionFilterCELAttributes...)
+		if err != nil {
+			return nil, err
+		}
+		convertCtx := filter.NewConvertContext()
+		// ConvertExprToSQL converts the parsed expression to a SQL condition string.
+		converter := filter.NewCommonSQLConverter(&filter.PostgreSQLDialect{})
+		if err := converter.ConvertExprToSQL(convertCtx, parsedExpr.GetExpr()); err != nil {
+			return nil, err
+		}
+		condition := convertCtx.Buffer.String()
+		if condition != "" {
+			where = append(where, fmt.Sprintf("(%s)", condition))
+			args = append(args, convertCtx.Args...)
+		}
+	}
+
 	if find.ID != nil {
 		where, args = append(where, "id = "+placeholder(len(args)+1)), append(args, *find.ID)
 	}

--- a/store/db/postgres/reaction_filter_test.go
+++ b/store/db/postgres/reaction_filter_test.go
@@ -1,0 +1,39 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/usememos/memos/plugin/filter"
+)
+
+func TestReactionConvertExprToSQL(t *testing.T) {
+	tests := []struct {
+		filter string
+		want   string
+		args   []any
+	}{
+		{
+			filter: `content_id in ["memos/5atZAj8GcvkSuUA3X2KLaY"]`,
+			want:   "reaction.content_id IN ($1)",
+			args:   []any{"memos/5atZAj8GcvkSuUA3X2KLaY"},
+		},
+		{
+			filter: `content_id in ["memos/5atZAj8GcvkSuUA3X2KLaY", "memos/4EN8aEpcJ3MaK4ExHTpiTE"]`,
+			want:   "reaction.content_id IN ($1,$2)",
+			args:   []any{"memos/5atZAj8GcvkSuUA3X2KLaY", "memos/4EN8aEpcJ3MaK4ExHTpiTE"},
+		},
+	}
+
+	for _, tt := range tests {
+		parsedExpr, err := filter.Parse(tt.filter, filter.ReactionFilterCELAttributes...)
+		require.NoError(t, err)
+		convertCtx := filter.NewConvertContext()
+		converter := filter.NewCommonSQLConverter(&filter.PostgreSQLDialect{})
+		err = converter.ConvertExprToSQL(convertCtx, parsedExpr.GetExpr())
+		require.NoError(t, err)
+		require.Equal(t, tt.want, convertCtx.Buffer.String())
+		require.Equal(t, tt.args, convertCtx.Args)
+	}
+}

--- a/store/db/sqlite/reaction.go
+++ b/store/db/sqlite/reaction.go
@@ -2,8 +2,10 @@ package sqlite
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	"github.com/usememos/memos/plugin/filter"
 	"github.com/usememos/memos/store"
 )
 
@@ -25,6 +27,27 @@ func (d *DB) UpsertReaction(ctx context.Context, upsert *store.Reaction) (*store
 
 func (d *DB) ListReactions(ctx context.Context, find *store.FindReaction) ([]*store.Reaction, error) {
 	where, args := []string{"1 = 1"}, []interface{}{}
+
+	for _, filterStr := range find.Filters {
+		// Parse filter string and return the parsed expression.
+		// The filter string should be a CEL expression.
+		parsedExpr, err := filter.Parse(filterStr, filter.ReactionFilterCELAttributes...)
+		if err != nil {
+			return nil, err
+		}
+		convertCtx := filter.NewConvertContext()
+		// ConvertExprToSQL converts the parsed expression to a SQL condition string.
+		converter := filter.NewCommonSQLConverter(&filter.SQLiteDialect{})
+		if err := converter.ConvertExprToSQL(convertCtx, parsedExpr.GetExpr()); err != nil {
+			return nil, err
+		}
+		condition := convertCtx.Buffer.String()
+		if condition != "" {
+			where = append(where, fmt.Sprintf("(%s)", condition))
+			args = append(args, convertCtx.Args...)
+		}
+	}
+
 	if find.ID != nil {
 		where, args = append(where, "id = ?"), append(args, *find.ID)
 	}

--- a/store/db/sqlite/reaction_filter_test.go
+++ b/store/db/sqlite/reaction_filter_test.go
@@ -1,0 +1,39 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/usememos/memos/plugin/filter"
+)
+
+func TestReactionConvertExprToSQL(t *testing.T) {
+	tests := []struct {
+		filter string
+		want   string
+		args   []any
+	}{
+		{
+			filter: `content_id in ["memos/5atZAj8GcvkSuUA3X2KLaY"]`,
+			want:   "`reaction`.`content_id` IN (?)",
+			args:   []any{"memos/5atZAj8GcvkSuUA3X2KLaY"},
+		},
+		{
+			filter: `content_id in ["memos/5atZAj8GcvkSuUA3X2KLaY", "memos/4EN8aEpcJ3MaK4ExHTpiTE"]`,
+			want:   "`reaction`.`content_id` IN (?,?)",
+			args:   []any{"memos/5atZAj8GcvkSuUA3X2KLaY", "memos/4EN8aEpcJ3MaK4ExHTpiTE"},
+		},
+	}
+
+	for _, tt := range tests {
+		parsedExpr, err := filter.Parse(tt.filter, filter.ReactionFilterCELAttributes...)
+		require.NoError(t, err)
+		convertCtx := filter.NewConvertContext()
+		converter := filter.NewCommonSQLConverter(&filter.SQLiteDialect{})
+		err = converter.ConvertExprToSQL(convertCtx, parsedExpr.GetExpr())
+		require.NoError(t, err)
+		require.Equal(t, tt.want, convertCtx.Buffer.String())
+		require.Equal(t, tt.args, convertCtx.Args)
+	}
+}

--- a/store/reaction.go
+++ b/store/reaction.go
@@ -17,6 +17,7 @@ type FindReaction struct {
 	ID        *int32
 	CreatorID *int32
 	ContentID *string
+	Filters   []string
 }
 
 type DeleteReaction struct {


### PR DESCRIPTION
Another PR to incrementally address #4946.

Implemented filter logic for `reaction` entities inline with `memo` and `user` filters.

The reactions table is now queryable using a filter. ListMemos queries the reactions table using a collection of memo names, reducing all calls to this table to just a single call. If there are 10 memos in the collection, 1 call is made to the database to retrieve the reactions, instead of 10.

`convertMemoFromStore` has fallback logic to query the DB if no reactions are passed in. The goal is to align `convertMemoFromStore` with a method that purely maps DB entities to response entities.

The `ListMemoReactions` public endpoint remains untouched. It is not publicly exposed by the router but it can be in the future.

Tested with sqlite, mysql, postgres.