### PR TITLE
fix(calendar): color and click adjacent-month days in month view

### DIFF
--- a/web/src/components/ActivityCalendar/CalendarCell.tsx
+++ b/web/src/components/ActivityCalendar/CalendarCell.tsx
@@ -35,16 +35,19 @@ export const CalendarCell = memo((props: CalendarCellProps) => {
   const isInteractive = Boolean(onClick && day.count > 0);
   const ariaLabel = day.isSelected ? `${tooltipText} (selected)` : tooltipText;
 
-  if (!day.isCurrentMonth) {
-    return <div className={cn(baseClasses, "text-muted-foreground/30 bg-transparent border-transparent cursor-default")}>{day.label}</div>;
-  }
-
   const intensityClass = getCellIntensityClass(day, maxCount);
+
+  // Adjacent-month days (those shown to fill out the first/last grid row) keep
+  // their heatmap color and click behavior so days with memos are never hidden
+  // by the grid boundary, but are visually muted so it's still obvious they
+  // aren't part of the current month. See #5816.
+  const adjacentMonthClass = !day.isCurrentMonth ? "opacity-60" : "";
 
   const buttonClasses = cn(
     baseClasses,
     intensityClass,
     getCalendarCellStateClass(day),
+    adjacentMonthClass,
     isInteractive ? "cursor-pointer hover:bg-muted/40 hover:border-border/30" : "cursor-default",
   );
 

--- a/web/src/components/ActivityCalendar/utils.ts
+++ b/web/src/components/ActivityCalendar/utils.ts
@@ -12,7 +12,7 @@ dayjs.extend(isSameOrBefore);
 export type TranslateFunction = ReturnType<typeof useTranslate>;
 
 export const getCellIntensityClass = (day: CalendarDayCell, maxCount: number): string => {
-  if (!day.isCurrentMonth || day.count === 0) {
+  if (day.count === 0) {
     return CELL_STYLES.EMPTY;
   }
 


### PR DESCRIPTION
Closes #5816.

## Problem

Days shown from adjacent months (to fill the first/last week of the month grid) rendered as plain muted divs with no heatmap color and no click handler. Memos created on the last few days of the previous month — which appear in the current month's first grid row — looked indistinguishable from empty days, and couldn't be clicked through to their date filter.

Bug reported by @bordam with screenshots in #5816.

## Fix

- `CalendarCell.tsx`: removed the `!day.isCurrentMonth` early-return that was rendering adjacent-month days as plain divs. They now flow through the normal button path with intensity class, tooltip, and click handler.
- `utils.ts`: removed the `!day.isCurrentMonth` check from `getCellIntensityClass` so intensity is count-based regardless of month.
- Added `opacity-60` to adjacent-month cells so a visual distinction from current-month cells is preserved — adjacent-month days are still clearly secondary in the grid.

The count lookup (`data[isoDate] ?? 0`) and click chain (`navigateToDateFilter` → `?filter=displayTime:YYYY-MM-DD`) already worked correctly for arbitrary dates; the data map isn't scoped to the visible month. Only the render path was gating these days out.

## Test plan

- [x] `pnpm lint` (tsc + biome) — clean
- [x] `pnpm build` — clean
- [x] Ran dev server with 7 test memos spanning the March/April boundary. Verified:
  - April 2026 grid top row shows `29 30 31` (March days) colored with heatmap intensity
  - Clicking March 29 navigates to `/home?filter=displayTime:2026-03-29` and the March 29 memo loads
  - Adjacent-month button has `aria-label="1 memo in 2026-03-29"`, `tabindex=0`, `opacity-60` class, and the expected `bg-primary*` intensity class
  - Visual de-emphasis preserved — adjacent-month cells are clearly secondary
- [x] No regressions on current-month cells (same render path, unchanged class chain when `day.isCurrentMonth` is true)

## Notes

- `YearCalendar` uses the same component. Adjacent-month days across the year boundary (Jan card showing Dec of prior year, Dec card showing Jan of next year) get `count=0` from `filterDataByYear` and render as EMPTY with opacity-60 — unchanged visual. Within the same year, an adjacent-month day with memos will appear colored in both its own card and the neighboring card. That's a minor visual duplication but internally consistent with how the grids have always worked, and matches the fix's intent of never hiding a day with memos behind a grid boundary.
- One drive-by comment on the issue suggested this might be "intended behavior." @bordam's rationale (coloring avoids ambiguity between empty and not-shown) is solid and the `opacity-60` preserves the "this isn't the current month" signal that the concern was really about.
- No frontend unit tests added — repo convention is no vitest tests in `web/src`. Verified manually via dev server + type check + build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjacent-month cells in the activity calendar now display intensity-based colors and remain interactive, providing a consistent experience across all visible cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->