### PR TITLE
fix(auth): retry user initialization before clearing session

### DIFF
--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -5,6 +5,7 @@ import { authServiceClient, refreshAccessToken, shortcutServiceClient, userServi
 import { userKeys } from "@/hooks/useUserQueries";
 import type { Shortcut } from "@/types/proto/api/v1/shortcut_service_pb";
 import type { User, UserSetting_GeneralSetting, UserSetting_WebhooksSetting } from "@/types/proto/api/v1/user_service_pb";
+import { retryAuthInitialization } from "./auth-initialize";
 
 interface AuthState {
   currentUser: User | undefined;
@@ -80,9 +81,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     try {
-      const { user: currentUser } = await authServiceClient.getCurrentUser({});
+      const { currentUser, settings } = await retryAuthInitialization({
+        operation: async () => {
+          const { user: currentUser } = await authServiceClient.getCurrentUser({});
 
-      if (!currentUser) {
+          if (!currentUser) {
+            return {
+              currentUser: undefined,
+              settings: undefined,
+            };
+          }
+
+          const settings = await fetchUserSettings(currentUser.name);
+
+          return {
+            currentUser,
+            settings,
+          };
+        },
+      });
+
+      if (!currentUser || !settings) {
         clearAccessToken();
         setState({
           currentUser: undefined,
@@ -94,8 +113,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         });
         return;
       }
-
-      const settings = await fetchUserSettings(currentUser.name);
 
       setState({
         currentUser,

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -2,10 +2,10 @@ import { useQueryClient } from "@tanstack/react-query";
 import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
 import { clearAccessToken, getAccessToken } from "@/auth-state";
 import { authServiceClient, refreshAccessToken, shortcutServiceClient, userServiceClient } from "@/connect";
+import { retryAuthInitialization } from "@/contexts/auth-initialize";
 import { userKeys } from "@/hooks/useUserQueries";
 import type { Shortcut } from "@/types/proto/api/v1/shortcut_service_pb";
 import type { User, UserSetting_GeneralSetting, UserSetting_WebhooksSetting } from "@/types/proto/api/v1/user_service_pb";
-import { retryAuthInitialization } from "./auth-initialize";
 
 interface AuthState {
   currentUser: User | undefined;

--- a/web/src/contexts/auth-initialize.ts
+++ b/web/src/contexts/auth-initialize.ts
@@ -1,5 +1,11 @@
+import { Code, ConnectError } from "@connectrpc/connect";
+
 const AUTH_INIT_MAX_RETRIES = 3;
 const AUTH_INIT_INITIAL_DELAY_MS = 500;
+
+function shouldRetryAuthInitialization(error: unknown): boolean {
+  return !(error instanceof ConnectError && error.code === Code.Unauthenticated);
+}
 
 const defaultSleep = async (delayMs: number): Promise<void> => {
   await new Promise((resolve) => {
@@ -19,6 +25,9 @@ export async function retryAuthInitialization<T>({ operation, sleep = defaultSle
     try {
       return await operation();
     } catch (error) {
+      if (!shouldRetryAuthInitialization(error)) {
+        throw error;
+      }
       if (attempt >= AUTH_INIT_MAX_RETRIES) {
         throw error;
       }

--- a/web/src/contexts/auth-initialize.ts
+++ b/web/src/contexts/auth-initialize.ts
@@ -1,0 +1,29 @@
+const AUTH_INIT_MAX_RETRIES = 3;
+const AUTH_INIT_INITIAL_DELAY_MS = 500;
+
+const defaultSleep = async (delayMs: number): Promise<void> => {
+  await new Promise((resolve) => {
+    window.setTimeout(resolve, delayMs);
+  });
+};
+
+interface RetryAuthInitializationOptions<T> {
+  operation: () => Promise<T>;
+  sleep?: (delayMs: number) => Promise<void>;
+}
+
+export async function retryAuthInitialization<T>({ operation, sleep = defaultSleep }: RetryAuthInitializationOptions<T>): Promise<T> {
+  let delayMs = AUTH_INIT_INITIAL_DELAY_MS;
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (attempt >= AUTH_INIT_MAX_RETRIES) {
+        throw error;
+      }
+      await sleep(delayMs);
+      delayMs *= 2;
+    }
+  }
+}

--- a/web/test/auth-initialize.test.mjs
+++ b/web/test/auth-initialize.test.mjs
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { Code, ConnectError } from "@connectrpc/connect";
 
 import { retryAuthInitialization } from "../src/contexts/auth-initialize.ts";
 
@@ -46,3 +47,29 @@ test("throws the final error after exhausting auth initialization retries", asyn
   assert.equal(attempts, 4);
   assert.deepEqual(delays, [500, 1000, 2000]);
 });
+
+test("does not retry terminal unauthenticated auth initialization failures", async () => {
+  const delays = [];
+  let attempts = 0;
+
+  await assert.rejects(
+    () =>
+      retryAuthInitialization({
+        operation: async () => {
+          attempts += 1;
+          throw new ConnectError("session expired", Code.Unauthenticated);
+        },
+        sleep: async (delayMs) => {
+          delays.push(delayMs);
+        },
+      }),
+    (error) => {
+      assert.ok(error instanceof ConnectError);
+      assert.equal(error.code, Code.Unauthenticated);
+      return true;
+    },
+  );
+
+  assert.equal(attempts, 1);
+  assert.deepEqual(delays, []);
+ });

--- a/web/test/auth-initialize.test.mjs
+++ b/web/test/auth-initialize.test.mjs
@@ -1,0 +1,48 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { retryAuthInitialization } from "../src/contexts/auth-initialize.ts";
+
+test("retries auth initialization with exponential backoff before succeeding", async () => {
+  const delays = [];
+  let attempts = 0;
+
+  const result = await retryAuthInitialization({
+    operation: async () => {
+      attempts += 1;
+      if (attempts < 4) {
+        throw new Error(`transient failure ${attempts}`);
+      }
+      return "ok";
+    },
+    sleep: async (delayMs) => {
+      delays.push(delayMs);
+    },
+  });
+
+  assert.equal(result, "ok");
+  assert.equal(attempts, 4);
+  assert.deepEqual(delays, [500, 1000, 2000]);
+});
+
+test("throws the final error after exhausting auth initialization retries", async () => {
+  const delays = [];
+  let attempts = 0;
+
+  await assert.rejects(
+    () =>
+      retryAuthInitialization({
+        operation: async () => {
+          attempts += 1;
+          throw new Error(`transient failure ${attempts}`);
+        },
+        sleep: async (delayMs) => {
+          delays.push(delayMs);
+        },
+      }),
+    /transient failure 4/,
+  );
+
+  assert.equal(attempts, 4);
+  assert.deepEqual(delays, [500, 1000, 2000]);
+});


### PR DESCRIPTION
## Summary
- retry auth initialization requests with exponential backoff before treating the session as lost
- keep post-login transient failures from immediately clearing frontend user state
- add a regression test covering retry success and retry exhaustion paths

## Test Plan
- [x] node --test web/test/auth-initialize.test.mjs
- [x] pnpm lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retry with exponential backoff for initial authentication to improve recovery from transient connection errors.

* **Bug Fixes**
  * More robust initialization: sessions are now cleared and initialized cleanly when user or settings are missing to prevent stale/partial sign-in states.

* **Tests**
  * Added tests covering retry behavior, retry exhaustion, and non-retry terminal failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->