### PR TITLE
fix(memo-editor): scope Cmd+Enter save to the active editor

### DIFF
--- a/web/src/components/MemoEditor/hooks/useKeyboard.ts
+++ b/web/src/components/MemoEditor/hooks/useKeyboard.ts
@@ -5,16 +5,29 @@ interface UseKeyboardOptions {
   onSave: () => void;
 }
 
-export const useKeyboard = (_editorRef: React.RefObject<EditorRefActions | null>, options: UseKeyboardOptions) => {
+export const useKeyboard = (editorRef: React.RefObject<EditorRefActions | null>, options: UseKeyboardOptions) => {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
-        event.preventDefault();
-        options.onSave();
+      if (!(event.metaKey || event.ctrlKey) || event.key !== "Enter") {
+        return;
       }
+
+      const editor = editorRef.current?.getEditor();
+      if (!editor) {
+        return;
+      }
+
+      const activeElement = document.activeElement;
+      const target = event.target;
+      if (activeElement !== editor && target !== editor) {
+        return;
+      }
+
+      event.preventDefault();
+      options.onSave();
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [options]);
+  }, [editorRef, options]);
 };


### PR DESCRIPTION
## Summary
- Limit the Cmd/Ctrl+Enter save shortcut to the memo editor that currently has focus
- Prevent inactive mounted editors from handling the shortcut and triggering false validation errors during memo edits
- Keep the existing global key listener behavior while guarding it with the active editor ref

## Testing
- Not run (not requested)