### PR TITLE
fix: handle underscores in environment variable names

### DIFF
--- a/cmd/memos/main.go
+++ b/cmd/memos/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -131,6 +132,7 @@ func init() {
 	}
 
 	viper.SetEnvPrefix("memos")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 }
 


### PR DESCRIPTION
Add SetEnvKeyReplacer to map dashes in flag names to underscores in env vars, so MEMOS_INSTANCE_URL and MEMOS_UNIX_SOCK work correctly.

Fixes #5597