### PR TITLE
fix: disable modal prop on DropdownMenu to prevent scroll disappearing

### DIFF
--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -9,7 +9,7 @@ const DropdownMenu = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Root>
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
 >(({ ...props }, _ref) => {
-  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" modal={false} {...props} />;
 });
 DropdownMenu.displayName = "DropdownMenu";
 


### PR DESCRIPTION
Fixed an issue where the layout was unstable because the scroll bar disappeared when the memo dropdown menu appeared.

Resolved #5860 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted dropdown menu modal interaction behavior for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->