### PR TITLE
fix: correct typos in comments, error messages, and identifiers

### DIFF
--- a/plugin/cron/parser.go
+++ b/plugin/cron/parser.go
@@ -12,7 +12,7 @@ import (
 // Configuration options for creating a parser. Most options specify which
 // fields should be included, while others enable features. If a field is not
 // included the parser will assume a default value. These options do not change
-// the order fields are parse in.
+// the order fields are parsed in.
 type ParseOption int
 
 const (

--- a/plugin/idp/oauth2/oauth2.go
+++ b/plugin/idp/oauth2/oauth2.go
@@ -82,7 +82,7 @@ func (p *IdentityProvider) UserInfo(token string) (*idp.IdentityProviderUserInfo
 	client := &http.Client{}
 	req, err := http.NewRequest(http.MethodGet, p.config.UserInfoUrl, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to new http request")
+		return nil, errors.Wrap(err, "failed to create http request")
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))

--- a/plugin/storage/s3/s3.go
+++ b/plugin/storage/s3/s3.go
@@ -74,7 +74,7 @@ func (c *Client) PresignGetObject(ctx context.Context, key string) (string, erro
 		opts.Expires = time.Duration(5 * 24 * time.Hour)
 	})
 	if err != nil {
-		return "", errors.Wrap(err, "failed to presign put object")
+		return "", errors.Wrap(err, "failed to presign get object")
 	}
 	return presignResult.URL, nil
 }

