### PR TITLE
fix(statistics): Re-render MonthNavigator when language changes

### DIFF
--- a/web/src/components/StatisticsView/MonthNavigator.tsx
+++ b/web/src/components/StatisticsView/MonthNavigator.tsx
@@ -4,11 +4,10 @@ import { memo, useCallback, useMemo, useState } from "react";
 import { YearCalendar } from "@/components/ActivityCalendar";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import i18n from "@/i18n";
 import { addMonths, formatMonth, getMonthFromDate, getYearFromDate, setYearAndMonth } from "@/lib/calendar-utils";
 import type { MonthNavigatorProps } from "@/types/statistics";
 
-export const MonthNavigator = memo(({ visibleMonth, onMonthChange, activityStats }: MonthNavigatorProps) => {
+export const MonthNavigator = memo(({ visibleMonth, onMonthChange, activityStats, language }: MonthNavigatorProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const { currentMonth, currentYear, currentMonthNum } = useMemo(
@@ -20,7 +19,7 @@ export const MonthNavigator = memo(({ visibleMonth, onMonthChange, activityStats
     [visibleMonth],
   );
 
-  const monthLabel = useMemo(() => currentMonth.toLocaleString(i18n.language, { year: "numeric", month: "long" }), [currentMonth]);
+  const monthLabel = useMemo(() => currentMonth.toLocaleString(language, { year: "numeric", month: "long" }), [currentMonth, language]);
 
   const handlePrevMonth = useCallback(() => onMonthChange(addMonths(visibleMonth, -1)), [visibleMonth, onMonthChange]);
   const handleNextMonth = useCallback(() => onMonthChange(addMonths(visibleMonth, 1)), [visibleMonth, onMonthChange]);

--- a/web/src/components/StatisticsView/StatisticsView.tsx
+++ b/web/src/components/StatisticsView/StatisticsView.tsx
@@ -2,6 +2,7 @@ import dayjs from "dayjs";
 import { useMemo, useState } from "react";
 import { MonthCalendar } from "@/components/ActivityCalendar";
 import { useDateFilterNavigation } from "@/hooks";
+import i18n from "@/i18n";
 import type { StatisticsData } from "@/types/statistics";
 import { MonthNavigator } from "./MonthNavigator";
 
@@ -22,7 +23,12 @@ const StatisticsView = (props: Props) => {
 
   return (
     <div className="group w-full mt-2 flex flex-col text-muted-foreground animate-fade-in">
-      <MonthNavigator visibleMonth={visibleMonthString} onMonthChange={setVisibleMonthString} activityStats={activityStats} />
+      <MonthNavigator
+        visibleMonth={visibleMonthString}
+        onMonthChange={setVisibleMonthString}
+        activityStats={activityStats}
+        language={i18n.language}
+      />
 
       <div className="w-full animate-scale-in">
         <MonthCalendar month={visibleMonthString} data={activityStats} maxCount={maxCount} onClick={navigateToDateFilter} />

--- a/web/src/types/statistics.ts
+++ b/web/src/types/statistics.ts
@@ -6,6 +6,7 @@ export interface MonthNavigatorProps {
   visibleMonth: string;
   onMonthChange: (month: string) => void;
   activityStats: Record<string, number>;
+  language: string;
 }
 
 export interface StatisticsData {


### PR DESCRIPTION
## Description
Fixes the issue where `MonthNavigator` fails to update its display text when the language is toggled. By passing `i18n.language` as a prop, we force a re-render to ensure `dayjs` re-formats the date with the active locale.

## Related Issue
Fixes #5578 

## Changes
- Pass `i18n.language` to `MonthNavigator` in `StatisticsView`.
- Update `MonthNavigatorProps` to accept `language` string.

## Testing
1. Open Statistics page.
2. Toggle language.
3. Confirm month title updates immediately.