### PR TITLE
fix(ui): allow list view to use full width

### DIFF
--- a/web/src/components/MasonryView/MasonryColumn.tsx
+++ b/web/src/components/MasonryView/MasonryColumn.tsx
@@ -8,11 +8,12 @@ export function MasonryColumn({
   renderContext,
   onHeightChange,
   isFirstColumn,
+  listMode,
   prefixElement,
   prefixElementRef,
 }: MasonryColumnProps) {
   return (
-    <div className="min-w-0 mx-auto w-full max-w-2xl">
+    <div className={listMode ? "min-w-0 w-full" : "min-w-0 mx-auto w-full max-w-2xl"}>
       {/* Prefix element (like memo editor) goes in first column */}
       {isFirstColumn && prefixElement && <div ref={prefixElementRef}>{prefixElement}</div>}
 

--- a/web/src/components/MasonryView/MasonryView.tsx
+++ b/web/src/components/MasonryView/MasonryView.tsx
@@ -36,6 +36,7 @@ const MasonryView = ({ memoList, renderer, prefixElement, listMode = false }: Ma
           renderContext={renderContext}
           onHeightChange={handleHeightChange}
           isFirstColumn={columnIndex === 0}
+          listMode={listMode}
           prefixElement={prefixElement}
           prefixElementRef={prefixElementRef}
         />

--- a/web/src/components/MasonryView/types.ts
+++ b/web/src/components/MasonryView/types.ts
@@ -26,6 +26,7 @@ export interface MasonryColumnProps {
   renderContext: MemoRenderContext;
   onHeightChange: (memoName: string, height: number) => void;
   isFirstColumn: boolean;
+  listMode?: boolean;
   prefixElement?: JSX.Element;
   prefixElementRef?: React.RefObject<HTMLDivElement>;
 }


### PR DESCRIPTION
## Summary
  Removes the max-width constraint in list mode so the list layout expands to the full viewport width (matching masonry behavior).

  ## Why
  In list view, the container was capped at ~672px, which felt inconsistent with masonry and wasted horizontal space on wide screens.

  ## Testing
  - Manual: toggled List/Masonry and verified list view now fills the viewport.

<img width="2138" height="1208" alt="CleanShot 2026-01-25 at 23 28 52@2x" src="https://github.com/user-attachments/assets/ddb876a2-c552-48fe-a723-ebb7ae8acb44" />
