### PR TITLE
feat: add install script and binary section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,14 @@ Open `http://localhost:5230` and start writing!
 Download and run the pre-built binary for your platform:
 
 ```bash
+# Quick install
 curl -sSL https://raw.githubusercontent.com/usememos/memos/main/install.sh | bash
+
+# Or download manually for inspection first
+curl -sSL https://raw.githubusercontent.com/usememos/memos/main/install.sh -o install.sh
+less install.sh
+bash install.sh
+rm install.sh
 ```
 
 Or manually download from [GitHub Releases](https://github.com/usememos/memos/releases).

--- a/install.sh
+++ b/install.sh
@@ -6,19 +6,28 @@ REPO="usememos/memos"
 BINARY_NAME="memos"
 INSTALL_DIR="$HOME/.local/bin"
 
+if [[ "$(uname -s)" == *"MINGW"* || "$(uname -s)" == *"MSYS"* || "$(uname -s)" == "Windows_NT" ]]; then
+    INSTALL_DIR="$HOME/bin"
+    BINARY_NAME="memos.exe"
+fi
+
+cleanup() {
+    rm -f "$TMPFILE" "$TMPDIR"/*
+}
+trap cleanup EXIT
+
 echo "Checking for latest version..."
 
-LATEST_TAG=$(curl -sL "https://api.github.com/repos/$REPO/releases/latest" | grep -oP '"tag_name":\s*"\K[^"]+')
+RESPONSE=$(curl -sL "https://api.github.com/repos/$REPO/releases/latest")
+LATEST_TAG=$(echo "$RESPONSE" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
 
-echo "Latest version: $LATEST_TAG"
-
-if [ -f "$INSTALL_DIR/$BINARY_NAME" ]; then
-    CURRENT_VERSION=$("$INSTALL_DIR/$BINARY_NAME" --version 2>/dev/null | awk '{print $2}')
-    if [ "$CURRENT_VERSION" = "$LATEST_TAG" ]; then
-        echo "Already at the latest version ($LATEST_TAG)"
-        exit 0
-    fi
+if [ -z "$LATEST_TAG" ]; then
+    echo "Error: Could not fetch latest version. API rate limit may be exceeded."
+    exit 1
 fi
+
+VERSION="${LATEST_TAG#v}"
+echo "Latest version: $LATEST_TAG"
 
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
@@ -26,9 +35,9 @@ ARCH="$(uname -m)"
 case "$OS" in
     linux*)
         case "$ARCH" in
-            x86_64) ASSET_NAME="memos_${LATEST_TAG}_linux_amd64.tar.gz" ;;
-            aarch64) ASSET_NAME="memos_${LATEST_TAG}_linux_arm64.tar.gz" ;;
-            armv7) ASSET_NAME="memos_${LATEST_TAG}_linux_armv7.tar.gz" ;;
+            x86_64) ASSET_NAME="memos_${VERSION}_linux_amd64.tar.gz" ;;
+            aarch64) ASSET_NAME="memos_${VERSION}_linux_arm64.tar.gz" ;;
+            armv7) ASSET_NAME="memos_${VERSION}_linux_armv7.tar.gz" ;;
             *)
                 echo "Unsupported architecture: $ARCH"
                 exit 1
@@ -37,8 +46,8 @@ case "$OS" in
         ;;
     darwin*)
         case "$ARCH" in
-            x86_64) ASSET_NAME="memos_${LATEST_TAG}_darwin_amd64.tar.gz" ;;
-            arm64) ASSET_NAME="memos_${LATEST_TAG}_darwin_arm64.tar.gz" ;;
+            x86_64) ASSET_NAME="memos_${VERSION}_darwin_amd64.tar.gz" ;;
+            arm64) ASSET_NAME="memos_${VERSION}_darwin_arm64.tar.gz" ;;
             *)
                 echo "Unsupported architecture: $ARCH"
                 exit 1
@@ -57,14 +66,33 @@ echo "Downloading from: $DOWNLOAD_URL"
 
 mkdir -p "$INSTALL_DIR"
 
-echo "Downloading..."
-curl -fL "$DOWNLOAD_URL" -o "/tmp/memos_install.tar.gz"
-
-echo "Extracting..."
-tar -xzf "/tmp/memos_install.tar.gz" -C "$INSTALL_DIR" memos
-chmod +x "$INSTALL_DIR/$BINARY_NAME"
-rm -f "/tmp/memos_install.tar.gz"
+TMPDIR=$(mktemp -d)
+if [[ "$ASSET_NAME" == *.zip ]]; then
+    echo "Downloading..."
+    curl -fL "$DOWNLOAD_URL" -o "$TMPDIR/memos_install.zip"
+    echo "Extracting..."
+    unzip -q -o "$TMPDIR/memos_install.zip" -d "$TMPDIR"
+    EXTRACTED=$(find "$TMPDIR" -name "memos.exe" -type f)
+    if [ -z "$EXTRACTED" ]; then
+        echo "Error: Could not find memos.exe in archive"
+        exit 1
+    fi
+    cp "$EXTRACTED" "$INSTALL_DIR/$BINARY_NAME"
+    chmod +x "$INSTALL_DIR/$BINARY_NAME"
+else
+    echo "Downloading..."
+    curl -fL "$DOWNLOAD_URL" -o "$TMPDIR/memos_install.tar.gz"
+    echo "Extracting..."
+    tar -xzf "$TMPDIR/memos_install.tar.gz" -C "$TMPDIR"
+    EXTRACTED=$(find "$TMPDIR" -name "memos" -type f)
+    if [ -z "$EXTRACTED" ]; then
+        echo "Error: Could not find memos binary in archive"
+        exit 1
+    fi
+    cp "$EXTRACTED" "$INSTALL_DIR/$BINARY_NAME"
+    chmod +x "$INSTALL_DIR/$BINARY_NAME"
+fi
 
 echo "Installed to $INSTALL_DIR/$BINARY_NAME"
 echo ""
-echo "Run: $BINARY_NAME --version"
+echo "Run: $BINARY_NAME"


### PR DESCRIPTION
## Summary
- Add install.sh script for easy binary installation on Linux, macOS, and Windows
- Add Binary section to README.md below Docker section