### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-and-push-canary-image.yml
+++ b/.github/workflows/build-and-push-canary-image.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4.1.0
+      - uses: pnpm/action-setup@v4.2.0
         with:
           version: 10
       - uses: actions/setup-node@v6

--- a/.github/workflows/build-and-push-stable-image.yml
+++ b/.github/workflows/build-and-push-stable-image.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4.1.0
+      - uses: pnpm/action-setup@v4.2.0
         with:
           version: 10
       - uses: actions/setup-node@v6

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4.1.0
+      - uses: pnpm/action-setup@v4.2.0
         with:
           version: 9
       - uses: actions/setup-node@v6
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4.1.0
+      - uses: pnpm/action-setup@v4.2.0
         with:
           version: 9
       - uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `pnpm/action-setup` | [`v4.1.0`](https://github.com/pnpm/action-setup/releases/tag/v4.1.0) | [`v4.2.0`](https://github.com/pnpm/action-setup/releases/tag/v4.2.0) | [Release](https://github.com/pnpm/action-setup/releases/tag/v4) | build-and-push-canary-image.yml, build-and-push-stable-image.yml, frontend-tests.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
