### PR TITLE
feat(web): internationalize editor toolbar buttons

### DIFF
--- a/web/src/components/MemoEditor/components/EditorToolbar.tsx
+++ b/web/src/components/MemoEditor/components/EditorToolbar.tsx
@@ -4,9 +4,11 @@ import { validationService } from "../services";
 import { useEditorContext } from "../state";
 import InsertMenu from "../Toolbar/InsertMenu";
 import VisibilitySelector from "../Toolbar/VisibilitySelector";
+import { useTranslate } from "@/utils/i18n";
 import type { EditorToolbarProps } from "../types";
 
 export const EditorToolbar: FC<EditorToolbarProps> = ({ onSave, onCancel, memoName }) => {
+  const t = useTranslate();
   const { state, actions, dispatch } = useEditorContext();
   const { valid } = validationService.canSave(state);
 
@@ -41,12 +43,12 @@ export const EditorToolbar: FC<EditorToolbarProps> = ({ onSave, onCancel, memoNa
 
         {onCancel && (
           <Button variant="ghost" onClick={onCancel} disabled={isSaving}>
-            Cancel
+            {t("common.cancel")}
           </Button>
         )}
 
         <Button onClick={onSave} disabled={!valid || isSaving}>
-          {isSaving ? "Saving..." : "Save"}
+          {isSaving ? t("editor.saving") : t("editor.save")}
         </Button>
       </div>
     </div>

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -121,6 +121,7 @@
     "add-your-comment-here": "Add your comment here...",
     "any-thoughts": "Any thoughts...",
     "save": "Save",
+    "saving": "Saving...",
     "no-changes-detected": "No changes detected",
     "focus-mode": "Focus Mode",
     "exit-focus-mode": "Exit Focus Mode",

--- a/web/src/locales/id.json
+++ b/web/src/locales/id.json
@@ -114,6 +114,7 @@
     "add-your-comment-here": "Tambahkan komentar Anda di sini...",
     "any-thoughts": "Punya pemikiran...",
     "save": "Simpan",
+    "saving": "Menyimpan...",
     "no-changes-detected": "Tidak ada perubahan yang terdeteksi"
   },
   "filters": {


### PR DESCRIPTION
Replaces the hardcoded labels on the memo editor's action buttons ("Save", "Saving...", "Cancel") with localization keys.