### PR TITLE
chore: View memo URL updated

### DIFF
--- a/web/src/components/UserMemoMap/UserMemoMap.tsx
+++ b/web/src/components/UserMemoMap/UserMemoMap.tsx
@@ -101,7 +101,7 @@ const UserMemoMap = ({ creator, className }: Props) => {
                         })}
                     </span>
                     <Link
-                      to={`/m/${memo.name.split("/").pop()}`}
+                      to={`/memos/${memo.name.split("/").pop()}`}
                       className="flex items-center gap-0.5 text-[10px] text-primary hover:opacity-80"
                     >
                       View


### PR DESCRIPTION
Link updated to match the actual path. Otherwise, it shows 404 page when trying to view a memo from the map