### PR TITLE
fix(api): resolve user resource names for SSO email-shaped usernames

### DIFF
--- a/server/router/api/v1/user_resource_name.go
+++ b/server/router/api/v1/user_resource_name.go
@@ -31,6 +31,7 @@ func ExtractUsernameFromName(name string) (string, error) {
 	return username, nil
 }
 
+// validateUsername enforces the strict username rules used when creating or renaming users.
 func validateUsername(username string) error {
 	if username == "" || isNumericUsername(username) || !base.UIDMatcher.MatchString(username) {
 		return errors.Errorf("invalid username %q", username)
@@ -38,6 +39,8 @@ func validateUsername(username string) error {
 	return nil
 }
 
+// validateUsernameForResourceName is the relaxed validator used when parsing an existing
+// resource name, so rows whose username was persisted by a non-strict path remain addressable.
 func validateUsernameForResourceName(username string) error {
 	if username == "" || isNumericUsername(username) || strings.Contains(username, "/") {
 		return errors.Errorf("invalid username %q", username)
@@ -45,6 +48,7 @@ func validateUsernameForResourceName(username string) error {
 	return nil
 }
 
+// isNumericUsername reports whether username consists solely of decimal digits.
 func isNumericUsername(username string) bool {
 	if username == "" {
 		return false

--- a/server/router/api/v1/user_resource_name.go
+++ b/server/router/api/v1/user_resource_name.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -24,7 +25,9 @@ func ExtractUsernameFromName(name string) (string, error) {
 	if username == "" {
 		return "", errors.Errorf("invalid user name %q", name)
 	}
-	if err := validateUsername(username); err != nil {
+	// SSO may persist Identifier (often an email) as Username without going through
+	// validateUsername (see auth_service). Resource names must still resolve those rows.
+	if err := validateUsernameForResourceName(username); err != nil {
 		return "", err
 	}
 	return username, nil
@@ -32,6 +35,22 @@ func ExtractUsernameFromName(name string) (string, error) {
 
 func validateUsername(username string) error {
 	if username == "" || isNumericUsername(username) || !base.UIDMatcher.MatchString(username) {
+		return errors.Errorf("invalid username %q", username)
+	}
+	return nil
+}
+
+// validateUsernameForResourceName validates the username segment when parsing a
+// resource name (e.g. users/<username>). Rules are looser than validateUsername so
+// legacy SSO users stored with an email-shaped username remain addressable.
+func validateUsernameForResourceName(username string) error {
+	if username == "" {
+		return errors.Errorf("invalid username %q", username)
+	}
+	if isNumericUsername(username) {
+		return errors.Errorf("invalid username %q", username)
+	}
+	if strings.Contains(username, "/") {
 		return errors.Errorf("invalid username %q", username)
 	}
 	return nil

--- a/server/router/api/v1/user_resource_name.go
+++ b/server/router/api/v1/user_resource_name.go
@@ -11,11 +11,21 @@ import (
 )
 
 // BuildUserName returns the canonical public resource name for a user.
+//
+// The returned value is of the form `users/<username>` and is the inverse of
+// ExtractUsernameFromName for usernames that satisfy validateUsername.
 func BuildUserName(username string) string {
 	return UserNamePrefix + username
 }
 
 // ExtractUsernameFromName extracts the username token from a user resource name.
+//
+// The input is expected to match the canonical form `users/<username>`. The
+// username segment is validated with validateUsernameForResourceName so rows
+// already persisted with a non-strict username (e.g. SSO identifiers shaped
+// like email addresses) remain addressable. Returns an error when the prefix
+// is missing, the username segment is empty, or the relaxed validator rejects
+// the value.
 func ExtractUsernameFromName(name string) (string, error) {
 	tokens, err := GetNameParentTokens(name, UserNamePrefix)
 	if err != nil {
@@ -31,7 +41,12 @@ func ExtractUsernameFromName(name string) (string, error) {
 	return username, nil
 }
 
-// validateUsername enforces the strict username rules used when creating or renaming users.
+// validateUsername enforces the strict username rules used when creating or
+// renaming users.
+//
+// A username must be non-empty, must not consist solely of digits (to avoid
+// clashing with numeric user IDs), and must match base.UIDMatcher. This is
+// intentionally stricter than validateUsernameForResourceName.
 func validateUsername(username string) error {
 	if username == "" || isNumericUsername(username) || !base.UIDMatcher.MatchString(username) {
 		return errors.Errorf("invalid username %q", username)
@@ -39,8 +54,15 @@ func validateUsername(username string) error {
 	return nil
 }
 
-// validateUsernameForResourceName is the relaxed validator used when parsing an existing
-// resource name, so rows whose username was persisted by a non-strict path remain addressable.
+// validateUsernameForResourceName is the relaxed validator used when parsing
+// an existing resource name.
+//
+// It rejects only values that would clearly make the resource name ambiguous
+// or unparsable: empty strings, all-digit strings (which would collide with
+// numeric IDs), and values containing a path separator. Everything else is
+// trusted because the username has already been persisted via some other
+// code path (for example SSO sign-in) and the store remains the source of
+// truth for whether the row exists.
 func validateUsernameForResourceName(username string) error {
 	if username == "" || isNumericUsername(username) || strings.Contains(username, "/") {
 		return errors.Errorf("invalid username %q", username)
@@ -48,7 +70,12 @@ func validateUsernameForResourceName(username string) error {
 	return nil
 }
 
-// isNumericUsername reports whether username consists solely of decimal digits.
+// isNumericUsername reports whether username consists solely of decimal
+// digits.
+//
+// An empty string is not considered numeric. It is used by both username
+// validators to prevent collisions with numeric user IDs that are handled by
+// ExtractUserIDFromName.
 func isNumericUsername(username string) bool {
 	if username == "" {
 		return false
@@ -61,7 +88,12 @@ func isNumericUsername(username string) bool {
 	return true
 }
 
-// ResolveUserByName resolves a username-based user resource name to a store user.
+// ResolveUserByName resolves a username-based user resource name to a store
+// user.
+//
+// It first parses the resource name with ExtractUsernameFromName and then
+// looks up the row in the store. A nil user is returned without an error when
+// the username is valid but no matching row exists.
 func ResolveUserByName(ctx context.Context, stores *store.Store, name string) (*store.User, error) {
 	username, err := ExtractUsernameFromName(name)
 	if err != nil {

--- a/server/router/api/v1/user_resource_name.go
+++ b/server/router/api/v1/user_resource_name.go
@@ -25,8 +25,6 @@ func ExtractUsernameFromName(name string) (string, error) {
 	if username == "" {
 		return "", errors.Errorf("invalid user name %q", name)
 	}
-	// SSO may persist Identifier (often an email) as Username without going through
-	// validateUsername (see auth_service). Resource names must still resolve those rows.
 	if err := validateUsernameForResourceName(username); err != nil {
 		return "", err
 	}
@@ -40,17 +38,8 @@ func validateUsername(username string) error {
 	return nil
 }
 
-// validateUsernameForResourceName validates the username segment when parsing a
-// resource name (e.g. users/<username>). Rules are looser than validateUsername so
-// legacy SSO users stored with an email-shaped username remain addressable.
 func validateUsernameForResourceName(username string) error {
-	if username == "" {
-		return errors.Errorf("invalid username %q", username)
-	}
-	if isNumericUsername(username) {
-		return errors.Errorf("invalid username %q", username)
-	}
-	if strings.Contains(username, "/") {
+	if username == "" || isNumericUsername(username) || strings.Contains(username, "/") {
 		return errors.Errorf("invalid username %q", username)
 	}
 	return nil

--- a/server/router/api/v1/user_resource_name_extract_test.go
+++ b/server/router/api/v1/user_resource_name_extract_test.go
@@ -26,4 +26,7 @@ func TestExtractUsernameFromName_StillRejectsEmptyAndNumeric(t *testing.T) {
 
 	_, err = ExtractUsernameFromName("users/123")
 	require.Error(t, err)
+
+	_, err = ExtractUsernameFromName("users/abc/def")
+	require.Error(t, err)
 }

--- a/server/router/api/v1/user_resource_name_extract_test.go
+++ b/server/router/api/v1/user_resource_name_extract_test.go
@@ -1,0 +1,25 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractUsernameFromName_EmailShapedSSOUsername(t *testing.T) {
+	u, err := ExtractUsernameFromName("users/529408806@QQ.COM")
+	require.NoError(t, err)
+	require.Equal(t, "529408806@QQ.COM", u)
+
+	u, err = ExtractUsernameFromName("users/abc.def@gmail.com")
+	require.NoError(t, err)
+	require.Equal(t, "abc.def@gmail.com", u)
+}
+
+func TestExtractUsernameFromName_StillRejectsEmptyAndNumeric(t *testing.T) {
+	_, err := ExtractUsernameFromName("users/")
+	require.Error(t, err)
+
+	_, err = ExtractUsernameFromName("users/123")
+	require.Error(t, err)
+}

--- a/server/router/api/v1/user_resource_name_extract_test.go
+++ b/server/router/api/v1/user_resource_name_extract_test.go
@@ -6,8 +6,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestExtractUsernameFromName_EmailShapedSSOUsername ensures that legacy SSO users whose
-// username was persisted as an email address remain resolvable through the resource name.
+// TestExtractUsernameFromName_EmailShapedSSOUsername ensures that legacy SSO
+// users whose username was persisted as an email address remain resolvable
+// through the resource name.
+//
+// Covers the representative samples reported in issue #5862, including both
+// local-part-only and dotted local-part shapes.
 func TestExtractUsernameFromName_EmailShapedSSOUsername(t *testing.T) {
 	u, err := ExtractUsernameFromName("users/529408806@QQ.COM")
 	require.NoError(t, err)
@@ -18,8 +22,13 @@ func TestExtractUsernameFromName_EmailShapedSSOUsername(t *testing.T) {
 	require.Equal(t, "abc.def@gmail.com", u)
 }
 
-// TestExtractUsernameFromName_StillRejectsEmptyAndNumeric guards that relaxing the resource-name
-// validator does not accept empty or all-numeric usernames, which would clash with numeric user IDs.
+// TestExtractUsernameFromName_StillRejectsEmptyAndNumeric guards that relaxing
+// the resource-name validator does not accept empty, all-numeric, or
+// multi-segment usernames.
+//
+// The three rejection cases cover, respectively, missing segments, collision
+// with numeric user IDs, and accidental truncation of `users/<a>/<b>` into a
+// single username.
 func TestExtractUsernameFromName_StillRejectsEmptyAndNumeric(t *testing.T) {
 	_, err := ExtractUsernameFromName("users/")
 	require.Error(t, err)

--- a/server/router/api/v1/user_resource_name_extract_test.go
+++ b/server/router/api/v1/user_resource_name_extract_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestExtractUsernameFromName_EmailShapedSSOUsername ensures that legacy SSO users whose
+// username was persisted as an email address remain resolvable through the resource name.
 func TestExtractUsernameFromName_EmailShapedSSOUsername(t *testing.T) {
 	u, err := ExtractUsernameFromName("users/529408806@QQ.COM")
 	require.NoError(t, err)
@@ -16,6 +18,8 @@ func TestExtractUsernameFromName_EmailShapedSSOUsername(t *testing.T) {
 	require.Equal(t, "abc.def@gmail.com", u)
 }
 
+// TestExtractUsernameFromName_StillRejectsEmptyAndNumeric guards that relaxing the resource-name
+// validator does not accept empty or all-numeric usernames, which would clash with numeric user IDs.
 func TestExtractUsernameFromName_StillRejectsEmptyAndNumeric(t *testing.T) {
 	_, err := ExtractUsernameFromName("users/")
 	require.Error(t, err)

--- a/server/router/api/v1/user_service.go
+++ b/server/router/api/v1/user_service.go
@@ -71,6 +71,7 @@ func (s *APIV1Service) ListUsers(ctx context.Context, request *v1pb.ListUsersReq
 	return response, nil
 }
 
+// normalizeBatchUsernames trims, de-duplicates and drops invalid entries from a batch lookup input.
 func normalizeBatchUsernames(usernames []string) []string {
 	uniqueUsernames := make([]string, 0, len(usernames))
 	seen := make(map[string]struct{}, len(usernames))

--- a/server/router/api/v1/user_service.go
+++ b/server/router/api/v1/user_service.go
@@ -76,7 +76,6 @@ func normalizeBatchUsernames(usernames []string) []string {
 	seen := make(map[string]struct{}, len(usernames))
 	for _, username := range usernames {
 		username = strings.TrimSpace(username)
-		// Match ExtractUsernameFromName: allow legacy SSO email-shaped usernames.
 		if validateUsernameForResourceName(username) != nil {
 			continue
 		}

--- a/server/router/api/v1/user_service.go
+++ b/server/router/api/v1/user_service.go
@@ -76,7 +76,8 @@ func normalizeBatchUsernames(usernames []string) []string {
 	seen := make(map[string]struct{}, len(usernames))
 	for _, username := range usernames {
 		username = strings.TrimSpace(username)
-		if validateUsername(username) != nil {
+		// Match ExtractUsernameFromName: allow legacy SSO email-shaped usernames.
+		if validateUsernameForResourceName(username) != nil {
 			continue
 		}
 		if _, ok := seen[username]; ok {

--- a/server/router/api/v1/user_service.go
+++ b/server/router/api/v1/user_service.go
@@ -71,7 +71,12 @@ func (s *APIV1Service) ListUsers(ctx context.Context, request *v1pb.ListUsersReq
 	return response, nil
 }
 
-// normalizeBatchUsernames trims, de-duplicates and drops invalid entries from a batch lookup input.
+// normalizeBatchUsernames trims, de-duplicates and drops invalid entries from
+// a batch lookup input.
+//
+// Filtering uses validateUsernameForResourceName so legacy SSO-provisioned
+// usernames (including email-shaped values) are preserved, matching the
+// relaxed contract used elsewhere when resolving existing resource names.
 func normalizeBatchUsernames(usernames []string) []string {
 	uniqueUsernames := make([]string, 0, len(usernames))
 	seen := make(map[string]struct{}, len(usernames))

--- a/server/router/api/v1/user_service_normalize_test.go
+++ b/server/router/api/v1/user_service_normalize_test.go
@@ -1,0 +1,21 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNormalizeBatchUsernames_EmailShapedSSOUsername locks in that email-shaped SSO
+// usernames survive batch normalization while empty and all-numeric inputs are dropped
+// and duplicates are de-duplicated.
+func TestNormalizeBatchUsernames_EmailShapedSSOUsername(t *testing.T) {
+	got := normalizeBatchUsernames([]string{
+		"abc.def@gmail.com",
+		"abc.def@gmail.com",
+		"123",
+		"",
+	})
+
+	require.Equal(t, []string{"abc.def@gmail.com"}, got)
+}

--- a/server/router/api/v1/user_service_normalize_test.go
+++ b/server/router/api/v1/user_service_normalize_test.go
@@ -6,9 +6,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNormalizeBatchUsernames_EmailShapedSSOUsername locks in that email-shaped SSO
-// usernames survive batch normalization while empty and all-numeric inputs are dropped
-// and duplicates are de-duplicated.
+// TestNormalizeBatchUsernames_EmailShapedSSOUsername locks in that
+// email-shaped SSO usernames survive batch normalization while empty and
+// all-numeric inputs are dropped and duplicates are de-duplicated.
+//
+// This complements the ExtractUsernameFromName tests by exercising the
+// BatchGetUsers normalization path independently.
 func TestNormalizeBatchUsernames_EmailShapedSSOUsername(t *testing.T) {
 	got := normalizeBatchUsernames([]string{
 		"abc.def@gmail.com",


### PR DESCRIPTION
## Summary

Fixes #5862.

SSO sign-in (`auth_service.SignIn`) writes the identity-provider `Identifier` straight into `User.Username` **without** going through `validateUsername`. When the IdP returns an email as the identifier (default for Google and most OAuth providers), the stored `username` contains characters that the strict `UIDMatcher` rejects.

Every admin action that resolves the user through the canonical resource name `users/<username>` (rename, archive, delete, `BatchGetUsers`) then goes through `ExtractUsernameFromName` → `validateUsername` → and fails with:

```
[invalid_argument] rpc error: code = InvalidArgument
desc = invalid username: <email>
```

This effectively locks the SSO-created account out of any management operation.

## Change

Split username validation into two functions with distinct intent:

- `validateUsername` — **unchanged**. Still enforced on `CreateUser` and on the `username` field of `UpdateUser`. New users / renames still cannot use email-shaped usernames.
- `validateUsernameForResourceName` — **new**. Used only when parsing an existing resource name (`ExtractUsernameFromName`, `normalizeBatchUsernames`). It forbids empty, all-numeric and `/`-containing values, but otherwise trusts what is already in the store, so pre-existing SSO rows remain addressable.

This is deliberately the **minimum** fix: it does not change the write-path policy, does not migrate existing rows, and does not widen what SSO is allowed to write. It only makes already-stored rows manageable so admins can rename / archive / delete them.

A more thorough long-term fix would be to sanitize the IdP `Identifier` at SSO user-creation time (e.g. derive a `UIDMatcher`-compatible username from the local part and store the email in `Email`). That is left out of this PR because it is a product decision that deserves its own discussion.

## Test plan

- [x] Added `TestExtractUsernameFromName_EmailShapedSSOUsername` covering `529408806@QQ.COM` and `abc.def@gmail.com`.
- [x] Added `TestExtractUsernameFromName_StillRejectsEmptyAndNumeric` to confirm empty / all-numeric names are still rejected.
- [x] `go test ./server/router/api/v1/...` passes locally.
- [ ] Manual: with an SSO-provisioned user whose `username` is an email, `Archive` / `Rename` / `Delete` now succeed (the error in #5862 no longer reproduces).

## Non-goals

- Allowing admins to **create** users with email-shaped usernames.
- Changing `UIDMatcher` or the URL / resource-name conventions.
- Data migration for historical SSO rows.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accept email-shaped legacy SSO identifiers (e.g., user@domain.com) as valid usernames when parsing resource names; empty, purely numeric, and slash-containing identifiers are rejected.

* **Bug Fixes / Improvements**
  * Batch username normalization now uses the relaxed parsing validation so more legacy-style names are retained for lookup and deduplication; docs updated to reflect this behavior.

* **Tests**
  * Added tests verifying extraction of email-shaped names and rejection of empty, numeric, and multi-segment inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->