### PR TITLE
fix: update useEffect dependency to location.key so drawer is closed also when re-navigating to current route

### DIFF
--- a/web/src/components/NavigationDrawer.tsx
+++ b/web/src/components/NavigationDrawer.tsx
@@ -16,7 +16,7 @@ const NavigationDrawer = observer(() => {
 
   useEffect(() => {
     setOpen(false);
-  }, [location.pathname]);
+  }, [location.key]);
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
When a user taps a nav item that routes to the page they are already on, the mobile navigation drawer stays open because the code only listened to pathname changes. Manual navigate() calls still create new history entries (new location.key). Switching the effect dependency from location.pathname to location.key lets the drawer close on any navigation attempt, including redundant same-path navigations.

closes #5076 