### PR TITLE
feat: add --allow-private-webhooks flag to bypass SSRF protection

### DIFF
--- a/cmd/memos/main.go
+++ b/cmd/memos/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/usememos/memos/internal/profile"
 	"github.com/usememos/memos/internal/version"
+	"github.com/usememos/memos/plugin/webhook"
 	"github.com/usememos/memos/server"
 	"github.com/usememos/memos/store"
 	"github.com/usememos/memos/store/db"
@@ -36,6 +37,7 @@ var (
 				InstanceURL: viper.GetString("instance-url"),
 			}
 			instanceProfile.Version = version.GetCurrentVersion()
+			webhook.AllowPrivateIPs = viper.GetBool("allow-private-webhooks")
 
 			if err := instanceProfile.Validate(); err != nil {
 				slog.Error("failed to validate profile", "error", err)
@@ -105,6 +107,7 @@ func init() {
 	rootCmd.PersistentFlags().String("driver", "sqlite", "database driver")
 	rootCmd.PersistentFlags().String("dsn", "", "database source name(aka. DSN)")
 	rootCmd.PersistentFlags().String("instance-url", "", "the url of your memos instance")
+	rootCmd.PersistentFlags().Bool("allow-private-webhooks", false, "allow webhook URLs to resolve to private/reserved IP addresses")
 
 	if err := viper.BindPFlag("demo", rootCmd.PersistentFlags().Lookup("demo")); err != nil {
 		panic(err)
@@ -128,6 +131,9 @@ func init() {
 		panic(err)
 	}
 	if err := viper.BindPFlag("instance-url", rootCmd.PersistentFlags().Lookup("instance-url")); err != nil {
+		panic(err)
+	}
+	if err := viper.BindPFlag("allow-private-webhooks", rootCmd.PersistentFlags().Lookup("allow-private-webhooks")); err != nil {
 		panic(err)
 	}
 

--- a/plugin/webhook/validate.go
+++ b/plugin/webhook/validate.go
@@ -35,8 +35,16 @@ func init() {
 	}
 }
 
+// AllowPrivateIPs controls whether webhook URLs may resolve to reserved/private
+// IP addresses. When true, the SSRF protection is disabled. This is useful for
+// self-hosted deployments where webhooks target services on the local network.
+var AllowPrivateIPs bool
+
 // isReservedIP reports whether ip falls within any reserved/private range.
 func isReservedIP(ip net.IP) bool {
+	if AllowPrivateIPs {
+		return false
+	}
 	for _, network := range reservedNetworks {
 		if network.Contains(ip) {
 			return true


### PR DESCRIPTION
## Summary

- Adds `--allow-private-webhooks` CLI flag (env: `MEMOS_ALLOW_PRIVATE_WEBHOOKS`) that allows webhook URLs to resolve to private/reserved IP addresses
- When enabled, bypasses SSRF protection in both URL validation and dial-time enforcement
- Defaults to `false` — SSRF protection remains on unless explicitly opted out

Closes #5677

## Test plan

- [ ] Start memos without the flag → verify webhooks to private IPs are still blocked
- [ ] Start memos with `--allow-private-webhooks` or `MEMOS_ALLOW_PRIVATE_WEBHOOKS=true` → verify webhooks to private IPs are allowed
- [ ] Verify `go build ./cmd/memos/` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)