### PR TITLE
feat(cli): add version subcommand

### DIFF
--- a/cmd/memos/main.go
+++ b/cmd/memos/main.go
@@ -92,6 +92,13 @@ var (
 			<-ctx.Done()
 		},
 	}
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print the current Memos version",
+		Run: func(_ *cobra.Command, _ []string) {
+			fmt.Println(version.GetCurrentVersion())
+		},
+	}
 )
 
 func init() {
@@ -140,6 +147,8 @@ func init() {
 	viper.SetEnvPrefix("memos")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
+
+	rootCmd.AddCommand(versionCmd)
 }
 
 func printGreetings(profile *profile.Profile) {


### PR DESCRIPTION
## Summary
- Add a dedicated `memos version` subcommand to print the current release version without starting the server
- Improve the CLI user journey for basic introspection and scripting

## Testing
- Not run (not requested)