### PR TITLE
chore: improve GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,45 +1,65 @@
 name: Bug Report
-description: If something isn't working as expected
+description: Something isn't working as expected
 labels: [bug]
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to report a bug! Please complete the form below to help us understand and fix the issue.
+        Thanks for reporting a bug! Please fill out the form below so we can reproduce and fix the issue.
+
+        **Before submitting**, please search [existing issues](https://github.com/usememos/memos/issues) to avoid duplicates.
 
   - type: checkboxes
     id: pre-check
     attributes:
       label: Pre-submission Checklist
-      description: Please confirm you have completed the following steps before submitting
       options:
-        - label: I have searched the existing issues and this bug has not been reported yet
+        - label: I have searched existing issues and confirmed this bug has not been reported
           required: true
-        - label: I have tested this issue on the [demo site](https://demo.usememos.com) or the latest version
+        - label: I can reproduce this bug on the latest version or the [demo site](https://demo.usememos.com)
           required: true
-
-  - type: dropdown
-    id: issue-location
-    attributes:
-      label: Where did you encounter this bug?
-      description: Select where you tested and confirmed this issue
-      options:
-        - Latest stable version (self-hosted)
-        - Latest development version (self-hosted)
-        - Demo site (demo.usememos.com)
-        - Older version (please specify below)
-      default: 0
-    validations:
-      required: true
+        - label: This is a bug, not a question (use [Discussions](https://github.com/usememos/memos/discussions) for questions)
+          required: true
 
   - type: input
     id: version
     attributes:
       label: Memos Version
-      description: Provide the exact version (e.g., `v0.25.2`). Find this in Settings → About or via `--version` flag
-      placeholder: v0.25.2
+      description: Find this in **Settings > System > About** or via the `--version` flag
+      placeholder: "v0.25.2"
     validations:
       required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment Method
+      options:
+        - Docker
+        - Pre-built binary
+        - Built from source
+    validations:
+      required: true
+
+  - type: dropdown
+    id: database
+    attributes:
+      label: Database
+      options:
+        - SQLite
+        - PostgreSQL
+        - MySQL
+    validations:
+      required: true
+
+  - type: input
+    id: browser-os
+    attributes:
+      label: Browser & OS
+      description: e.g. Chrome 120 on macOS 15, Firefox 130 on Ubuntu 24.04
+      placeholder: "Chrome 120 on macOS 15"
+    validations:
+      required: false
 
   - type: textarea
     id: bug-description
@@ -54,12 +74,11 @@ body:
     id: reproduction-steps
     attributes:
       label: Steps to Reproduce
-      description: Detailed steps to reproduce the behavior
+      description: Minimal steps to reliably reproduce the issue
       placeholder: |
         1. Go to '...'
         2. Click on '...'
-        3. Scroll down to '...'
-        4. See error
+        3. See error
     validations:
       required: true
 
@@ -67,16 +86,14 @@ body:
     id: expected-behavior
     attributes:
       label: Expected Behavior
-      description: What did you expect to happen?
+      description: What did you expect to happen instead?
       placeholder: I expected...
+    validations:
+      required: true
 
   - type: textarea
     id: additional-context
     attributes:
-      label: Screenshots & Additional Context
-      description: Add screenshots, browser/OS info, deployment method (Docker/binary), or any other relevant details
-      placeholder: |
-        - Browser: Chrome 120
-        - OS: macOS 14
-        - Deployment: Docker
-        - Database: SQLite
+      label: Screenshots, Logs & Additional Context
+      description: Attach screenshots, browser console errors, or server logs if available
+      placeholder: Drag and drop images here, or paste error logs...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Questions & Support
+    url: https://github.com/usememos/memos/discussions
+    about: Ask questions or get help in GitHub Discussions — please don't open issues for questions
+  - name: Documentation
+    url: https://www.usememos.com/docs
+    about: Check the documentation before opening an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,36 +1,36 @@
 name: Feature Request
-description: If you have a suggestion for a new feature
+description: Suggest a new feature or improvement
 labels: [enhancement]
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you for suggesting a new feature! Please complete the form below to help us understand your idea.
+        Thanks for suggesting a feature! Please fill out the form below so we can understand your idea.
+
+        **Before submitting**, please search [existing issues](https://github.com/usememos/memos/issues?q=label%3Aenhancement) to avoid duplicates.
 
   - type: checkboxes
     id: pre-check
     attributes:
       label: Pre-submission Checklist
-      description: Please confirm you have completed the following steps before submitting
       options:
-        - label: I have searched the existing issues and this feature has not been requested yet
+        - label: I have searched existing issues and confirmed this feature has not been requested
+          required: true
+        - label: This is a feature request, not a bug report or question
           required: true
 
   - type: dropdown
     id: feature-type
     attributes:
-      label: Type of Feature
-      description: What type of feature is this?
+      label: Feature Area
       options:
         - User Interface (UI)
         - User Experience (UX)
         - API / Backend
-        - Documentation
         - Integrations / Plugins
         - Security / Privacy
         - Performance
         - Other
-      default: 0
     validations:
       required: true
 
@@ -38,10 +38,9 @@ body:
     id: problem-statement
     attributes:
       label: Problem or Use Case
-      description: What problem does this feature solve? What are you trying to accomplish?
+      description: What problem does this feature solve? Why do you need it?
       placeholder: |
         I often need to... but currently there's no way to...
-        This would help me/users to...
     validations:
       required: true
 
@@ -49,10 +48,9 @@ body:
     id: proposed-solution
     attributes:
       label: Proposed Solution
-      description: A clear and concise description of what you want to happen
+      description: Describe what you'd like to happen
       placeholder: |
         It would be great if Memos could...
-        For example, a button/feature that...
     validations:
       required: true
 
@@ -60,17 +58,21 @@ body:
     id: alternatives
     attributes:
       label: Alternatives Considered
-      description: Have you considered any alternative solutions or workarounds?
+      description: Have you considered any workarounds or alternative approaches?
       placeholder: |
         I've tried... but it doesn't work well because...
-        An alternative could be...
 
   - type: textarea
     id: additional-context
     attributes:
       label: Additional Context
-      description: Add any other context, mockups, screenshots, or examples about the feature request
-      placeholder: |
-        - Similar feature in other apps: ...
-        - Mockups or screenshots: ...
-        - Related discussions: ...
+      description: Mockups, screenshots, examples from other apps, or any other context
+      placeholder: Drag and drop images here...
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Would you be willing to help implement this feature?
+      options:
+        - label: I'm willing to submit a pull request for this feature


### PR DESCRIPTION
## Summary

- **Bug report**: Replace free-text environment info with structured dropdowns (deployment method, database type) and a dedicated browser/OS field. Add required "not a question" checkbox to reduce misclassified issues. Make "Expected Behavior" required.
- **Feature request**: Add optional "willing to contribute" checkbox. Add "not a bug/question" checkpoint. Remove "Documentation" from feature type (not a feature request). Streamline placeholder text.
- **Config**: Add contact links to GitHub Discussions (for questions/support) and documentation site, so users are guided away from opening issues for non-bug, non-feature topics.

## Test plan

- [ ] Visit the "New Issue" page and verify both templates render correctly
- [ ] Confirm contact links to Discussions and Docs appear as alternatives
- [ ] Confirm blank issues remain disabled
- [ ] Submit a test bug report and verify all required fields are enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)