### PR TITLE
fix: user resource names can be uuidv4 from idp sub claim

### DIFF
--- a/internal/base/resource_name.go
+++ b/internal/base/resource_name.go
@@ -3,5 +3,5 @@ package base
 import "regexp"
 
 var (
-	UIDMatcher = regexp.MustCompile("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,30}[a-zA-Z0-9])?$")
+	UIDMatcher = regexp.MustCompile("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,34}[a-zA-Z0-9])?$")
 )

--- a/internal/base/resource_name_test.go
+++ b/internal/base/resource_name_test.go
@@ -22,6 +22,8 @@ func TestUIDMatcher(t *testing.T) {
 		{"a1234567890123456789012345678901", true},
 		{"abc123", true},
 		{"abc123-", false},
+		{"123e4567-e89b-12d3-a456-426614174000", true},   // UUID v4 from IDP
+		{"a123456789012345678901234567890123456", false}, // 37 characters (too long)
 	}
 
 	for _, test := range tests {

--- a/server/router/api/v1/resource_name.go
+++ b/server/router/api/v1/resource_name.go
@@ -143,7 +143,7 @@ func ValidateAndGenerateUID(provided string) (string, error) {
 		return shortuuid.New(), nil
 	}
 	if !base.UIDMatcher.MatchString(uid) {
-		return "", status.Errorf(codes.InvalidArgument, "invalid ID format: must be 1-32 characters, alphanumeric and hyphens only, cannot start or end with hyphen")
+		return "", status.Errorf(codes.InvalidArgument, "invalid ID format: must be 1-36 characters, alphanumeric and hyphens only, cannot start or end with hyphen")
 	}
 	return uid, nil
 }


### PR DESCRIPTION
usernames that come from identity providers might be UUIDv4 which would fail the UIDMatcher regex causing an invalid username error when trying to log in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Increased allowed UID length from 32 to 36 characters — validations and acceptance now permit longer identifiers.

* **Tests**
  * Added test cases to cover the updated UID length and expected validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->