### PR TITLE
Fix max-w on tags in the sidebar

### DIFF
--- a/web/src/components/MemoExplorer/TagsSection.tsx
+++ b/web/src/components/MemoExplorer/TagsSection.tsx
@@ -78,7 +78,7 @@ const TagsSection = observer((props: Props) => {
                   onClick={() => handleTagClick(tag)}
                 >
                   <HashIcon className="w-4 h-auto shrink-0" />
-                  <div className="inline-flex flex-nowrap ml-0.5 gap-0.5 max-w-[calc(100%-16px)]">
+                  <div className="inline-flex flex-nowrap ml-0.5 gap-0.5 max-w-[calc(100%-1em)]">
                     <span className={cn("truncate", isActive ? "font-medium" : "")}>{tag}</span>
                     {amount > 1 && <span className="opacity-60 shrink-0">({amount})</span>}
                   </div>


### PR DESCRIPTION
In Firefox on Linux the tags on the sidebar are truncated even shorter tags. It might be my larger than usual min fonts or something because Chromium on the same machine doesn't have this problem. Anways, changing the 16px to 1em works fine with short and long tags.
<img width="224" height="112" alt="Screenshot 2025-11-17 at 13-04-15 Memos" src="https://github.com/user-attachments/assets/c068cc8a-1599-4bd6-aba1-97e2181692db" />
