### PR TITLE
fix(web): calendar navigation should use current page path

### DIFF
--- a/web/src/hooks/useDateFilterNavigation.ts
+++ b/web/src/hooks/useDateFilterNavigation.ts
@@ -1,16 +1,18 @@
 import { useCallback } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { stringifyFilters } from "@/contexts/MemoFilterContext";
 
-export const useDateFilterNavigation = () => {
+export const useDateFilterNavigation = (targetPath?: string) => {
   const navigate = useNavigate();
+  const location = useLocation();
 
   const navigateToDateFilter = useCallback(
     (date: string) => {
       const filterQuery = stringifyFilters([{ factor: "displayTime", value: date }]);
-      navigate(`/?filter=${filterQuery}`);
+      const basePath = targetPath ?? location.pathname;
+      navigate(`${basePath}?filter=${filterQuery}`);
     },
-    [navigate],
+    [navigate, location.pathname, targetPath],
   );
 
   return navigateToDateFilter;


### PR DESCRIPTION
## Summary
Previously, clicking on a date in the calendar activity heatmap always navigated to `/?filter=...` regardless of the current page context. This caused issues on non-home pages like `/explore` where users expected to stay on the same page with the date filter applied.

## Changes
- Added optional `targetPath` parameter to `useDateFilterNavigation` hook
- Falls back to `location.pathname` when no `targetPath` is provided
- Maintains backward compatibility for existing usage

## Testing
- Tested on `/explore` page: clicking calendar dates now navigates to `/explore?filter=...`
- Tested on `/` (home): clicking calendar dates still works as expected (`/?filter=...`)

Fixes calendar navigation on /explore and other non-home pages.