### PR TITLE
fix: prevent default focus behavior on open and close events in sheet

### DIFF
--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -72,6 +72,13 @@ const SheetContent = React.forwardRef<
             "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
           className,
         )}
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+        }}
+        onCloseAutoFocus={(e) => {
+          e.preventDefault();
+          document.body.style.pointerEvents = "auto";
+        }}
         {...props}
       >
         {children}


### PR DESCRIPTION
- Prevent the search bar from automatically focusing when the sidebar is opened and on mobile devices.
- Fix interaction issues on the settings page on mobile devices https://github.com/usememos/memos/issues/4896.

Reference: https://github.com/radix-ui/primitives/issues/1241