### PR TITLE
fix: avoid hiding reaction selector and keep it always shown for mobile

### DIFF
--- a/web/src/components/MemoView.tsx
+++ b/web/src/components/MemoView.tsx
@@ -136,7 +136,7 @@ const MemoView: React.FC<Props> = observer((props: Props) => {
   ) : (
     <div
       className={cn(
-        "group relative flex flex-col justify-start items-start bg-card w-full px-4 py-3 mb-2 gap-2 text-card-foreground rounded-lg border border-border transition-colors",
+        "relative flex flex-col justify-start items-start bg-card w-full px-4 py-3 mb-2 gap-2 text-card-foreground rounded-lg border border-border transition-colors",
         className,
       )}
     >
@@ -177,7 +177,7 @@ const MemoView: React.FC<Props> = observer((props: Props) => {
           )}
         </div>
         <div className="flex flex-row justify-end items-center select-none shrink-0 gap-2">
-          <div className="w-auto invisible group-hover:visible flex flex-row justify-between items-center gap-2">
+          <div className="w-auto flex flex-row justify-between items-center gap-2">
             {props.showVisibility && memo.visibility !== Visibility.PRIVATE && (
               <Tooltip>
                 <TooltipTrigger>
@@ -192,10 +192,7 @@ const MemoView: React.FC<Props> = observer((props: Props) => {
           </div>
           {!isInMemoDetailPage && commentAmount > 0 && (
             <Link
-              className={cn(
-                "flex flex-row justify-start items-center rounded-md p-1 hover:opacity-80",
-                commentAmount === 0 && "invisible group-hover:visible",
-              )}
+              className={cn("flex flex-row justify-start items-center rounded-md p-1 hover:opacity-80", commentAmount === 0 && "invisible")}
               to={`/${memo.name}#comments`}
               viewTransition
               state={{


### PR DESCRIPTION
closes #5045

### TLDR of the problem

Currently there is no proper way of adding a reaction to a note on mobile because the reaction selector is only shown on hover (`hover` and `focus` are applied altogether when you tap on mobile devices but it's much more of a hack than a real thought user experience).
This PR makes it always visible.

Considering the very small size of the button, I think it's perfectly safe to keep it as visible as it doesn't obscure or shadows any important content.

## Screenshot

<img width="491" height="479" alt="image" src="https://github.com/user-attachments/assets/08540e4b-2c41-4d8c-b5dc-e605ed4b11bc" />
