### PR TITLE
feat(web): add upload progress UI for attachments in MemoEditor\n\n- …

### DIFF
--- a/web/src/components/MemoEditor/ActionButton/UploadAttachmentButton.tsx
+++ b/web/src/components/MemoEditor/ActionButton/UploadAttachmentButton.tsx
@@ -1,13 +1,10 @@
 import { t } from "i18next";
 import { LoaderIcon, PaperclipIcon } from "lucide-react";
-import mime from "mime";
 import { observer } from "mobx-react-lite";
 import { useContext, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { attachmentStore } from "@/store";
-import { Attachment } from "@/types/proto/api/v1/attachment_service";
 import { MemoEditorContext } from "../types";
 
 interface Props {
@@ -39,32 +36,15 @@ const UploadAttachmentButton = observer((props: Props) => {
         uploadingFlag: true,
       };
     });
-
-    const createdAttachmentList: Attachment[] = [];
     try {
-      if (!fileInputRef.current || !fileInputRef.current.files) {
-        return;
-      }
-      for (const file of fileInputRef.current.files) {
-        const { name: filename, size, type } = file;
-        const buffer = new Uint8Array(await file.arrayBuffer());
-        const attachment = await attachmentStore.createAttachment({
-          attachment: Attachment.fromPartial({
-            filename,
-            size,
-            type: type || mime.getType(filename) || "text/plain",
-            content: buffer,
-          }),
-          attachmentId: "",
-        });
-        createdAttachmentList.push(attachment);
+      // Delegate to editor's upload handler so progress UI is consistent
+      if (context.uploadFiles) {
+        await context.uploadFiles(fileInputRef.current.files);
       }
     } catch (error: any) {
       console.error(error);
       toast.error(error.details);
     }
-
-    context.setAttachmentList([...context.attachmentList, ...createdAttachmentList]);
     setState((state) => {
       return {
         ...state,

--- a/web/src/components/MemoEditor/types/context.ts
+++ b/web/src/components/MemoEditor/types/context.ts
@@ -8,6 +8,8 @@ interface Context {
   setAttachmentList: (attachmentList: Attachment[]) => void;
   setRelationList: (relationList: MemoRelation[]) => void;
   memoName?: string;
+  // Optional: central upload handler so UI can show progress consistently
+  uploadFiles?: (files: FileList) => Promise<void>;
 }
 
 export const MemoEditorContext = createContext<Context>({


### PR DESCRIPTION
Centralize uploads via MemoEditor context to show progress consistently
Show per-file progress bars during file selection, drag and drop, and paste
Disable Save while uploads are in flight
Keep server logic unchanged
Fixes #5020