### PR TITLE
Fix public memos auth #5443

### DIFF
--- a/server/router/api/v1/v1.go
+++ b/server/router/api/v1/v1.go
@@ -59,7 +59,7 @@ func (s *APIV1Service) RegisterGateway(ctx context.Context, echoServer *echo.Ech
 			ctx := r.Context()
 
 			// Get the RPC method name from context (set by grpc-gateway after routing)
-			rpcMethod, _ := runtime.RPCMethod(ctx)
+			rpcMethod, ok := runtime.RPCMethod(ctx)
 
 			// Extract credentials from HTTP headers
 			authHeader := r.Header.Get("Authorization")
@@ -67,7 +67,8 @@ func (s *APIV1Service) RegisterGateway(ctx context.Context, echoServer *echo.Ech
 			result := authenticator.Authenticate(ctx, authHeader)
 
 			// Enforce authentication for non-public methods
-			if result == nil && !IsPublicMethod(rpcMethod) {
+			// If rpcMethod cannot be determined, allow through - service layer will handle visibility checks
+			if result == nil && ok && !IsPublicMethod(rpcMethod) {
 				http.Error(w, `{"code": 16, "message": "authentication required"}`, http.StatusUnauthorized)
 				return
 			}


### PR DESCRIPTION
## Problem
GET `/api/v1/memos` was blocked even though it's listed as a public endpoint in `PublicMethods`.

## Root Cause
The gRPC-Gateway middleware ignored the return value from `runtime.RPCMethod()`. When the method name couldn't be determined (returned empty string), it treated all requests as protected endpoints.

## Solution
Check if `rpcMethod` was successfully retrieved (`ok` value). If not, allow the request through - the service layer handles visibility checks for individual memos.

## Testing
-GET `/api/v1/memos` - Returns 200 with public memos (no auth required)
-POST `/api/v1/memos` - Returns 401 "user not authenticated" (auth still required)
<img width="976" height="128" alt="image" src="https://github.com/user-attachments/assets/2c707d0e-2982-40b9-b6ad-8f09d2f16d64" />

