### PR TITLE
fix: inbox notifications fail to be fetched when using postgres driver

### DIFF
--- a/store/db/postgres/inbox.go
+++ b/store/db/postgres/inbox.go
@@ -51,9 +51,10 @@ func (d *DB) ListInboxes(ctx context.Context, find *store.FindInbox) ([]*store.I
 		where, args = append(where, "status = "+placeholder(len(args)+1)), append(args, *find.Status)
 	}
 	if find.MessageType != nil {
-		// Filter by message type using PostgreSQL JSON extraction
-		// Note: The type field in JSON is stored as string representation of the enum name
-		where, args = append(where, "message->>'type' = "+placeholder(len(args)+1)), append(args, find.MessageType.String())
+		// Filter by message type.
+		// IMPORTANT: In Postgres migrations, `inbox.message` is TEXT (not JSON/JSONB).
+		// We store JSON text, so cast to JSONB before applying JSON operators.
+		where, args = append(where, "(message::jsonb)->>'type' = "+placeholder(len(args)+1)), append(args, find.MessageType.String())
 	}
 
 	query := "SELECT id, created_ts, sender_id, receiver_id, status, message FROM inbox WHERE " + strings.Join(where, " AND ") + " ORDER BY created_ts DESC"


### PR DESCRIPTION
### Error

When visiting `/inbox`, server was responding with:

`ERROR server error method=/memos.api.v1.UserService/ListUserNotifications error="internal: rpc error: code = Internal desc = failed to list inboxes: pq: operator does not exist: text ->> unknown"`

### Fix

Updated the message type filter in `ListInboxes` to cast the `message` column from TEXT to JSONB before extracting the `type` field, ensuring compatibility with the current database schema where `inbox.message` is stored as TEXT.