### PR TITLE
fix: update the link of Installation Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ docker run -d \
 
 Access Memos at `http://localhost:5230` and complete the initial setup.
 
-**Alternative methods**: For Docker Compose, Kubernetes, binary installation, or building from source, see our [Installation Guide](https://www.usememos.com/docs/install).
+**Alternative methods**: For Docker Compose, Kubernetes, binary installation, or building from source, see our [Installation Guide](https://www.usememos.com/docs/installation).
 
 **Pro Tip**: The data directory stores all your notes, uploads, and settings. Include it in your backup strategy!
 


### PR DESCRIPTION
the old link of installation guide was 404: 
[https://www.usememos.com/docs/install](https://www.usememos.com/docs/install)

the new one should be:
[https://www.usememos.com/docs/installation](https://www.usememos.com/docs/installation)