### PR TITLE
fix: avoid truncating memo batch attachments

### DIFF
--- a/store/attachment.go
+++ b/store/attachment.go
@@ -80,11 +80,12 @@ func (s *Store) CreateAttachment(ctx context.Context, create *Attachment) (*Atta
 
 func (s *Store) ListAttachments(ctx context.Context, find *FindAttachment) ([]*Attachment, error) {
 	// Set default limits to prevent loading too many attachments at once
-	if find.Limit == nil && find.GetBlob {
+	shouldApplyDefaultLimit := find.Limit == nil && len(find.MemoIDList) == 0
+	if shouldApplyDefaultLimit && find.GetBlob {
 		// When fetching blobs, we should be especially careful with limits
 		defaultLimit := 10
 		find.Limit = &defaultLimit
-	} else if find.Limit == nil {
+	} else if shouldApplyDefaultLimit {
 		// Even without blobs, let's default to a reasonable limit
 		defaultLimit := 100
 		find.Limit = &defaultLimit


### PR DESCRIPTION
## Summary

Fixes attachment truncation when `ListMemos` loads attachments for a large batch of memos.

`Store.ListAttachments()` was applying a default limit even when the caller queried by `MemoIDList`.
This could silently cap the returned attachments and cause missing attachments in clients that use a larger memo page size. (See https://github.com/mudkipme/MoeMemosAndroid/issues/332#issuecomment-3943298137).

## Root Cause

In `store/attachment.go`, `ListAttachments()` sets a default `Limit` when none is provided.

When `ListMemos` fetches attachments using `MemoIDList`, that default 100 limit could truncate results across the entire memo batch.

## Fix

Skip applying the default limit when `MemoIDList` is provided, so batched memo attachment lookups return all matching attachments unless the caller explicitly sets a limit.

## Impact

- Prevents missing attachments in `ListMemos` responses for large memo pages
- Keeps existing default-limit behavior for regular attachment list queries