### PR TITLE
feat(web): show comment button on homepage when no cofeat(web): show comment button on homepage when no comments existmments exist

### DIFF
--- a/web/src/components/MemoView/MemoView.tsx
+++ b/web/src/components/MemoView/MemoView.tsx
@@ -11,9 +11,9 @@ import MemoShareImageDialog from "../MemoActionMenu/MemoShareImageDialog";
 import MemoEditor from "../MemoEditor";
 import PreviewImageDialog from "../PreviewImageDialog";
 import { MemoBody, MemoCommentListView, MemoHeader } from "./components";
+import { MemoViewContext } from "./MemoViewContext";
 import { MEMO_CARD_BASE_CLASSES } from "./constants";
 import { useImagePreview } from "./hooks";
-import { computeCommentAmount, MemoViewContext } from "./MemoViewContext";
 import type { MemoViewProps } from "./types";
 
 const MemoView: React.FC<MemoViewProps> = (props: MemoViewProps) => {
@@ -41,7 +41,7 @@ const MemoView: React.FC<MemoViewProps> = (props: MemoViewProps) => {
 
   const location = useLocation();
   const isInMemoDetailPage = location.pathname.startsWith(`/${memoData.name}`) || location.pathname.startsWith("/memos/shares/");
-  const showCommentPreview = !isInMemoDetailPage && computeCommentAmount(memoData) > 0;
+  const showCommentPreview = !isInMemoDetailPage && currentUser;
 
   useEffect(() => {
     const card = cardRef.current;

--- a/web/src/components/MemoView/components/MemoCommentListView.tsx
+++ b/web/src/components/MemoView/components/MemoCommentListView.tsx
@@ -49,7 +49,7 @@ const MemoCommentListView: React.FC = () => {
             to={`/${memo.name}#comments`}
             className="flex items-center gap-0.5 text-xs text-muted-foreground/80 hover:underline underline-offset-2 transition-colors"
           >
-            View all
+            {t("memo.comment.view-all")}
             <ArrowUpRightIcon className="w-3 h-3" />
           </Link>
         )}

--- a/web/src/components/MemoView/components/MemoCommentListView.tsx
+++ b/web/src/components/MemoView/components/MemoCommentListView.tsx
@@ -1,36 +1,60 @@
-import { ArrowUpRightIcon } from "lucide-react";
+import { ArrowUpRightIcon, MessageCircleIcon } from "lucide-react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
+import MemoEditor from "@/components/MemoEditor";
 import { MemoPreview } from "@/components/MemoPreview";
+import { Button } from "@/components/ui/button";
 import { extractMemoIdFromName } from "@/helpers/resource-names";
+import useCurrentUser from "@/hooks/useCurrentUser";
 import { useMemoComments } from "@/hooks/useMemoQueries";
 import { useUsersByNames } from "@/hooks/useUserQueries";
+import { useTranslate } from "@/utils/i18n";
 import { useMemoViewContext, useMemoViewDerived } from "../MemoViewContext";
 
 const MemoCommentListView: React.FC = () => {
+  const t = useTranslate();
   const { memo } = useMemoViewContext();
   const { isInMemoDetailPage, commentAmount } = useMemoViewDerived();
+  const currentUser = useCurrentUser();
+  const [showEditor, setShowEditor] = useState(false);
 
   const { data } = useMemoComments(memo.name, { enabled: !isInMemoDetailPage && commentAmount > 0 });
   const comments = data?.memos ?? [];
   const displayedComments = comments.slice(0, 3);
   const { data: commentCreators } = useUsersByNames(displayedComments.map((comment) => comment.creator));
 
-  if (isInMemoDetailPage || commentAmount === 0) {
+  if (isInMemoDetailPage) {
     return null;
   }
+
+  const hasComments = commentAmount > 0;
+  const showCreateButton = currentUser && !showEditor;
+
+  const handleCommentCreated = async (_memoCommentName: string) => {
+    setShowEditor(false);
+  };
 
   return (
     <div className="border border-t-0 border-border rounded-b-lg px-4 pt-2 pb-3 flex flex-col gap-1">
       <div className="flex items-center justify-between mb-1">
-        <span className="text-xs text-muted-foreground">Comments{commentAmount > 1 ? ` (${commentAmount})` : ""}</span>
-        <Link
-          to={`/${memo.name}#comments`}
-          className="flex items-center gap-0.5 text-xs text-muted-foreground/80 hover:underline underline-offset-2 transition-colors"
-        >
-          View all
-          <ArrowUpRightIcon className="w-3 h-3" />
-        </Link>
+        <div className="flex items-center gap-1">
+          <MessageCircleIcon className="w-3.5 h-3.5 text-muted-foreground" />
+          <span className="text-xs text-muted-foreground">
+            {t("memo.comment.self")}
+            {commentAmount > 0 && ` (${commentAmount})`}
+          </span>
+        </div>
+        {hasComments && (
+          <Link
+            to={`/${memo.name}#comments`}
+            className="flex items-center gap-0.5 text-xs text-muted-foreground/80 hover:underline underline-offset-2 transition-colors"
+          >
+            View all
+            <ArrowUpRightIcon className="w-3 h-3" />
+          </Link>
+        )}
       </div>
+
       {displayedComments.map((comment) => {
         const uid = extractMemoIdFromName(comment.name);
         const creator = commentCreators?.get(comment.creator);
@@ -51,6 +75,26 @@ const MemoCommentListView: React.FC = () => {
           </Link>
         );
       })}
+
+      {showEditor && (
+        <div className="mt-2">
+          <MemoEditor
+            cacheKey={`${memo.name}-inline-comment`}
+            placeholder={t("editor.add-your-comment-here")}
+            parentMemoName={memo.name}
+            autoFocus
+            onConfirm={handleCommentCreated}
+            onCancel={() => setShowEditor(false)}
+          />
+        </div>
+      )}
+
+      {showCreateButton && !hasComments && (
+        <Button variant="ghost" size="sm" className="w-full mt-1 text-muted-foreground" onClick={() => setShowEditor(true)}>
+          <MessageCircleIcon className="w-4 h-4 mr-1" />
+          {t("memo.comment.write-a-comment")}
+        </Button>
+      )}
     </div>
   );
 };

--- a/web/src/locales/ar.json
+++ b/web/src/locales/ar.json
@@ -175,7 +175,8 @@
     "code": "كود",
     "comment": {
       "self": "التعليقات",
-      "write-a-comment": "اكتب تعليقاً"
+      "write-a-comment": "اكتب تعليقاً",
+      "view-all": "View all"
     },
     "copy-content": "نسخ المحتوى",
     "copy-link": "نسخ الرابط",

--- a/web/src/locales/ca.json
+++ b/web/src/locales/ca.json
@@ -175,7 +175,8 @@
     "code": "Codi",
     "comment": {
       "self": "Comentaris",
-      "write-a-comment": "Escriu un comentari"
+      "write-a-comment": "Escriu un comentari",
+      "view-all": "View all"
     },
     "copy-content": "Copia el contingut",
     "copy-link": "Copia l'enllaç",

--- a/web/src/locales/cs.json
+++ b/web/src/locales/cs.json
@@ -175,7 +175,8 @@
     "code": "Kód",
     "comment": {
       "self": "Komentáře",
-      "write-a-comment": "Napsat komentář"
+      "write-a-comment": "Napsat komentář",
+      "view-all": "View all"
     },
     "copy-content": "Kopírovat obsah",
     "copy-link": "Kopírovat odkaz",

--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -175,7 +175,8 @@
     "code": "Code",
     "comment": {
       "self": "Kommentare",
-      "write-a-comment": "Schreibe einen Kommentar"
+      "write-a-comment": "Schreibe einen Kommentar",
+      "view-all": "View all"
     },
     "copy-content": "Inhalt kopieren",
     "copy-link": "Link kopieren",

--- a/web/src/locales/en-GB.json
+++ b/web/src/locales/en-GB.json
@@ -224,7 +224,8 @@
     "code": "Code",
     "comment": {
       "self": "Comments",
-      "write-a-comment": "Write a comment"
+      "write-a-comment": "Write a comment",
+      "view-all": "View all"
     },
     "copy-content": "Copy Content",
     "copy-link": "Copy Link",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -224,7 +224,8 @@
     "code": "Code",
     "comment": {
       "self": "Comments",
-      "write-a-comment": "Write a comment"
+      "write-a-comment": "Write a comment",
+      "view-all": "View all"
     },
     "copy-content": "Copy Content",
     "copy-link": "Copy Link",

--- a/web/src/locales/es.json
+++ b/web/src/locales/es.json
@@ -175,7 +175,8 @@
     "code": "Código",
     "comment": {
       "self": "Comentarios",
-      "write-a-comment": "Escribe un comentario"
+      "write-a-comment": "Escribe un comentario",
+      "view-all": "View all"
     },
     "copy-content": "Copiar contenido",
     "copy-link": "Copiar enlace",

--- a/web/src/locales/fa.json
+++ b/web/src/locales/fa.json
@@ -175,7 +175,8 @@
     "code": "کد",
     "comment": {
       "self": "نظرات",
-      "write-a-comment": "یک نظر بنویسید"
+      "write-a-comment": "یک نظر بنویسید",
+      "view-all": "View all"
     },
     "copy-content": "کپی محتوا",
     "copy-link": "کپی پیوند",

--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -175,7 +175,8 @@
     "code": "Code",
     "comment": {
       "self": "Commentaires",
-      "write-a-comment": "Écrire un commentaire"
+      "write-a-comment": "Écrire un commentaire",
+      "view-all": "View all"
     },
     "copy-content": "Copier le contenu",
     "copy-link": "Copier le lien",

--- a/web/src/locales/gl.json
+++ b/web/src/locales/gl.json
@@ -175,7 +175,8 @@
     "code": "Código",
     "comment": {
       "self": "Comentarios",
-      "write-a-comment": "Escribe un comentario"
+      "write-a-comment": "Escribe un comentario",
+      "view-all": "View all"
     },
     "copy-content": "Copiar contido",
     "copy-link": "Copiar ligazón",

--- a/web/src/locales/hi.json
+++ b/web/src/locales/hi.json
@@ -175,7 +175,8 @@
     "code": "कोड",
     "comment": {
       "self": "टिप्पणियाँ",
-      "write-a-comment": "टिप्पणी लिखें"
+      "write-a-comment": "टिप्पणी लिखें",
+      "view-all": "View all"
     },
     "copy-content": "सामग्री कॉपी करें",
     "copy-link": "लिंक कॉपी करें",

--- a/web/src/locales/hr.json
+++ b/web/src/locales/hr.json
@@ -175,7 +175,8 @@
     "code": "Kod",
     "comment": {
       "self": "Komentari",
-      "write-a-comment": "Napiši komentar"
+      "write-a-comment": "Napiši komentar",
+      "view-all": "View all"
     },
     "copy-content": "Kopiraj sadržaj",
     "copy-link": "Kopiraj link",

--- a/web/src/locales/hu.json
+++ b/web/src/locales/hu.json
@@ -175,7 +175,8 @@
     "code": "Kód",
     "comment": {
       "self": "Hozzászólások",
-      "write-a-comment": "Írj hozzászólást"
+      "write-a-comment": "Írj hozzászólást",
+      "view-all": "View all"
     },
     "copy-content": "Tartalom másolása",
     "copy-link": "Hivatkozás másolása",

--- a/web/src/locales/id.json
+++ b/web/src/locales/id.json
@@ -175,7 +175,8 @@
     "code": "Kode",
     "comment": {
       "self": "Komentar",
-      "write-a-comment": "Tulis komentar"
+      "write-a-comment": "Tulis komentar",
+      "view-all": "View all"
     },
     "copy-content": "Salin Konten",
     "copy-link": "Salin Tautan",

--- a/web/src/locales/it.json
+++ b/web/src/locales/it.json
@@ -175,7 +175,8 @@
     "code": "Codice",
     "comment": {
       "self": "Commenti",
-      "write-a-comment": "Scrivi un commento"
+      "write-a-comment": "Scrivi un commento",
+      "view-all": "View all"
     },
     "copy-content": "Copia contenuto",
     "copy-link": "Copia link",

--- a/web/src/locales/ja.json
+++ b/web/src/locales/ja.json
@@ -171,7 +171,8 @@
     "code": "コード",
     "comment": {
       "self": "コメント",
-      "write-a-comment": "コメントを書く"
+      "write-a-comment": "コメントを書く",
+      "view-all": "View all"
     },
     "copy-content": "コンテンツをコピー",
     "copy-link": "リンクをコピー",

--- a/web/src/locales/ka-GE.json
+++ b/web/src/locales/ka-GE.json
@@ -175,7 +175,8 @@
     "code": "კოდი",
     "comment": {
       "self": "კომენტარები",
-      "write-a-comment": "კომენტარის დაწერა"
+      "write-a-comment": "კომენტარის დაწერა",
+      "view-all": "View all"
     },
     "copy-content": "კონტენტის კოპირება",
     "copy-link": "ლინკის კოპირება",

--- a/web/src/locales/ko.json
+++ b/web/src/locales/ko.json
@@ -175,7 +175,8 @@
     "code": "코드",
     "comment": {
       "self": "댓글",
-      "write-a-comment": "댓글 작성"
+      "write-a-comment": "댓글 작성",
+      "view-all": "View all"
     },
     "copy-content": "콘텐츠 복사",
     "copy-link": "링크 복사",

--- a/web/src/locales/mr.json
+++ b/web/src/locales/mr.json
@@ -175,7 +175,8 @@
     "code": "कोड",
     "comment": {
       "self": "टिप्पण्या",
-      "write-a-comment": "टिप्पणी लिहा"
+      "write-a-comment": "टिप्पणी लिहा",
+      "view-all": "View all"
     },
     "copy-content": "सामग्रीची प्रत बनवा",
     "copy-link": "लिंकची प्रत बनवा",

--- a/web/src/locales/nb.json
+++ b/web/src/locales/nb.json
@@ -175,7 +175,8 @@
     "code": "Kode",
     "comment": {
       "self": "Kommentarer",
-      "write-a-comment": "Skriv en kommentar"
+      "write-a-comment": "Skriv en kommentar",
+      "view-all": "View all"
     },
     "copy-content": "Kopier innhold",
     "copy-link": "Kopier link",

--- a/web/src/locales/nl.json
+++ b/web/src/locales/nl.json
@@ -175,7 +175,8 @@
     "code": "Code",
     "comment": {
       "self": "Opmerkingen",
-      "write-a-comment": "Schrijf een opmerking"
+      "write-a-comment": "Schrijf een opmerking",
+      "view-all": "View all"
     },
     "copy-content": "Inhoud kopiëren",
     "copy-link": "Kopieer link",

--- a/web/src/locales/pl.json
+++ b/web/src/locales/pl.json
@@ -176,7 +176,8 @@
     "code": "Kod",
     "comment": {
       "self": "Komentarze",
-      "write-a-comment": "Napisz komentarz"
+      "write-a-comment": "Napisz komentarz",
+      "view-all": "View all"
     },
     "copy-content": "Kopiuj treść",
     "copy-link": "Kopiuj link",

--- a/web/src/locales/pt-BR.json
+++ b/web/src/locales/pt-BR.json
@@ -175,7 +175,8 @@
     "code": "Código",
     "comment": {
       "self": "Comentários",
-      "write-a-comment": "Escreva um comentário"
+      "write-a-comment": "Escreva um comentário",
+      "view-all": "View all"
     },
     "copy-content": "Copiar conteúdo",
     "copy-link": "Copiar link",

--- a/web/src/locales/pt-PT.json
+++ b/web/src/locales/pt-PT.json
@@ -175,7 +175,8 @@
     "code": "Código",
     "comment": {
       "self": "Comentários",
-      "write-a-comment": "Escreva um comentário"
+      "write-a-comment": "Escreva um comentário",
+      "view-all": "View all"
     },
     "copy-content": "Copiar Conteúdo",
     "copy-link": "Copiar link",

--- a/web/src/locales/ru.json
+++ b/web/src/locales/ru.json
@@ -175,7 +175,8 @@
     "code": "Код",
     "comment": {
       "self": "Комментарии",
-      "write-a-comment": "Добавить комментарий"
+      "write-a-comment": "Добавить комментарий",
+      "view-all": "View all"
     },
     "copy-content": "Копировать контент",
     "copy-link": "Скопировать ссылку",

--- a/web/src/locales/sl.json
+++ b/web/src/locales/sl.json
@@ -176,7 +176,8 @@
     "code": "Koda",
     "comment": {
       "self": "Komentarji",
-      "write-a-comment": "Napiši komentar"
+      "write-a-comment": "Napiši komentar",
+      "view-all": "View all"
     },
     "copy-link": "Kopiraj povezavo",
     "copy-content": "Kopiraj vsebino",

--- a/web/src/locales/sv.json
+++ b/web/src/locales/sv.json
@@ -175,7 +175,8 @@
     "code": "Kod",
     "comment": {
       "self": "Kommentarer",
-      "write-a-comment": "Skriv en kommentar"
+      "write-a-comment": "Skriv en kommentar",
+      "view-all": "View all"
     },
     "copy-content": "Kopiera innehåll",
     "copy-link": "Kopiera länk",

--- a/web/src/locales/th.json
+++ b/web/src/locales/th.json
@@ -175,7 +175,8 @@
     "code": "โค้ด",
     "comment": {
       "self": "ความคิดเห็น",
-      "write-a-comment": "เขียนความคิดเห็น"
+      "write-a-comment": "เขียนความคิดเห็น",
+      "view-all": "View all"
     },
     "copy-content": "คัดลอกเนื้อหา",
     "copy-link": "คัดลอกลิงก์",

--- a/web/src/locales/tr.json
+++ b/web/src/locales/tr.json
@@ -180,7 +180,8 @@
     "code": "Kod",
     "comment": {
       "self": "Yorumlar",
-      "write-a-comment": "Yorum yaz"
+      "write-a-comment": "Yorum yaz",
+      "view-all": "View all"
     },
     "copy-content": "İçeriği kopyala",
     "copy-link": "Bağlantıyı Kopyala",

--- a/web/src/locales/uk.json
+++ b/web/src/locales/uk.json
@@ -175,7 +175,8 @@
     "code": "Код",
     "comment": {
       "self": "Коментарі",
-      "write-a-comment": "Напишіть коментар"
+      "write-a-comment": "Напишіть коментар",
+      "view-all": "View all"
     },
     "copy-content": "Копіювати вміст",
     "copy-link": "Скопіювати посилання",

--- a/web/src/locales/vi.json
+++ b/web/src/locales/vi.json
@@ -175,7 +175,8 @@
     "code": "Mã",
     "comment": {
       "self": "Bình luận",
-      "write-a-comment": "Viết bình luận"
+      "write-a-comment": "Viết bình luận",
+      "view-all": "View all"
     },
     "copy-content": "Sao chép nội dung",
     "copy-link": "Sao chép liên kết",

--- a/web/src/locales/zh-Hans.json
+++ b/web/src/locales/zh-Hans.json
@@ -186,7 +186,8 @@
     "code": "代码",
     "comment": {
       "self": "评论",
-      "write-a-comment": "写评论"
+      "write-a-comment": "写评论",
+      "view-all": "View all"
     },
     "copy-content": "复制内容",
     "copy-link": "复制链接",

--- a/web/src/locales/zh-Hant.json
+++ b/web/src/locales/zh-Hant.json
@@ -185,7 +185,8 @@
     "code": "程式碼",
     "comment": {
       "self": "評論",
-      "write-a-comment": "寫下評論"
+      "write-a-comment": "寫下評論",
+      "view-all": "View all"
     },
     "copy-content": "複製內容",
     "copy-link": "複製連結",


### PR DESCRIPTION
## Related Issue
Closes #5838 (partial - addresses the comment button visibility)
## What this PR does
This PR adds a "Write a comment" button on memo cards in the homepage, even when there are no existing comments.
## Why
As described in #5838, if a memo has no existing comments, the comment button is not shown. Users had to navigate to the memo detail page to write a comment. This PR fixes that by:
- Showing the comment section on memo cards for logged-in users
- Adding an inline "Write a comment" button that opens an editor directly on the homepage
## Changes
- `MemoView.tsx`: Show comment preview section for logged-in users (not just when comments exist)
- `MemoCommentListView.tsx`: Added inline comment editor and "Write a comment" button
## Screenshot
<img width="700" height="155" alt="image" src="https://github.com/user-attachments/assets/ec4c5c8f-cafe-4f57-a2a6-c52bd704955e" />
<img width="669" height="234" alt="image" src="https://github.com/user-attachments/assets/c21f6ef5-836f-4399-a484-35168661b999" />
<img width="686" height="163" alt="image" src="https://github.com/user-attachments/assets/f93565ec-bd56-4d4d-bdac-817ee1c30b8f" />

## Testing
- [x] Tested locally with Docker build
- [x] Comment button appears on homepage when no comments exist
- [x] Inline comment editor works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline comment editor with a "write a comment" trigger for quicker replies.

* **Bug Fixes**
  * Comment preview now respects user sign-in state (shows only for signed-in users).

* **Improvements**
  * Comment list UI: clearer header with icon, conditional counts and "View all" link.
  * Added "View all" localization across many languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->