### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -19,7 +19,7 @@ jobs:
   go-static-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - uses: actions/setup-go@v6
         with:
@@ -33,7 +33,7 @@ jobs:
           git diff --exit-code
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.4.0
           args: --timeout=3m
@@ -49,7 +49,7 @@ jobs:
           - plugin
           - other
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/build-and-push-canary-image.yml
+++ b/.github/workflows/build-and-push-canary-image.yml
@@ -12,12 +12,12 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4.1.0
         with:
           version: 10
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: pnpm
@@ -27,7 +27,7 @@ jobs:
         shell: bash
         run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('web/pnpm-lock.yaml') }}
@@ -39,7 +39,7 @@ jobs:
         working-directory: web
 
       - name: Upload frontend artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: frontend-dist
           path: server/router/frontend/dist
@@ -58,10 +58,10 @@ jobs:
           - linux/amd64
           - linux/arm64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Download frontend artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: frontend-dist
           path: server/router/frontend/dist
@@ -103,7 +103,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digests-${{ strategy.job-index }}
           path: /tmp/digests/*
@@ -118,7 +118,7 @@ jobs:
       packages: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: digests-*
           merge-multiple: true

--- a/.github/workflows/build-and-push-stable-image.yml
+++ b/.github/workflows/build-and-push-stable-image.yml
@@ -25,12 +25,12 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4.1.0
         with:
           version: 10
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: pnpm
@@ -40,7 +40,7 @@ jobs:
         shell: bash
         run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('web/pnpm-lock.yaml') }}
@@ -52,7 +52,7 @@ jobs:
         working-directory: web
 
       - name: Upload frontend artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: frontend-dist
           path: server/router/frontend/dist
@@ -72,10 +72,10 @@ jobs:
           - linux/arm/v7
           - linux/arm64
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Download frontend artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: frontend-dist
           path: server/router/frontend/dist
@@ -117,7 +117,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: digests-${{ strategy.job-index }}
           path: /tmp/digests/*
@@ -132,7 +132,7 @@ jobs:
       packages: write
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: digests-*
           merge-multiple: true

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -13,11 +13,11 @@ jobs:
   static-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4.1.0
         with:
           version: 9
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: pnpm
@@ -31,11 +31,11 @@ jobs:
   frontend-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4.1.0
         with:
           version: 9
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: pnpm

--- a/.github/workflows/proto-linter.yml
+++ b/.github/workflows/proto-linter.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup buf


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/build-and-push-canary-image.yml`
- Updated `golangci/golangci-lint-action` from `v8` to `v9` in `.github/workflows/backend-tests.yml`
- Updated `actions/setup-node` from `v5` to `v6` in `.github/workflows/build-and-push-stable-image.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/build-and-push-canary-image.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/backend-tests.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/proto-linter.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/build-and-push-stable-image.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/build-and-push-stable-image.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/build-and-push-stable-image.yml`
- Updated `actions/cache` from `v4` to `v5` in `.github/workflows/build-and-push-stable-image.yml`
- Updated `actions/setup-node` from `v5` to `v6` in `.github/workflows/build-and-push-canary-image.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/build-and-push-canary-image.yml`
- Updated `actions/checkout` from `v5` to `v6` in `.github/workflows/frontend-tests.yml`
- Updated `actions/setup-node` from `v5` to `v6` in `.github/workflows/frontend-tests.yml`
- Updated `actions/cache` from `v4` to `v5` in `.github/workflows/build-and-push-canary-image.yml`
