### PR TITLE
fix: add a visual separator to the save button

### DIFF
--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -526,7 +526,7 @@ const MemoEditor = observer((props: Props) => {
               {!state.isRequesting ? (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-                    <span className="pointer-events-auto">
+                    <span className="pointer-events-auto border-l pl-1">
                       <VisibilityIcon visibility={state.memoVisibility} className="w-4 h-auto ml-1 text-primary-foreground opacity-80" />
                     </span>
                   </DropdownMenuTrigger>


### PR DESCRIPTION
Simple visual indicator to the save button to make it clear there are two buttons there.

Before:
<img width="242" height="122" alt="Screenshot 2025-09-08 at 18 48 31" src="https://github.com/user-attachments/assets/f588e56d-eabf-4ca7-8170-155c2fbd1af3" />

After:
<img width="242" height="122" alt="Screenshot 2025-09-08 at 18 49 01" src="https://github.com/user-attachments/assets/9363d5c9-ad3c-4801-be77-9c99af6d162d" />
