### PR TITLE
fix(web): markdown list auto-completion creates new line correctly

### DIFF
--- a/web/src/components/MemoEditor/Editor/index.tsx
+++ b/web/src/components/MemoEditor/Editor/index.tsx
@@ -164,7 +164,8 @@ const Editor = forwardRef(function Editor(props: Props, ref: React.ForwardedRef<
       // Detect list item using regex-based detection
       const listInfo = detectLastListItem(prevContent);
       if (listInfo.type) {
-        const insertText = generateListContinuation(listInfo);
+        event.preventDefault();
+        const insertText = "\n" + generateListContinuation(listInfo);
         editorActions.insertText(insertText);
       }
     }


### PR DESCRIPTION
Fix issue where pressing Enter on a markdown list item would append the list symbol to the current line instead of creating a new line.

The fix adds event.preventDefault() to stop the default Enter behavior and prepends a newline character to the inserted list continuation text.

Fixes #5236