### PR TITLE
feat(web): improve list auto-completion and tag insertion UX

### DIFF
--- a/web/src/components/MemoEditor/Editor/TagSuggestions.tsx
+++ b/web/src/components/MemoEditor/Editor/TagSuggestions.tsx
@@ -43,9 +43,9 @@ const TagSuggestions = observer(({ editorRef, editorActions }: TagSuggestionsPro
       return items.filter((tag) => tag.toLowerCase().includes(searchQuery));
     },
     onAutocomplete: (tag, word, index, actions) => {
-      // Replace the trigger word with the complete tag
+      // Replace the trigger word with the complete tag and add a trailing space
       actions.removeText(index, word.length);
-      actions.insertText(`#${tag}`);
+      actions.insertText(`#${tag} `);
     },
   });
 


### PR DESCRIPTION
Two user experience improvements based on feedback:

1. **GitHub-style empty list item handling:**
   - When pressing Enter on an empty list item (e.g., just "- "), remove the list marker instead of continuing the list
   - Matches GitHub's behavior for exiting list mode
   - Works for all list types: unordered (-, *, +), ordered (1., 2.), and task lists (- [ ])
   - Makes it easier to exit list mode without manual deletion

2. **Auto-space after tag selection:**
   - When selecting a tag from suggestions, automatically add a trailing space after the tag
   - Improves typing flow - users can immediately continue typing
   - Matches common expectation for autocomplete behavior

These changes make the editor feel more intuitive and reduce friction during content creation.