### PR TITLE
fix(ui): math_render_bug

### DIFF
--- a/web/src/components/MemoContent/index.tsx
+++ b/web/src/components/MemoContent/index.tsx
@@ -50,7 +50,7 @@ const MemoContent = (props: MemoContentProps) => {
       >
         <ReactMarkdown
           remarkPlugins={[remarkDisableSetext, remarkMath, remarkGfm, remarkBreaks, remarkTag, remarkPreserveType]}
-          rehypePlugins={[rehypeRaw, rehypeKatex, [rehypeSanitize, SANITIZE_SCHEMA]]}
+          rehypePlugins={[rehypeRaw, [rehypeSanitize, SANITIZE_SCHEMA], rehypeKatex]}
           components={{
             // Child components consume from MemoViewContext directly
             input: ((inputProps: React.ComponentProps<"input"> & { node?: Element }) => {


### PR DESCRIPTION
Fixes https://github.com/usememos/memos/issues/5544

Summary
Running rehype-sanitize before rehype-katex to preserve KaTeX HTML/SVG


Description of fix
1. Change plugin order so rehype-sanitize runs before rehype-katex.
2. If rehype-sanitize runs after rehype-katex, it remove the .katex-html nodes and leave only the MathML fallback ( i.e plain numbers), causing √ to render as just its inner value.

UT

<img width="3024" height="1596" alt="image" src="https://github.com/user-attachments/assets/4e81af58-9039-4e62-9bc0-a471f8d4f071" />


