### PR TITLE
fix: Update SSO login flow to encode redirect_uri

### DIFF
--- a/web/src/pages/SignIn.tsx
+++ b/web/src/pages/SignIn.tsx
@@ -48,7 +48,7 @@ const SignIn = observer(() => {
       }
       const authUrl = `${oauth2Config.authUrl}?client_id=${
         oauth2Config.clientId
-      }&redirect_uri=${redirectUri}&state=${stateQueryParameter}&response_type=code&scope=${encodeURIComponent(
+      }&redirect_uri=${encodeURIComponent(redirectUri)}&state=${stateQueryParameter}&response_type=code&scope=${encodeURIComponent(
         oauth2Config.scopes.join(" "),
       )}`;
       window.location.href = authUrl;


### PR DESCRIPTION
This fix is intended to fix some authorization flow errors that I have encountered with my identity provider. It seems to be standard to encode the `redirect_uri` so that the server can properly parse the request parameters. Without encoding, my server (running pocket-id) is unable to handle the request.

Please let me know if you have any thoughts or suggestions.