### PR TITLE
feat: attachments by id

### DIFF
--- a/plugin/filter/filter.go
+++ b/plugin/filter/filter.go
@@ -46,6 +46,11 @@ var UserFilterCELAttributes = []cel.EnvOption{
 	cel.Variable("username", cel.StringType),
 }
 
+// AttachmentFilterCELAttributes are the CEL attributes for user.
+var AttachmentFilterCELAttributes = []cel.EnvOption{
+	cel.Variable("memo_id", cel.StringType),
+}
+
 // Parse parses the filter string and returns the parsed expression.
 // The filter string should be a CEL expression.
 func Parse(filter string, opts ...cel.EnvOption) (expr *exprv1.ParsedExpr, err error) {

--- a/server/router/api/v1/memo_attachment_service.go
+++ b/server/router/api/v1/memo_attachment_service.go
@@ -96,7 +96,7 @@ func (s *APIV1Service) ListMemoAttachments(ctx context.Context, request *v1pb.Li
 		Attachments: []*v1pb.Attachment{},
 	}
 	for _, attachment := range attachments {
-		response.Attachments = append(response.Attachments, s.convertAttachmentFromStore(ctx, attachment))
+		response.Attachments = append(response.Attachments, convertAttachmentFromStore(attachment))
 	}
 	return response, nil
 }

--- a/server/router/api/v1/memo_service_converter.go
+++ b/server/router/api/v1/memo_service_converter.go
@@ -16,7 +16,7 @@ import (
 	"github.com/usememos/memos/store"
 )
 
