### PR TITLE
fix(ui): change focus search bar shortcut overlapping with url shortcut

### DIFF
--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -13,7 +13,7 @@ const SearchBar = observer(() => {
 
   useEffect(() => {
     const handleGlobalShortcut = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+      if ((event.metaKey || event.ctrlKey) && event.key === "/") {
         event.preventDefault();
         inputRef.current?.focus();
       }


### PR DESCRIPTION
Fixes #5327 
Documentation update https://github.com/usememos/dotcom/pull/236

Reasoning for selected shortcut:
`ctrl + k` is conventional for text editors.
`/` or `ctrl + /` is used in some tools that support search (in github it's `/`)