### PR TITLE
fix: resolve locale for logged-out visitors from browser/localStorage

### DIFF
--- a/web/src/hooks/useUserLocale.ts
+++ b/web/src/hooks/useUserLocale.ts
@@ -1,31 +1,21 @@
-import { useEffect } from "react";
-import { useTranslation } from "react-i18next";
 import { useAuth } from "@/contexts/AuthContext";
 import { getLocaleWithFallback, loadLocale } from "@/utils/i18n";
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
 
-/**
- * Hook that reactively applies user locale preference.
- * Priority: User setting → localStorage → browser language
- */
 export const useUserLocale = () => {
   const { i18n } = useTranslation();
   const { userGeneralSetting } = useAuth();
 
-  // Apply locale when user setting changes or user logs in
   useEffect(() => {
-    if (!userGeneralSetting) {
-      return;
-    }
-    const locale = getLocaleWithFallback(userGeneralSetting.locale);
+    const locale = getLocaleWithFallback(userGeneralSetting?.locale);
     loadLocale(locale);
   }, [userGeneralSetting?.locale]);
 
-  // Update HTML lang and dir attributes based on current locale
   useEffect(() => {
     const currentLocale = i18n.language;
     document.documentElement.setAttribute("lang", currentLocale);
 
-    // RTL languages
     if (["ar", "fa"].includes(currentLocale)) {
       document.documentElement.setAttribute("dir", "rtl");
     } else {


### PR DESCRIPTION
### **Problem:**
Logged-out visitors always see English because `useUserLocale` returned early when `userGeneralSetting` was undefined, and `i18n.init()`had no lng set (the `detection` config referenced a plugin that was never loaded).

### **Fix:**
- `i18n.ts:` resolve initial locale at module load (query param → localStorage → `navigator.languages` → "en") so the first render is correct.
- `useUserLocale.ts`: remove early return → run `getLocaleWithFallback()` for all users.
- `utils/i18n.ts`: add `normalizeLocale()` helper, query param support, and `navigator.languages` iteration.

### **Locale priority (both logged-in and logged-out):**
1. `?locale=xx` query parameter
2. User setting (authenticated only)
3. `localStorage("memos-locale")`
4. `navigator.languages`
5. `"en"`