### PR TITLE
fix limit html meta response body size

### DIFF
--- a/plugin/httpgetter/html_meta.go
+++ b/plugin/httpgetter/html_meta.go
@@ -51,9 +51,8 @@ func GetHTMLMeta(urlStr string) (*HTMLMeta, error) {
 		return nil, errors.New("not a HTML page")
 	}
 
-	// TODO: limit the size of the response body
-
-	htmlMeta := extractHTMLMeta(response.Body)
+	reader := io.LimitReader(response.Body, 1<<20) // 1 MB max
+	htmlMeta := extractHTMLMeta(reader)
 	enrichSiteMeta(response.Request.URL, htmlMeta)
 	return htmlMeta, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTTP response handling by implementing a 1 MB size limit on response parsing, improving stability and performance when processing large web content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->