### PR TITLE
Add Backdate Memos feature — Set custom creation dates when writing new memos

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Open-source, self-hosted note-taking tool built for quick capture. Markdown-nati
 ## Features
 
 - **Instant Capture** — Timeline-first UI. Open, write, done — no folders to navigate.
+- **Backdate Memos** — Set a custom creation date when writing a new memo to place it anywhere on your timeline — perfect for journaling, importing old notes, or filling in past events.
 - **Total Data Ownership** — Self-hosted on your infrastructure. Notes stored in Markdown, always portable. Zero telemetry.
 - **Radical Simplicity** — Single Go binary, ~20MB Docker image. One command to deploy with SQLite, MySQL, or PostgreSQL.
 - **Open & Extensible** — MIT-licensed with full REST and gRPC APIs for integration.

--- a/web/src/components/MemoEditor/components/TimestampPopover.tsx
+++ b/web/src/components/MemoEditor/components/TimestampPopover.tsx
@@ -1,5 +1,7 @@
+import { CalendarClockIcon, XIcon } from "lucide-react";
 import { type FC, useRef, useState } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
 import { useTranslate } from "@/utils/i18n";
 import { useEditorContext } from "../state";
 
@@ -8,6 +10,12 @@ const DATETIME_FORMAT = "YYYY-MM-DD HH:mm:ss";
 function formatDate(date: Date): string {
   const pad = (n: number) => String(n).padStart(2, "0");
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
+/** Format a Date as a value for <input type="datetime-local"> (YYYY-MM-DDTHH:mm). */
+function toDatetimeLocalValue(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
 function parseDate(value: string): Date | undefined {
@@ -55,6 +63,7 @@ const TimestampInput: FC<{
   );
 };
 
+/** Popover shown when editing an existing memo (full create + update time editing). */
 export const TimestampPopover: FC = () => {
   const t = useTranslate();
   const { state, actions, dispatch } = useEditorContext();
@@ -83,6 +92,64 @@ export const TimestampPopover: FC = () => {
           date={updateTime}
           onChange={(d) => dispatch(actions.setTimestamps({ updateTime: d }))}
         />
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+/** Calendar icon with a date & time picker for backdating new memos. */
+export const BackdatePopover: FC = () => {
+  const t = useTranslate();
+  const { state, actions, dispatch } = useEditorContext();
+  const { createTime } = state.timestamps;
+  const [open, setOpen] = useState(false);
+
+  const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const date = new Date(e.target.value);
+    if (!Number.isNaN(date.getTime())) {
+      dispatch(actions.setTimestamps({ createTime: date }));
+    }
+  };
+
+  const handleClear = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    dispatch(actions.setTimestamps({ createTime: undefined }));
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex items-center gap-1.5 text-sm transition-colors cursor-pointer",
+            createTime ? "text-foreground hover:text-foreground/80" : "text-muted-foreground hover:text-foreground",
+          )}
+          title={t("editor.set-creation-date")}
+        >
+          <CalendarClockIcon className="size-4" />
+          {createTime && <span className="font-mono text-xs">{formatDate(createTime)}</span>}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-auto p-3 space-y-2">
+        <label className="text-xs font-medium text-muted-foreground">{t("editor.set-creation-date")}</label>
+        <input
+          type="datetime-local"
+          className="block w-full rounded-md border border-border bg-background px-2 py-1 text-sm"
+          value={createTime ? toDatetimeLocalValue(createTime) : ""}
+          onChange={handleDateChange}
+        />
+        {createTime && (
+          <button
+            type="button"
+            onClick={handleClear}
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-destructive transition-colors cursor-pointer"
+          >
+            <XIcon className="size-3" />
+            {t("common.clear")}
+          </button>
+        )}
       </PopoverContent>
     </Popover>
   );

--- a/web/src/components/MemoEditor/components/TimestampPopover.tsx
+++ b/web/src/components/MemoEditor/components/TimestampPopover.tsx
@@ -105,7 +105,13 @@ export const BackdatePopover: FC = () => {
   const [open, setOpen] = useState(false);
 
   const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const date = new Date(e.target.value);
+    const value = e.target.value;
+    if (!value) return;
+    // Parse datetime-local value (YYYY-MM-DDTHH:mm) as local time explicitly
+    const [datePart, timePart] = value.split("T");
+    const [year, month, day] = datePart.split("-").map(Number);
+    const [hours, minutes] = timePart.split(":").map(Number);
+    const date = new Date(year, month - 1, day, hours, minutes);
     if (!Number.isNaN(date.getTime())) {
       dispatch(actions.setTimestamps({ createTime: date }));
     }

--- a/web/src/components/MemoEditor/components/index.ts
+++ b/web/src/components/MemoEditor/components/index.ts
@@ -5,4 +5,4 @@ export * from "./EditorContent";
 export * from "./EditorMetadata";
 export * from "./EditorToolbar";
 export { FocusModeExitButton, FocusModeOverlay } from "./FocusModeOverlay";
-export { TimestampPopover } from "./TimestampPopover";
+export { BackdatePopover, TimestampPopover } from "./TimestampPopover";

--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -13,6 +13,7 @@ import { useTranslate } from "@/utils/i18n";
 import { convertVisibilityFromString } from "@/utils/memo";
 import {
   AudioRecorderPanel,
+  BackdatePopover,
   EditorContent,
   EditorMetadata,
   EditorToolbar,
@@ -289,9 +290,13 @@ const MemoEditorImpl: React.FC<MemoEditorProps> = ({
         {/* Exit button is absolutely positioned in top-right corner when active */}
         <FocusModeExitButton isActive={state.ui.isFocusMode} onToggle={handleToggleFocusMode} title={t("editor.exit-focus-mode")} />
 
-        {memoName && (
+        {memoName ? (
           <div className="w-full -mb-1">
             <TimestampPopover />
+          </div>
+        ) : (
+          <div className="w-full -mb-1">
+            <BackdatePopover />
           </div>
         )}
 

--- a/web/src/locales/de.json
+++ b/web/src/locales/de.json
@@ -154,7 +154,8 @@
       "trigger": "Audio aufnehmen",
       "unsupported": "Audioaufnahme wird nicht unterstützt",
       "unsupported-description": "Dieser Browser kann keine Audiodaten vom Memo Composer aufzeichnen."
-    }
+    },
+    "set-creation-date": "Erstellungsdatum festlegen"
   },
   "inbox": {
     "failed-to-load": "Fehler beim Laden des Eintrags",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -198,7 +198,8 @@
       "trigger": "Record audio",
       "unsupported": "Audio recording unsupported",
       "unsupported-description": "This browser cannot record audio from the memo composer."
-    }
+    },
+    "set-creation-date": "Set creation date"
   },
   "inbox": {
     "failed-to-load": "Failed to load inbox item",


### PR DESCRIPTION
## Feature

Adds the ability to set a custom creation date when writing a new memo, allowing users to place memos anywhere on their timeline.

## Use Cases

- **Journaling**: Backdate journal entries to their actual dates
- **Importing**: Preserve original dates when migrating notes from other tools
- **Timeline Management**: Fill in historical events or past memories

## Changes

- new date picker in memo editor (UI)
- no backend changes needed

## Testing

- Feature was tested on MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now set a custom creation date for new memos, allowing them to be placed anywhere on the timeline. Internationalization support added.

* **Documentation**
  * Updated README with the new Backdate Memos feature description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->