### PR TITLE
fix: use stable memos image tag

### DIFF
--- a/scripts/compose.yaml
+++ b/scripts/compose.yaml
@@ -1,6 +1,6 @@
 services:
   memos:
-    image: neosmemo/memos:latest
+    image: neosmemo/memos:stable
     container_name: memos
     volumes:
       - ~/.memos/:/var/opt/memos


### PR DESCRIPTION
## Summary
The `latest` tag does not exist on Docker Hub. However, `scripts/compose.yaml` still used it.  This PR updates the Docker Compose configuration to use the `stable` tag for the `neosmemo/memos` image. The `latest` tag is not published on Docker Hub, so using `stable` avoids pull/startup failures.

## Changes
- Update `scripts/compose.yaml` to use `neosmemo/memos:stable` instead of `neosmemo/memos:latest`

## Rationale
The Docker Hub repository does not provide a `latest` tag, which makes the current Compose file invalid for users who expect to pull the default tag.

## Testing
- Not run (config-only change)

## Notes
- Consider pinning to a specific version tag in the future for reproducible deployments.