--- a/proto/api/v1/attachment_service.proto
+++ b/proto/api/v1/attachment_service.proto
@@ -25,12 +25,12 @@ service AttachmentService {
   rpc ListAttachments(ListAttachmentsRequest) returns (ListAttachmentsResponse) {
     option (google.api.http) = {get: "/api/v1/attachments"};
   }
-  // GetAttachment returns a attachment by name.
+  // GetAttachment returns an attachment by name.
   rpc GetAttachment(GetAttachmentRequest) returns (Attachment) {
     option (google.api.http) = {get: "/api/v1/{name=attachments/*}"};
     option (google.api.method_signature) = "name";
   }
-  // UpdateAttachment updates a attachment.
+  // UpdateAttachment updates an attachment.
   rpc UpdateAttachment(UpdateAttachmentRequest) returns (Attachment) {
     option (google.api.http) = {
       patch: "/api/v1/{attachment.name=attachments/*}"
@@ -38,7 +38,7 @@ service AttachmentService {
     };
     option (google.api.method_signature) = "attachment,update_mask";
   }
-  // DeleteAttachment deletes a attachment by name.
+  // DeleteAttachment deletes an attachment by name.
   rpc DeleteAttachment(DeleteAttachmentRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {delete: "/api/v1/{name=attachments/*}"};
     option (google.api.method_signature) = "name";

--- a/proto/gen/api/v1/apiv1connect/attachment_service.connect.go
+++ b/proto/gen/api/v1/apiv1connect/attachment_service.connect.go
@@ -57,11 +57,11 @@ type AttachmentServiceClient interface {
 	CreateAttachment(context.Context, *connect.Request[v1.CreateAttachmentRequest]) (*connect.Response[v1.Attachment], error)
 	// ListAttachments lists all attachments.
 	ListAttachments(context.Context, *connect.Request[v1.ListAttachmentsRequest]) (*connect.Response[v1.ListAttachmentsResponse], error)
-	// GetAttachment returns a attachment by name.
+	// GetAttachment returns an attachment by name.
 	GetAttachment(context.Context, *connect.Request[v1.GetAttachmentRequest]) (*connect.Response[v1.Attachment], error)
-	// UpdateAttachment updates a attachment.
+	// UpdateAttachment updates an attachment.
 	UpdateAttachment(context.Context, *connect.Request[v1.UpdateAttachmentRequest]) (*connect.Response[v1.Attachment], error)
-	// DeleteAttachment deletes a attachment by name.
+	// DeleteAttachment deletes an attachment by name.
 	DeleteAttachment(context.Context, *connect.Request[v1.DeleteAttachmentRequest]) (*connect.Response[emptypb.Empty], error)
 }
 
@@ -149,11 +149,11 @@ type AttachmentServiceHandler interface {
 	CreateAttachment(context.Context, *connect.Request[v1.CreateAttachmentRequest]) (*connect.Response[v1.Attachment], error)
 	// ListAttachments lists all attachments.
 	ListAttachments(context.Context, *connect.Request[v1.ListAttachmentsRequest]) (*connect.Response[v1.ListAttachmentsResponse], error)
-	// GetAttachment returns a attachment by name.
+	// GetAttachment returns an attachment by name.
 	GetAttachment(context.Context, *connect.Request[v1.GetAttachmentRequest]) (*connect.Response[v1.Attachment], error)
-	// UpdateAttachment updates a attachment.
+	// UpdateAttachment updates an attachment.
 	UpdateAttachment(context.Context, *connect.Request[v1.UpdateAttachmentRequest]) (*connect.Response[v1.Attachment], error)
-	// DeleteAttachment deletes a attachment by name.
+	// DeleteAttachment deletes an attachment by name.
 	DeleteAttachment(context.Context, *connect.Request[v1.DeleteAttachmentRequest]) (*connect.Response[emptypb.Empty], error)
 }
 

--- a/proto/gen/api/v1/attachment_service_grpc.pb.go
+++ b/proto/gen/api/v1/attachment_service_grpc.pb.go
@@ -35,11 +35,11 @@ type AttachmentServiceClient interface {
 	CreateAttachment(ctx context.Context, in *CreateAttachmentRequest, opts ...grpc.CallOption) (*Attachment, error)
 	// ListAttachments lists all attachments.
 	ListAttachments(ctx context.Context, in *ListAttachmentsRequest, opts ...grpc.CallOption) (*ListAttachmentsResponse, error)
-	// GetAttachment returns a attachment by name.
+	// GetAttachment returns an attachment by name.
 	GetAttachment(ctx context.Context, in *GetAttachmentRequest, opts ...grpc.CallOption) (*Attachment, error)
-	// UpdateAttachment updates a attachment.
+	// UpdateAttachment updates an attachment.
 	UpdateAttachment(ctx context.Context, in *UpdateAttachmentRequest, opts ...grpc.CallOption) (*Attachment, error)
-	// DeleteAttachment deletes a attachment by name.
+	// DeleteAttachment deletes an attachment by name.
 	DeleteAttachment(ctx context.Context, in *DeleteAttachmentRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
@@ -109,11 +109,11 @@ type AttachmentServiceServer interface {
 	CreateAttachment(context.Context, *CreateAttachmentRequest) (*Attachment, error)
 	// ListAttachments lists all attachments.
 	ListAttachments(context.Context, *ListAttachmentsRequest) (*ListAttachmentsResponse, error)
-	// GetAttachment returns a attachment by name.
+	// GetAttachment returns an attachment by name.
 	GetAttachment(context.Context, *GetAttachmentRequest) (*Attachment, error)
-	// UpdateAttachment updates a attachment.
+	// UpdateAttachment updates an attachment.
 	UpdateAttachment(context.Context, *UpdateAttachmentRequest) (*Attachment, error)
-	// DeleteAttachment deletes a attachment by name.
+	// DeleteAttachment deletes an attachment by name.
 	DeleteAttachment(context.Context, *DeleteAttachmentRequest) (*emptypb.Empty, error)
 	mustEmbedUnimplementedAttachmentServiceServer()
 }

--- a/proto/gen/openapi.yaml
+++ b/proto/gen/openapi.yaml
@@ -158,7 +158,7 @@ paths:
         get:
             tags:
                 - AttachmentService
-            description: GetAttachment returns a attachment by name.
+            description: GetAttachment returns an attachment by name.
             operationId: AttachmentService_GetAttachment
             parameters:
                 - name: attachment
@@ -183,7 +183,7 @@ paths:
         delete:
             tags:
                 - AttachmentService
-            description: DeleteAttachment deletes a attachment by name.
+            description: DeleteAttachment deletes an attachment by name.
             operationId: AttachmentService_DeleteAttachment
             parameters:
                 - name: attachment
@@ -205,7 +205,7 @@ paths:
         patch:
             tags:
                 - AttachmentService
-            description: UpdateAttachment updates a attachment.
+            description: UpdateAttachment updates an attachment.
             operationId: AttachmentService_UpdateAttachment
             parameters:
                 - name: attachment

--- a/server/router/api/v1/attachment_service.go
+++ b/server/router/api/v1/attachment_service.go
@@ -352,7 +352,7 @@ func convertAttachmentFromStore(attachment *store.Attachment) *v1pb.Attachment {
 	return attachmentMessage
 }
 
-// SaveAttachmentBlob save the blob of attachment based on the storage config.
+// SaveAttachmentBlob saves the blob of attachment based on the storage config.
 func SaveAttachmentBlob(ctx context.Context, profile *profile.Profile, stores *store.Store, create *store.Attachment) error {
 	instanceStorageSetting, err := stores.GetInstanceStorageSetting(ctx)
 	if err != nil {

--- a/store/db/mysql/mysql.go
+++ b/store/db/mysql/mysql.go
@@ -29,7 +29,7 @@ func NewDB(profile *profile.Profile) (store.Driver, error) {
 	driver := DB{profile: profile}
 	driver.config, err = mysql.ParseDSN(dsn)
 	if err != nil {
-		return nil, errors.New("Parse DSN eroor")
+		return nil, errors.New("Parse DSN error")
 	}
 
 	driver.db, err = sql.Open("mysql", dsn)

--- a/web/src/types/proto/api/v1/attachment_service_pb.ts
+++ b/web/src/types/proto/api/v1/attachment_service_pb.ts
@@ -288,7 +288,7 @@ export const AttachmentService: GenService<{
     output: typeof ListAttachmentsResponseSchema;
   },
   /**
-   * GetAttachment returns a attachment by name.
+   * GetAttachment returns an attachment by name.
    *
    * @generated from rpc memos.api.v1.AttachmentService.GetAttachment
    */
@@ -298,7 +298,7 @@ export const AttachmentService: GenService<{
     output: typeof AttachmentSchema;
   },
   /**
-   * UpdateAttachment updates a attachment.
+   * UpdateAttachment updates an attachment.
    *
    * @generated from rpc memos.api.v1.AttachmentService.UpdateAttachment
    */
@@ -308,7 +308,7 @@ export const AttachmentService: GenService<{
     output: typeof AttachmentSchema;
   },
   /**
-   * DeleteAttachment deletes a attachment by name.
+   * DeleteAttachment deletes an attachment by name.
    *
    * @generated from rpc memos.api.v1.AttachmentService.DeleteAttachment
    */

--- a/web/src/utils/i18n.ts
+++ b/web/src/utils/i18n.ts
@@ -66,7 +66,7 @@ export const useTranslate = (): TypedT => {
   return t;
 };
 
-export const isValidateLocale = (locale: string | undefined | null): boolean => {
+export const isValidLocale = (locale: string | undefined | null): boolean => {
   if (!locale) return false;
   return locales.includes(locale);
 };
@@ -77,7 +77,7 @@ export const isValidateLocale = (locale: string | undefined | null): boolean => 
 // 3. Browser language preference
 export const getLocaleWithFallback = (userLocale?: string): Locale => {
   // Priority 1: User setting (if logged in and valid)
-  if (userLocale && isValidateLocale(userLocale)) {
+  if (userLocale && isValidLocale(userLocale)) {
     return userLocale as Locale;
   }
 
@@ -93,7 +93,7 @@ export const getLocaleWithFallback = (userLocale?: string): Locale => {
 
 // Applies and persists a locale setting
 export const loadLocale = (locale: string): Locale => {
-  const validLocale = isValidateLocale(locale) ? (locale as Locale) : findNearestMatchedLanguage(navigator.language);
+  const validLocale = isValidLocale(locale) ? (locale as Locale) : findNearestMatchedLanguage(navigator.language);
   setStoredLocale(validLocale);
   i18n.changeLanguage(validLocale);
   return validLocale;


### PR DESCRIPTION
## Summary
- **store/db/mysql**: Fix "eroor" → "error" in DSN parse error message
- **plugin/storage/s3**: Fix "presign put object" → "presign get object" in `PresignGetObject` error message (copy-paste bug)
- **plugin/idp/oauth2**: Fix "failed to new http request" → "failed to create http request"
- **plugin/cron/parser**: Fix "are parse in" → "are parsed in" in comment
- **proto/attachment_service**: Fix "a attachment" → "an attachment" in 3 RPC comments + regenerated proto
- **server/attachment_service**: Fix "save the blob" → "saves the blob" in godoc
- **web/i18n**: Rename `isValidateLocale` → `isValidLocale` (grammatically incorrect predicate name)

## Test plan
- [ ] No logic changes — only comments, error strings, and a function rename
- [ ] Proto files regenerated via `buf generate`
- [ ] `isValidLocale` rename is consistent across all 3 call sites in `i18n.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)