### PR TITLE
feature: Add this_day filter

### DIFF
--- a/plugin/filter/ir.go
+++ b/plugin/filter/ir.go
@@ -88,6 +88,11 @@ type ConstantCondition struct {
 
 func (*ConstantCondition) isCondition() {}
 
+// ThisDayCondition matches memos created on today's month-day in any year.
+type ThisDayCondition struct{}
+
+func (*ThisDayCondition) isCondition() {}
+
 // ValueExpr models arithmetic or scalar expressions whose result feeds a comparison.
 type ValueExpr interface {
 	isValueExpr()

--- a/plugin/filter/parser.go
+++ b/plugin/filter/parser.go
@@ -94,6 +94,8 @@ func buildCallCondition(call *exprv1.Expr_Call, schema Schema) (Condition, error
 		return buildInCondition(call, schema)
 	case "contains":
 		return buildContainsCondition(call, schema)
+	case "this_day":
+		return &ThisDayCondition{}, nil
 	default:
 		val, ok, err := evaluateBool(call)
 		if err != nil {

--- a/plugin/filter/schema.go
+++ b/plugin/filter/schema.go
@@ -97,6 +97,14 @@ var nowFunction = cel.Function("now",
 	),
 )
 
+var thisDayFunction = cel.Function("this_day",
+	cel.Overload("this_day", []*cel.Type{}, cel.BoolType,
+		cel.FunctionBinding(func(_ ...ref.Val) ref.Val {
+			return types.Bool(true)
+		}),
+	),
+)
+
 // NewSchema constructs the memo filter schema and CEL environment.
 func NewSchema() Schema {
 	fields := map[string]Field{
@@ -240,6 +248,7 @@ func NewSchema() Schema {
 		cel.Variable("has_code", cel.BoolType),
 		cel.Variable("has_incomplete_tasks", cel.BoolType),
 		nowFunction,
+		thisDayFunction,
 	}
 
 	return Schema{

--- a/store/test/filter_helpers_test.go
+++ b/store/test/filter_helpers_test.go
@@ -85,6 +85,11 @@ func (b *MemoBuilder) Property(fn func(*storepb.MemoPayload_Property)) *MemoBuil
 	return b
 }
 
+func (b *MemoBuilder) CreatedTs(ts int64) *MemoBuilder {
+	b.memo.CreatedTs = ts
+	return b
+}
+
 func (b *MemoBuilder) Build() *store.Memo {
 	return b.memo
 }


### PR DESCRIPTION
## Description

Adds a new `this_day()` CEL filter function that matches memos created on today's month-day in any year. Supports all three database dialects (SQLite, MySQL, PostgreSQL).

## Changes

- Add `ThisDayCondition` IR node in the filter pipeline.
- Register `this_day` as a zero-arg boolean CEL function in the memo schema.
- Parse `this_day()` calls into `ThisDayCondition` in the filter parser.
- Render dialect-specific SQL comparing `created_ts` month-day against current date for SQLite, MySQL, and PostgreSQL.
- Add `CreatedTs` builder method to test helpers for setting custom creation timestamps.
- Add tests covering basic matching, combined filters, no-match, and negation.

## Usage

```
this_day()                          # memos created on today's month-day in any year
this_day() && tag in ["work"]       # combine with other filters
!this_day()                         # exclude today's date matches
```

## Related Issue

Resolves https://github.com/usememos/memos/issues/5633

## Testing

### Manual
  1. Create a new shortcut with `this_day()` in the Filter field and save it.
  2. Create several memos, then edit their creation dates to fall on today's month-day but in different years (e.g., 2024, 2023).
  3. Create additional memos with creation dates that do not match today's month-day.
  4. Apply the shortcut. Only the memos from step 2 should appear.

### Automated
- `TestMemoFilterThisDay` - matches today + same day last year, excludes different day.
- `TestMemoFilterThisDayCombinedWithOtherFilters` - combines with tag filter.
- `TestMemoFilterThisDayNoMatches` - only different-day memos, expects 0 results.
- `TestMemoFilterThisDayNegated` - verifies `!this_day()` negation.