-func (s *APIV1Service) convertMemoFromStore(ctx context.Context, memo *store.Memo, reactions []*store.Reaction) (*v1pb.Memo, error) {
+func (s *APIV1Service) convertMemoFromStore(ctx context.Context, memo *store.Memo, reactions []*store.Reaction, attachments []*store.Attachment) (*v1pb.Memo, error) {
 	displayTs := memo.CreatedTs
 	workspaceMemoRelatedSetting, err := s.Store.GetWorkspaceMemoRelatedSetting(ctx)
 	if err != nil {
@@ -62,11 +62,12 @@ func (s *APIV1Service) convertMemoFromStore(ctx context.Context, memo *store.Mem
 	}
 	memoMessage.Relations = listMemoRelationsResponse.Relations
 
-	listMemoAttachmentsResponse, err := s.ListMemoAttachments(ctx, &v1pb.ListMemoAttachmentsRequest{Name: name})
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to list memo attachments")
+	memoMessage.Attachments = []*v1pb.Attachment{}
+
+	for _, attachment := range attachments {
+		attachmentResponse := convertAttachmentFromStore(attachment)
+		memoMessage.Attachments = append(memoMessage.Attachments, attachmentResponse)
 	}
-	memoMessage.Attachments = listMemoAttachmentsResponse.Attachments
 
 	nodes, err := parser.Parse(tokenizer.Tokenize(memo.Content))
 	if err != nil {

--- a/store/attachment.go
+++ b/store/attachment.go
@@ -35,6 +35,9 @@ type Attachment struct {
 
 	// The related memo ID.
 	MemoID *int32
+
+	// Composed field
+	MemoUID *string
 }
 
 type FindAttachment struct {
@@ -49,6 +52,7 @@ type FindAttachment struct {
 	StorageType    *storepb.AttachmentStorageType
 	Limit          *int
 	Offset         *int
+	Filters        []string
 }
 
 type UpdateAttachment struct {

--- a/store/db/mysql/attachment.go
+++ b/store/db/mysql/attachment.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/usememos/memos/plugin/filter"
 	storepb "github.com/usememos/memos/proto/gen/store"
 	"github.com/usememos/memos/store"
 )
@@ -48,37 +49,74 @@ func (d *DB) CreateAttachment(ctx context.Context, create *store.Attachment) (*s
 func (d *DB) ListAttachments(ctx context.Context, find *store.FindAttachment) ([]*store.Attachment, error) {
 	where, args := []string{"1 = 1"}, []any{}
 
+	for _, filterStr := range find.Filters {
+		// Parse filter string and return the parsed expression.
+		// The filter string should be a CEL expression.
+		parsedExpr, err := filter.Parse(filterStr, filter.AttachmentFilterCELAttributes...)
+		if err != nil {
+			return nil, err
+		}
+		convertCtx := filter.NewConvertContext()
+		// ConvertExprToSQL converts the parsed expression to a SQL condition string.
+		converter := filter.NewCommonSQLConverter(&filter.MySQLDialect{})
+		if err := converter.ConvertExprToSQL(convertCtx, parsedExpr.GetExpr()); err != nil {
+			return nil, err
+		}
+		condition := convertCtx.Buffer.String()
+		if condition != "" {
+			where = append(where, fmt.Sprintf("(%s)", condition))
+			args = append(args, convertCtx.Args...)
+		}
+	}
+
 	if v := find.ID; v != nil {
-		where, args = append(where, "`id` = ?"), append(args, *v)
+		where, args = append(where, "`resource`.`id` = ?"), append(args, *v)
 	}
 	if v := find.UID; v != nil {
-		where, args = append(where, "`uid` = ?"), append(args, *v)
+		where, args = append(where, "`resource`.`uid` = ?"), append(args, *v)
 	}
 	if v := find.CreatorID; v != nil {
-		where, args = append(where, "`creator_id` = ?"), append(args, *v)
+		where, args = append(where, "`resource`.`creator_id` = ?"), append(args, *v)
 	}
 	if v := find.Filename; v != nil {
-		where, args = append(where, "`filename` = ?"), append(args, *v)
+		where, args = append(where, "`resource`.`filename` = ?"), append(args, *v)
 	}
 	if v := find.FilenameSearch; v != nil {
-		where, args = append(where, "`filename` LIKE ?"), append(args, "%"+*v+"%")
+		where, args = append(where, "`resource`.`filename` LIKE ?"), append(args, "%"+*v+"%")
 	}
 	if v := find.MemoID; v != nil {
-		where, args = append(where, "`memo_id` = ?"), append(args, *v)
+		where, args = append(where, "`resource`.`memo_id` = ?"), append(args, *v)
 	}
 	if find.HasRelatedMemo {
-		where = append(where, "`memo_id` IS NOT NULL")
+		where = append(where, "`resource`.`memo_id` IS NOT NULL")
 	}
 	if find.StorageType != nil {
-		where, args = append(where, "`storage_type` = ?"), append(args, find.StorageType.String())
+		where, args = append(where, "`resource`.`storage_type` = ?"), append(args, find.StorageType.String())
 	}
 
-	fields := []string{"`id`", "`uid`", "`filename`", "`type`", "`size`", "`creator_id`", "UNIX_TIMESTAMP(`created_ts`)", "UNIX_TIMESTAMP(`updated_ts`)", "`memo_id`", "`storage_type`", "`reference`", "`payload`"}
+	fields := []string{
+		"`resource`.`id` AS `id`",
+		"`resource`.`uid` AS `uid`",
+		"`resource`.`filename` AS `filename`",
+		"`resource`.`type` AS `type`",
+		"`resource`.`size` AS `size`",
+		"`resource`.`creator_id` AS `creator_id`",
+		"UNIX_TIMESTAMP(`resource`.`created_ts`) AS `created_ts`",
+		"UNIX_TIMESTAMP(`resource`.`updated_ts`) AS `updated_ts`",
+		"`resource`.`memo_id` AS `memo_id`",
+		"`resource`.`storage_type` AS `storage_type`",
+		"`resource`.`reference` AS `reference`",
+		"`resource`.`payload` AS `payload`",
+		"CASE WHEN `memo`.`uid` IS NOT NULL THEN `memo`.`uid` ELSE NULL END AS `memo_uid`",
+	}
 	if find.GetBlob {
-		fields = append(fields, "`blob`")
+		fields = append(fields, "`resource`.`blob` AS `blob`")
 	}
 
-	query := fmt.Sprintf("SELECT %s FROM `resource` WHERE %s ORDER BY `updated_ts` DESC", strings.Join(fields, ", "), strings.Join(where, " AND "))
+	query := "SELECT " + strings.Join(fields, ", ") + " FROM `resource`" + " " +
+		"LEFT JOIN `memo` ON `resource`.`memo_id` = `memo`.`id`" + " " +
+		"WHERE " + strings.Join(where, " AND ") + " " +
+		"ORDER BY `updated_ts` DESC"
 	if find.Limit != nil {
 		query = fmt.Sprintf("%s LIMIT %d", query, *find.Limit)
 		if find.Offset != nil {
@@ -111,6 +149,7 @@ func (d *DB) ListAttachments(ctx context.Context, find *store.FindAttachment) ([
 			&storageType,
 			&attachment.Reference,
 			&payloadBytes,
+			&attachment.MemoUID,
 		}
 		if find.GetBlob {
 			dests = append(dests, &attachment.Blob)

--- a/store/db/mysql/attachment_filter_test.go
+++ b/store/db/mysql/attachment_filter_test.go
@@ -1,0 +1,39 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/usememos/memos/plugin/filter"
+)
+
+func TestAttachmentConvertExprToSQL(t *testing.T) {
+	tests := []struct {
+		filter string
+		want   string
+		args   []any
+	}{
+		{
+			filter: `memo_id in ["5atZAj8GcvkSuUA3X2KLaY"]`,
+			want:   "`resource`.`memo_id` IN (?)",
+			args:   []any{"5atZAj8GcvkSuUA3X2KLaY"},
+		},
+		{
+			filter: `memo_id in ["5atZAj8GcvkSuUA3X2KLaY", "4EN8aEpcJ3MaK4ExHTpiTE"]`,
+			want:   "`resource`.`memo_id` IN (?,?)",
+			args:   []any{"5atZAj8GcvkSuUA3X2KLaY", "4EN8aEpcJ3MaK4ExHTpiTE"},
+		},
+	}
+
+	for _, tt := range tests {
+		parsedExpr, err := filter.Parse(tt.filter, filter.AttachmentFilterCELAttributes...)
+		require.NoError(t, err)
+		convertCtx := filter.NewConvertContext()
+		converter := filter.NewCommonSQLConverter(&filter.MySQLDialect{})
+		err = converter.ConvertExprToSQL(convertCtx, parsedExpr.GetExpr())
+		require.NoError(t, err)
+		require.Equal(t, tt.want, convertCtx.Buffer.String())
+		require.Equal(t, tt.args, convertCtx.Args)
+	}
+}

--- a/store/db/postgres/attachment_filter_test.go
+++ b/store/db/postgres/attachment_filter_test.go
@@ -1,0 +1,39 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/usememos/memos/plugin/filter"
+)
+
+func TestAttachmentConvertExprToSQL(t *testing.T) {
+	tests := []struct {
+		filter string
+		want   string
+		args   []any
+	}{
+		{
+			filter: `memo_id in ["5atZAj8GcvkSuUA3X2KLaY"]`,
+			want:   "resource.memo_id IN ($1)",
+			args:   []any{"5atZAj8GcvkSuUA3X2KLaY"},
+		},
+		{
+			filter: `memo_id in ["5atZAj8GcvkSuUA3X2KLaY", "4EN8aEpcJ3MaK4ExHTpiTE"]`,
+			want:   "resource.memo_id IN ($1,$2)",
+			args:   []any{"5atZAj8GcvkSuUA3X2KLaY", "4EN8aEpcJ3MaK4ExHTpiTE"},
+		},
+	}
+
+	for _, tt := range tests {
+		parsedExpr, err := filter.Parse(tt.filter, filter.AttachmentFilterCELAttributes...)
+		require.NoError(t, err)
+		convertCtx := filter.NewConvertContext()
+		converter := filter.NewCommonSQLConverter(&filter.PostgreSQLDialect{})
+		err = converter.ConvertExprToSQL(convertCtx, parsedExpr.GetExpr())
+		require.NoError(t, err)
+		require.Equal(t, tt.want, convertCtx.Buffer.String())
+		require.Equal(t, tt.args, convertCtx.Args)
+	}
+}

--- a/store/db/sqlite/attachment_filter_test.go
+++ b/store/db/sqlite/attachment_filter_test.go
@@ -1,0 +1,39 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/usememos/memos/plugin/filter"
+)
+
+func TestAttachmentConvertExprToSQL(t *testing.T) {
+	tests := []struct {
+		filter string
+		want   string
+		args   []any
+	}{
+		{
+			filter: `memo_id in ["5atZAj8GcvkSuUA3X2KLaY"]`,
+			want:   "`resource`.`memo_id` IN (?)",
+			args:   []any{"5atZAj8GcvkSuUA3X2KLaY"},
+		},
+		{
+			filter: `memo_id in ["5atZAj8GcvkSuUA3X2KLaY", "4EN8aEpcJ3MaK4ExHTpiTE"]`,
+			want:   "`resource`.`memo_id` IN (?,?)",
+			args:   []any{"5atZAj8GcvkSuUA3X2KLaY", "4EN8aEpcJ3MaK4ExHTpiTE"},
+		},
+	}
+
+	for _, tt := range tests {
+		parsedExpr, err := filter.Parse(tt.filter, filter.AttachmentFilterCELAttributes...)
+		require.NoError(t, err)
+		convertCtx := filter.NewConvertContext()
+		converter := filter.NewCommonSQLConverter(&filter.SQLiteDialect{})
+		err = converter.ConvertExprToSQL(convertCtx, parsedExpr.GetExpr())
+		require.NoError(t, err)
+		require.Equal(t, tt.want, convertCtx.Buffer.String())
+		require.Equal(t, tt.args, convertCtx.Args)
+	}
+}


### PR DESCRIPTION
This PR addresses attachments in regards to the n+1 problem listed in #4946 .

`convertAttachmentFromStore` has been converted to a pure function that only maps the database model to a response model.

The store.attachment model now has a composed field - memo_uid - that is used to avoid querying the db to retrieve the related memo, which was done for every memo in the list of memos. This change is inline with the parent_uid composed field in the store.memo model.

The ListAttachments method can now also filter by memo_id.

There is now a single call to retrieve the attachments in ListMemos instead of 2 calls per memo. `convertMemoFromStore`  is closer to being a pure mapping function and completely removing the n+1 problem. The last remaining entities are the memo relations which I will address in the next PR.

 