### PR TITLE
fix: prevent auto focus on open for sidebar drawer

### DIFF
--- a/web/src/components/HomeSidebar/HomeSidebarDrawer.tsx
+++ b/web/src/components/HomeSidebar/HomeSidebarDrawer.tsx
@@ -20,7 +20,7 @@ const HomeSidebarDrawer = () => {
           <MenuIcon className="size-5 text-foreground" />
         </Button>
       </SheetTrigger>
-      <SheetContent side="right" className="w-80 max-w-full bg-background">
+      <SheetContent side="right" className="w-80 max-w-full bg-background" onOpenAutoFocus={(e) => e.preventDefault()}>
         <SheetHeader>
           <SheetTitle />
         </SheetHeader>


### PR DESCRIPTION
Prevent the search bar from automatically focusing when the sidebar is opened on mobile devices.