### PR TITLE
feat: server-side search/filtering for attachments

### DIFF
--- a/server/router/api/v1/attachment_service.go
+++ b/server/router/api/v1/attachment_service.go
@@ -159,6 +159,11 @@ func (s *APIV1Service) ListAttachments(ctx context.Context, request *v1pb.ListAt
 		Offset:    &offset,
 	}
 
+	if request.Filter != "" {
+		filter := strings.TrimSpace(request.Filter)
+		findAttachment.FilenameSearch = &filter
+	}
+
 	attachments, err := s.Store.ListAttachments(ctx, findAttachment)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to list attachments: %v", err)


### PR DESCRIPTION
Resolves #5267 

Implements server-side filtering for search in the attachments tab. This allows users to search for attachments even if they have not been loaded yet. Previously, filtering was client-side and only searched files that were already loaded (50 by default).