### PR TITLE
chore: update Italian translation for 'cancel' key

### DIFF
--- a/web/src/locales/it.json
+++ b/web/src/locales/it.json
@@ -28,7 +28,7 @@
     "basic": "Base",
     "beta": "Beta",
     "calendar": "Calendario",
-    "cancel": "Cancella",
+    "cancel": "Annulla",
     "change": "Cambia",
     "clear": "Pulisci",
     "close": "Chiudi",


### PR DESCRIPTION
Fix wrong Italian translation for Cancel.

Sorry for the mini PR but it's very annoying as Cancel button is seen frequently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated Italian translation for the cancel button label in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->