### PR TITLE
Restore memo edit drafts after session expiry

### DIFF
--- a/web/src/components/MemoEditor/hooks/useAutoSave.ts
+++ b/web/src/components/MemoEditor/hooks/useAutoSave.ts
@@ -1,9 +1,37 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { cacheService } from "../services";
 
 export const useAutoSave = (content: string, username: string, cacheKey: string | undefined) => {
+  const latestContentRef = useRef(content);
+  const latestKeyRef = useRef(cacheService.key(username, cacheKey));
+
   useEffect(() => {
     const key = cacheService.key(username, cacheKey);
+    latestContentRef.current = content;
+    latestKeyRef.current = key;
     cacheService.save(key, content);
   }, [content, username, cacheKey]);
+
+  useEffect(() => {
+    const flushPendingSave = () => {
+      cacheService.save(latestKeyRef.current, latestContentRef.current);
+      cacheService.flush();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        flushPendingSave();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("pagehide", flushPendingSave);
+    window.addEventListener("beforeunload", flushPendingSave);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("pagehide", flushPendingSave);
+      window.removeEventListener("beforeunload", flushPendingSave);
+    };
+  }, []);
 };

--- a/web/src/components/MemoEditor/hooks/useMemoInit.ts
+++ b/web/src/components/MemoEditor/hooks/useMemoInit.ts
@@ -21,10 +21,18 @@ export const useMemoInit = ({ editorRef, memo, cacheKey, username, autoFocus, de
     if (initializedRef.current) return;
     initializedRef.current = true;
 
+    const cacheStorageKey = cacheService.key(username, cacheKey);
+    const cachedContent = cacheService.load(cacheStorageKey);
+
     if (memo) {
-      dispatch(actions.initMemo(memoService.fromMemo(memo)));
+      const initialMemo = memoService.fromMemo(memo);
+      dispatch(
+        actions.initMemo({
+          ...initialMemo,
+          content: cachedContent || initialMemo.content,
+        }),
+      );
     } else {
-      const cachedContent = cacheService.load(cacheService.key(username, cacheKey));
       if (cachedContent) {
         dispatch(actions.updateContent(cachedContent));
       }

--- a/web/src/components/MemoEditor/services/cacheService.ts
+++ b/web/src/components/MemoEditor/services/cacheService.ts
@@ -2,18 +2,28 @@ import { debounce } from "lodash-es";
 
 export const CACHE_DEBOUNCE_DELAY = 500;
 
+const persistCache = (key: string, content: string) => {
+  if (content.trim()) {
+    localStorage.setItem(key, content);
+  } else {
+    localStorage.removeItem(key);
+  }
+};
+
+const debouncedSave = debounce(persistCache, CACHE_DEBOUNCE_DELAY);
+
 export const cacheService = {
   key: (username: string, cacheKey?: string): string => {
     return `${username}-${cacheKey || ""}`;
   },
 
-  save: debounce((key: string, content: string) => {
-    if (content.trim()) {
-      localStorage.setItem(key, content);
-    } else {
-      localStorage.removeItem(key);
-    }
-  }, CACHE_DEBOUNCE_DELAY),
+  save(key: string, content: string): void {
+    debouncedSave(key, content);
+  },
+
+  flush(): void {
+    debouncedSave.flush();
+  },
 
   load(key: string): string {
     return localStorage.getItem(key) || "";

--- a/web/src/components/MemoView/MemoView.tsx
+++ b/web/src/components/MemoView/MemoView.tsx
@@ -31,6 +31,7 @@ const MemoView: React.FC<MemoViewProps> = (props: MemoViewProps) => {
 
   const { previewState, openPreview, setPreviewOpen } = useImagePreview();
   const { unpinMemo } = useMemoActions(memoData);
+  const editCacheKey = `inline-memo-editor-${memoData.name}-${memoData.updateTime}`;
 
   const closeEditor = () => setShowEditor(false);
   const openEditor = () => setShowEditor(true);
@@ -62,16 +63,7 @@ const MemoView: React.FC<MemoViewProps> = (props: MemoViewProps) => {
   );
 
   if (showEditor) {
-    return (
-      <MemoEditor
-        autoFocus
-        className="mb-2"
-        cacheKey={`inline-memo-editor-${memoData.name}`}
-        memo={memoData}
-        onConfirm={closeEditor}
-        onCancel={closeEditor}
-      />
-    );
+    return <MemoEditor autoFocus className="mb-2" cacheKey={editCacheKey} memo={memoData} onConfirm={closeEditor} onCancel={closeEditor} />;
   }
 
   const article = (


### PR DESCRIPTION
Resolves #5667

## Summary

When a tab sits inactive until the session expires, Memos can lose the unsaved text from inline edits on existing memos. The draft may still be present in local storage, but reopening the editor initializes from the persisted memo body and immediately overwrites that cached draft.

This change restores cached draft content when editing an existing memo, scopes edit draft cache keys to the memo version, and flushes pending autosave writes when the tab is hidden or unloaded.

## Changes

- restore cached content when reopening the inline editor for an existing memo
- version inline edit cache keys by memo update time so stale drafts do not leak across later edits
- expose a cache flush hook and force pending autosave writes to local storage on tab hide/page unload

## Validation

- `corepack pnpm lint`
- `corepack pnpm build`
