### PR TITLE
chore: unify the Chinese localization of ellipsis

### DIFF
--- a/web/src/locales/zh-Hans.json
+++ b/web/src/locales/zh-Hans.json
@@ -214,7 +214,7 @@
         "type-placeholder": "文件类型"
       },
       "local-file": {
-        "choose": "选择文件…",
+        "choose": "选择文件...",
         "option": "本地文件"
       },
       "title": "创建资源",


### PR DESCRIPTION
Unify the localization of `...` in the Chinese translation. The current localization file contains two different styles of translation of `...`. I've decided to unify them to `...` since it's more commonly used in Chinese.