### PR TITLE
chore(i18n): add missing Korean translations

### DIFF
--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -462,7 +462,7 @@
     "link-memo": "메모 링크",
     "markdown-menu": "Markdown",
     "select-location": "위치",
-    "select-visibility": "가시성 선택",
+    "select-visibility": "공개 범위",
     "tags": "태그",
     "upload-attachment": "첨부파일 업로드"
   }


### PR DESCRIPTION
Adds missing Korean translations for better localization coverage.