### PR TITLE
fix: sync html lang attribute with active locale

### DIFF
--- a/web/src/utils/i18n.ts
+++ b/web/src/utils/i18n.ts
@@ -96,6 +96,7 @@ export const loadLocale = (locale: string): Locale => {
   const validLocale = isValidLocale(locale) ? (locale as Locale) : findNearestMatchedLanguage(navigator.language);
   setStoredLocale(validLocale);
   i18n.changeLanguage(validLocale);
+  document.documentElement.lang = validLocale;
   return validLocale;
 };
 


### PR DESCRIPTION
## What

Sync `document.documentElement.lang` with the active locale whenever `loadLocale()` is called.

## Why

The `<html lang="en">` in `index.html` is hardcoded, causing browsers to incorrectly prompt non-English users to translate the page.

All locale changes flow through `loadLocale()`, so this one-line fix covers:
- Initial page load (via `applyLocaleEarly()`)
- User changing language in settings
- Login (user's stored preference applied)

The hardcoded `lang="en"` in `index.html` remains as a safe pre-JS fallback.

Closes #5752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed language selection to properly persist to the page's language attribute, ensuring better accessibility and SEO compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->