### PR TITLE
fix(web): handle emoji variation selectors in tag parsing

### DIFF
--- a/web/src/utils/remark-plugins/remark-tag.ts
+++ b/web/src/utils/remark-plugins/remark-tag.ts
@@ -18,7 +18,11 @@ function isTagChar(char: string): boolean {
     return true;
   }
 
-  return char === "_" || char === "-" || char === "/" || char === "&";
+  if (/\p{M}/u.test(char)) {
+    return true;
+  }
+
+  return char === "_" || char === "-" || char === "/" || char === "&" || char === "\u200D";
 }
 
 function parseTagsFromText(text: string): Array<{ type: "text"; value: string } | { type: "tag"; value: string }> {


### PR DESCRIPTION
This PR closes https://github.com/usememos/memos/issues/5495 and fixes frontend tag parsing to keep emoji sequences that include [Variation Selector-16](https://emojipedia.org/variation-selector-16) (`\p{M}`) and [Zero Width Joiner](https://emojipedia.org/zero-width-joiner) (`\u200D`).

The test case is 

```
#🤔/🤔 #🤔/text #🀄️/text #🀄️/🀄️ #🀄️test/🀄️ #test🀄️test/🀄️
```

<img width="808" height="199" alt="image" src="https://github.com/user-attachments/assets/5baf0a31-c2d0-4c94-bc44-5a0563a8749a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced tag character support to recognize Unicode combining marks and special formatting characters, enabling more flexible and diverse tag naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->