### PR TITLE
fix: add unix socket file permission setting (755 -> 660)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -111,7 +111,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	if network == "unix" {
 		if err := os.Chmod(address, 0660); err != nil {
-			listener.Close()
+			_ = listener.Close()
 			return errors.Wrap(err, "failed to chmod socket")
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -106,6 +107,13 @@ func (s *Server) Start(ctx context.Context) error {
 	listener, err := net.Listen(network, address)
 	if err != nil {
 		return errors.Wrap(err, "failed to listen")
+	}
+
+	if network == "unix" {
+		if err := os.Chmod(address, 0660); err != nil {
+			listener.Close()
+			return errors.Wrap(err, "failed to chmod socket")
+		}
 	}
 
 	// Start Echo server directly (no cmux needed - all traffic is HTTP).


### PR DESCRIPTION
Changed the permissions of Unix socket files created by flags or environment variables from 755 to 660. 

Communication via socket files is possible simply by adding a reverse proxy user (e.g., nginx) to memos' group.

Resolves #5827 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filesystem permission handling for UNIX socket connections. The server now correctly applies and validates socket permissions immediately after establishing the listener, ensuring proper access control. Server startup will fail safely if permissions cannot be set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->