### PR TITLE
fix: preference not being saved

### DIFF
--- a/web/src/store/user.ts
+++ b/web/src/store/user.ts
@@ -177,8 +177,6 @@ const userStore = (() => {
 
   const fetchUserSettings = async () => {
     if (!state.currentUser) {
-      console.error("No current user");
-
       return;
     }
 

--- a/web/src/store/user.ts
+++ b/web/src/store/user.ts
@@ -177,6 +177,8 @@ const userStore = (() => {
 
   const fetchUserSettings = async () => {
     if (!state.currentUser) {
+      console.error("No current user");
+
       return;
     }
 
@@ -280,6 +282,10 @@ const userStore = (() => {
   };
 })();
 
+// TODO: refactor initialUserStore as it has temporal coupling
+// need to make it more clear that the order of the body is important
+// or it leads to false positives
+// See: https://github.com/usememos/memos/issues/4978
 export const initialUserStore = async () => {
   try {
     const { user: currentUser } = await authServiceClient.getCurrentSession({});
@@ -293,9 +299,6 @@ export const initialUserStore = async () => {
       return;
     }
 
-    // Fetch all user settings
-    await userStore.fetchUserSettings();
-
     userStore.state.setPartial({
       currentUser: currentUser.name,
       userMapByName: {
@@ -303,6 +306,10 @@ export const initialUserStore = async () => {
       },
     });
 
+    // must be called after user is set in store
+    await userStore.fetchUserSettings();
+
+    // must be run after fetchUserSettings is called.
     // Apply general settings to workspace if available
     const generalSetting = userStore.state.userGeneralSetting;
     if (generalSetting) {


### PR DESCRIPTION
`initialUserStore` has temporal coupling which led to `fetchUserSettings` unintentionally being called before a user was set in the store.

Fixed by moving the call to occur after the user has been set to the store.

Added comments on the order, a todo to try avoid similar bugs, and a console.error call to help debug if it occurs before/if a refactor is done.

fixes: #4978 