### PR TITLE
When editing memos, use input type `datetime-local` instead of `text`

### DIFF
--- a/web/src/components/DateTimeInput.tsx
+++ b/web/src/components/DateTimeInput.tsx
@@ -18,7 +18,7 @@ interface Props {
 const DateTimeInput: React.FC<Props> = ({ value, onChange }) => {
   return (
     <input
-      type="text"
+      type="datetime-local"
       className={cn("px-1 bg-transparent rounded text-xs transition-all", "border-transparent outline-none focus:border-border", "border")}
       defaultValue={formatDate(value)}
       onBlur={(e) => {


### PR DESCRIPTION
This allow to use the browsers' calendar instead of manually add the date.

Potentially this could help getting rid of the date format check

<img width="934" height="782" alt="image" src="https://github.com/user-attachments/assets/c143157d-0a86-4e63-b7c7-99b79f550721" />
