### PR TITLE
fix: access token refresh on web app

### DIFF
--- a/web/src/connect.ts
+++ b/web/src/connect.ts
@@ -1,7 +1,7 @@
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { Code, ConnectError, createClient, type Interceptor } from "@connectrpc/connect";
 import { createConnectTransport } from "@connectrpc/connect-web";
-import { getAccessToken, isTokenExpired, REQUEST_TOKEN_EXPIRY_BUFFER_MS, setAccessToken } from "./auth-state";
+import { getAccessToken, hasStoredToken, isTokenExpired, REQUEST_TOKEN_EXPIRY_BUFFER_MS, setAccessToken } from "./auth-state";
 import { ActivityService } from "./types/proto/api/v1/activity_service_pb";
 import { AttachmentService } from "./types/proto/api/v1/attachment_service_pb";
 import { AuthService } from "./types/proto/api/v1/auth_service_pb";
@@ -124,7 +124,13 @@ async function refreshAndGetAccessToken(): Promise<string> {
 async function getRequestToken(): Promise<string | null> {
   let token = getAccessToken();
   if (!token) {
-    return null;
+    if (!hasStoredToken()) return null;
+    try {
+      token = await refreshAndGetAccessToken();
+    } catch {
+      return null;
+    }
+    return token;
   }
 
   // Preflight refresh: avoid sending requests with expired access tokens.

--- a/web/src/hooks/useTokenRefreshOnFocus.ts
+++ b/web/src/hooks/useTokenRefreshOnFocus.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { FOCUS_TOKEN_EXPIRY_BUFFER_MS, getAccessToken, isTokenExpired } from "@/auth-state";
+import { FOCUS_TOKEN_EXPIRY_BUFFER_MS, hasStoredToken, isTokenExpired } from "@/auth-state";
 
 /**
  * Hook that proactively refreshes the access token when the tab becomes visible
@@ -20,9 +20,8 @@ export function useTokenRefreshOnFocus(refreshFn: () => Promise<void>, enabled: 
         return;
       }
 
-      // Only refresh if we have a token
-      const token = getAccessToken();
-      if (!token) {
+      // Only refresh if the user has logged in before (token in localStorage)
+      if (!hasStoredToken()) {
         return;
       }
 


### PR DESCRIPTION
A bug exists within the token refresh flow that invalidates active browser sessions. Retrieving the active access token returns `null` if it's expired. Seem like a small oversight when token storage was migrated to the jwt tokens.

This means expired tokens don't refresh, and if leave the browser tab idle for 15min, the tab drops auth context and shows logged out view (you're still logged in though - reload fixes it). A few issues are open for this.

Resolves #5658, #5607, #5589, #5565
(last 3 are closed but underlying issue persisted)

May also fix some of the other issues where drafts keep getting lost (but I'm not sure, may be that the reauth is what makes the draft get lost)