### PR TITLE
fix(ui): correct calendar header month parsing

### DIFF
--- a/web/src/components/StatisticsView/MonthNavigator.tsx
+++ b/web/src/components/StatisticsView/MonthNavigator.tsx
@@ -1,3 +1,4 @@
+import dayjs from "dayjs";
 import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useState } from "react";
 import { YearCalendar } from "@/components/ActivityCalendar";
@@ -8,7 +9,7 @@ import type { MonthNavigatorProps } from "@/types/statistics";
 
 export const MonthNavigator = ({ visibleMonth, onMonthChange, activityStats }: MonthNavigatorProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const currentMonth = new Date(visibleMonth);
+  const currentMonth = dayjs(visibleMonth).toDate();
   const currentYear = getYearFromDate(visibleMonth);
   const currentMonthNum = getMonthFromDate(visibleMonth);
 


### PR DESCRIPTION
## Summary
  Fixes the calendar header month label by parsing the visible month string with dayjs instead of `new Date("YYYY-MM")`, which can show the previous month in some
  timezones.

  ## Why
  `new Date("YYYY-MM")` is parsed as UTC and can roll back a month for users in negative timezones. Using dayjs keeps the month consistent with the calendar grid.

  ## Testing
  - Manual: verified header month displays correctly for January 2026 in local timezone.