### PR TITLE
fix: prevent photos from being cut off

### DIFF
--- a/web/src/components/MemoView/components/metadata/AttachmentCard.tsx
+++ b/web/src/components/MemoView/components/metadata/AttachmentCard.tsx
@@ -17,7 +17,7 @@ const AttachmentCard = ({ attachment, onClick, className }: AttachmentCardProps)
       <img
         src={sourceUrl}
         alt={attachment.filename}
-        className={cn("w-full h-full object-cover rounded-lg cursor-pointer", className)}
+        className={cn("w-full h-full object-contain rounded-lg cursor-pointer", className)}
         onClick={onClick}
         loading="lazy"
       />
@@ -25,7 +25,7 @@ const AttachmentCard = ({ attachment, onClick, className }: AttachmentCardProps)
   }
 
   if (attachmentType === "video/*") {
-    return <video src={sourceUrl} className={cn("w-full h-full object-cover rounded-lg", className)} controls preload="metadata" />;
+    return <video src={sourceUrl} className={cn("w-full h-full object-contain rounded-lg", className)} controls preload="metadata" />;
   }
 
   return null;


### PR DESCRIPTION
## Summary
Fixes #5497

Photos were being randomly cut off when displayed in memos.

## Root Cause
The CSS class \`object-cover\` was cropping images to fill the container, cutting off portions of tall or wide photos (particularly phone camera photos).

## Solution
Changed \`object-cover\` to \`object-contain\` in \`AttachmentCard.tsx\` for both images and videos. This ensures the full image is displayed within the container without any cropping.