### PR TITLE
fix: support name attribute when extracting HTML meta tags

### DIFF
--- a/plugin/httpgetter/html_meta.go
+++ b/plugin/httpgetter/html_meta.go
@@ -106,7 +106,7 @@ func extractHTMLMeta(resp io.Reader) *HTMLMeta {
 func extractMetaProperty(token html.Token, prop string) (content string, ok bool) {
 	content, ok = "", false
 	for _, attr := range token.Attr {
-		if attr.Key == "property" && attr.Val == prop {
+		if (attr.Key == "property" || attr.Key == "name") && attr.Val == prop {
 			ok = true
 		}
 		if attr.Key == "content" {


### PR DESCRIPTION
Fixes #5821

## Problem

The `extractMetaProperty` function in `plugin/httpgetter/html_meta.go` only matched meta tags with the `property` attribute (used by Open Graph), but standard HTML meta descriptions use the `name` attribute:

```html
<!-- Standard HTML (was broken) -->
<meta name="description" content="Page description">

<!-- Open Graph (worked fine) -->
<meta property="og:description" content="Page description">
```

As a result, link previews would silently drop the description for any page that doesn't use Open Graph markup.

## Fix

Add `attr.Key == "name"` as an alternative to `attr.Key == "property"` in the attribute check:

```go
if (attr.Key == "property" || attr.Key == "name") && attr.Val == prop {
```

This is a one-line change that makes the extractor match both standard HTML and Open Graph meta tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced metadata extraction from web pages to recognize additional tag formats, improving detection of page descriptions, titles, and images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->