### PR TITLE
fix: restrict archived memo access to creator only

### DIFF
--- a/server/router/api/v1/memo_service.go
+++ b/server/router/api/v1/memo_service.go
@@ -153,9 +153,19 @@ func (s *APIV1Service) ListMemos(ctx context.Context, request *v1pb.ListMemosReq
 		// Exclude comments by default.
 		ExcludeComments: true,
 	}
+	currentUser, err := s.fetchCurrentUser(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get user")
+	}
+
 	if request.State == v1pb.State_ARCHIVED {
 		state := store.Archived
 		memoFind.RowStatus = &state
+		// Archived memos are only visible to their creator.
+		if currentUser == nil {
+			return &v1pb.ListMemosResponse{}, nil
+		}
+		memoFind.CreatorID = &currentUser.ID
 	} else {
 		state := store.Normal
 		memoFind.RowStatus = &state
@@ -178,10 +188,6 @@ func (s *APIV1Service) ListMemos(ctx context.Context, request *v1pb.ListMemosReq
 		memoFind.Filters = append(memoFind.Filters, request.Filter)
 	}
 
-	currentUser, err := s.fetchCurrentUser(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get user")
-	}
 	if currentUser == nil {
 		memoFind.VisibilityList = []store.Visibility{store.Public}
 	} else {
@@ -311,6 +317,18 @@ func (s *APIV1Service) GetMemo(ctx context.Context, request *v1pb.GetMemoRequest
 	if memo == nil {
 		return nil, status.Errorf(codes.NotFound, "memo not found")
 	}
+
+	// Archived memos are only visible to their creator.
+	if memo.RowStatus == store.Archived {
+		user, err := s.fetchCurrentUser(ctx)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to get user")
+		}
+		if user == nil || memo.CreatorID != user.ID {
+			return nil, status.Errorf(codes.NotFound, "memo not found")
+		}
+	}
+
 	if memo.Visibility != store.Public {
 		user, err := s.fetchCurrentUser(ctx)
 		if err != nil {


### PR DESCRIPTION
## Summary
- **ListMemos**: When `State=ARCHIVED`, scope query to the authenticated user's own memos only. Unauthenticated requests return empty results instead of leaking archived public memos from all users.
- **GetMemo**: Return 404 for archived memos when the requester is not the creator, preventing direct access by UID.

Archived memos are intended to be visible only on the archive page and only to their creator. The frontend already enforces this, but the backend API did not — allowing archived public memos to be retrieved via direct API calls.

Closes #5706

## Test plan
- [ ] Verify archived memos still appear on `/archived` page for the creator
- [ ] Verify archived public memos no longer appear on `/explore` via API with `State=ARCHIVED`
- [ ] Verify unauthenticated `ListMemos(State=ARCHIVED)` returns empty response
- [ ] Verify `GetMemo` for an archived memo returns 404 for non-creators
- [ ] Verify `GetMemo` for an archived memo still works for the creator
- [ ] Run `go test ./server/...` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)