### PR TITLE
feat(web): add ability to delete unused attachments

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -231,6 +231,8 @@
     "delete-selected-resources": "Delete Selected Resources",
     "delete-all-unused": "Delete all unused",
     "delete-all-unused-confirm": "Are you sure you want to delete all unused resources? THIS ACTION IS IRREVERSIBLE",
+    "delete-all-unused-success": "Resources deleted successfully",
+    "delete-all-unused-error": "Failed to delete unused resources",
     "fetching-data": "Fetching data…",
     "file-drag-drop-prompt": "Drag and drop your file here to upload file",
     "linked-amount": "Linked amount",


### PR DESCRIPTION
## Summary

This adds the ability to delete unused attachments on the attachments page. This addresses issue #5233.

## Testing steps

1. Upload attachments to a new memo, but do NOT save the memo
2. Navigate to the attachments page
3. See that you have unused attachments
4. Click the new "Delete all unused" button
5. Confirm deletion via the dialog
6. See the attachments refresh with unused attachments now gone

## Screenshots

### User flow

<img width="250" alt="SCR-20251121-rkzm" src="https://github.com/user-attachments/assets/3aaf324f-5551-4f1f-950d-1b37d1898059"  />
<img width="250" alt="SCR-20251121-rlbn" src="https://github.com/user-attachments/assets/2db78791-9f65-4d4e-ae53-a6faf534510b" />
<img width="250" alt="SCR-20251121-rlcz" src="https://github.com/user-attachments/assets/c15ee6b7-3648-4369-b2ab-488e5990f987" />

### At different screen sizes

<img width="250" alt="SCR-20251121-rlit" src="https://github.com/user-attachments/assets/b15a29a3-75ad-40b1-9606-c0a5f2a69f28" />
<img width="250" alt="SCR-20251121-rljv" src="https://github.com/user-attachments/assets/de4f68a1-12b9-4fe1-acc0-40059777e3b6" />
<img width="250" alt="SCR-20251121-rllf" src="https://github.com/user-attachments/assets/98ff8684-0cf9-4812-8859-09cebec22241" />
