### PR TITLE
refactor(store): remove synthetic system bot user lookup

### DIFF
--- a/store/test/user_test.go
+++ b/store/test/user_test.go
@@ -91,14 +91,6 @@ func TestUserGetByID(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, notFound)
 
-	// Get system bot
-	systemBotID := store.SystemBotID
-	systemBot, err := ts.GetUser(ctx, &store.FindUser{ID: &systemBotID})
-	require.NoError(t, err)
-	require.NotNil(t, systemBot)
-	require.Equal(t, store.SystemBotID, systemBot.ID)
-	require.Equal(t, "system_bot", systemBot.Username)
-
 	ts.Close()
 }
 

--- a/store/user.go
+++ b/store/user.go
@@ -23,20 +23,6 @@ func (e Role) String() string {
 	}
 }
 
-const (
-	SystemBotID int32 = 0
-)
-
-var (
-	SystemBot = &User{
-		ID:       SystemBotID,
-		Username: "system_bot",
-		Role:     RoleAdmin,
-		Email:    "",
-		Nickname: "Bot",
-	}
-)
-
 type User struct {
 	ID int32
 
@@ -125,9 +111,6 @@ func (s *Store) ListUsers(ctx context.Context, find *FindUser) ([]*User, error) 
 
 func (s *Store) GetUser(ctx context.Context, find *FindUser) (*User, error) {
 	if find.ID != nil {
-		if *find.ID == SystemBotID {
-			return SystemBot, nil
-		}
 		if cache, ok := s.userCache.Get(ctx, string(*find.ID)); ok {
 			user, ok := cache.(*User)
 			if ok {


### PR DESCRIPTION
## Summary
- Remove the reserved in-memory system bot user and its special-case ID handling in store user lookups
- Keep `GetUser` behavior limited to cached or persisted users
- Drop the obsolete store test coverage for resolving the synthetic system bot

## Testing
- Not run (not requested)