### PR TITLE
fix: toggle focus mode do not reset editor height

### DIFF
--- a/web/src/components/MemoEditor/Editor/index.tsx
+++ b/web/src/components/MemoEditor/Editor/index.tsx
@@ -181,7 +181,7 @@ const Editor = forwardRef(function Editor(props: EditorProps, ref: React.Forward
     isInIME,
   });
 
-  // focus mode scroll height is handled by flex layout
+  // Recalculate editor height when focus mode changes
   useEffect(() => {
     updateEditorHeight();
   }, [isFocusMode, updateEditorHeight]);


### PR DESCRIPTION
At editor, enter focus mode, and write something, then exit focus mode, the editor height is too high, didn't reset.
<img width="300" alt="截屏2026-01-19 14 11 01" src="https://github.com/user-attachments/assets/5774c2b3-8b7f-4d79-ac56-ee8fad664efb" />
<img width="300" alt="截屏2026-01-19 14 11 17" src="https://github.com/user-attachments/assets/a5bb30c9-137b-4c11-87c1-837f9af9dbdc" />
<img width="300" alt="截屏2026-01-19 14 11 23" src="https://github.com/user-attachments/assets/3b556499-7967-4aa0-a074-be0ee12b09e2" />
