### PR TITLE
fix: clear content search filter when selecting shortcut

### DIFF
--- a/web/src/contexts/MemoFilterContext.tsx
+++ b/web/src/contexts/MemoFilterContext.tsx
@@ -117,6 +117,10 @@ export function MemoFilterProvider({ children }: { children: ReactNode }) {
 
   const setShortcut = useCallback((newShortcut?: string) => {
     setShortcutState(newShortcut);
+    // Clear content search filter when selecting a shortcut (issue #5462)
+    if (newShortcut !== undefined) {
+      setFiltersState((prev) => prev.filter((f) => f.factor !== "contentSearch"));
+    }
   }, []);
 
   const hasFilter = useCallback((filter: MemoFilter) => filters.some((f) => getMemoFilterKey(f) === getMemoFilterKey(filter)), [filters]);


### PR DESCRIPTION
## Summary
Fixes #5462

## Problem
After performing a search, clicking on a Shortcut keeps the previous contentSearch filter active even though the search box becomes empty. This creates confusing behavior where old search results still influence the displayed memos.

## Solution
Modified \`setShortcut\` in \`MemoFilterContext.tsx\` to automatically clear any \`contentSearch\` filters when a shortcut is selected. This ensures only the shortcut filter takes effect.