### PR TITLE
fix(web): ensure default memo visibility is correctly applied

### DIFF
--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -96,6 +96,9 @@ const MemoEditorImpl: React.FC<MemoEditorProps> = ({
 
       // Reset editor state to initial values
       dispatch(actions.reset());
+      if (!memoName && defaultVisibility) {
+        dispatch(actions.setMetadata({ visibility: defaultVisibility }));
+      }
 
       // Notify parent component of successful save
       onConfirm?.(result.memoName);


### PR DESCRIPTION
**Title:** fix(web): ensure default memo visibility is correctly applied
-----

 Summary
-----
This PR fixes an issue where the user's default memo visibility setting (e.g., `PROTECTED`) was reset to `PRIVATE` after posting a memo.

Changes
-----
- **`web/src/components/MemoEditor/index.tsx`**: Updated the `handleSave` function to re-apply the `defaultVisibility` setting immediately after resetting the editor state.
-----
 Related Issue
Fixes #5622


![output](https://github.com/user-attachments/assets/8b7abadf-b9b8-4f33-a5b5-5599b166d73a)


🤖 Generated with [Trae](https://www.trae.ai/)
