### PR TITLE
fix(user): omit internal settings from list responses

### DIFF
--- a/server/router/api/v1/test/user_setting_test.go
+++ b/server/router/api/v1/test/user_setting_test.go
@@ -1,0 +1,58 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	apiv1 "github.com/usememos/memos/proto/gen/api/v1"
+	storepb "github.com/usememos/memos/proto/gen/store"
+	apiv1server "github.com/usememos/memos/server/router/api/v1"
+)
+
+func TestListUserSettingsOmitsInternalStoreSettings(t *testing.T) {
+	ctx := context.Background()
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+
+	user, err := ts.CreateRegularUser(ctx, "locale-user")
+	require.NoError(t, err)
+
+	_, err = ts.Store.UpsertUserSetting(ctx, &storepb.UserSetting{
+		UserId: user.ID,
+		Key:    storepb.UserSetting_REFRESH_TOKENS,
+		Value: &storepb.UserSetting_RefreshTokens{
+			RefreshTokens: &storepb.RefreshTokensUserSetting{},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = ts.Store.UpsertUserSetting(ctx, &storepb.UserSetting{
+		UserId: user.ID,
+		Key:    storepb.UserSetting_SHORTCUTS,
+		Value: &storepb.UserSetting_Shortcuts{
+			Shortcuts: &storepb.ShortcutsUserSetting{},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = ts.Store.UpsertUserSetting(ctx, &storepb.UserSetting{
+		UserId: user.ID,
+		Key:    storepb.UserSetting_GENERAL,
+		Value: &storepb.UserSetting_General{
+			General: &storepb.GeneralUserSetting{
+				Locale: "ja",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := ts.Service.ListUserSettings(ts.CreateUserContext(ctx, user.ID), &apiv1.ListUserSettingsRequest{
+		Parent: apiv1server.BuildUserName(user.Username),
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Settings, 1)
+	require.Equal(t, "users/locale-user/settings/GENERAL", resp.Settings[0].Name)
+	require.Equal(t, "ja", resp.Settings[0].GetGeneralSetting().Locale)
+}

--- a/server/router/api/v1/user_service.go
+++ b/server/router/api/v1/user_service.go
@@ -1294,6 +1294,10 @@ func convertUserSettingFromStore(storeSetting *storepb.UserSetting, user *store.
 		}
 
 		switch key {
+		case storepb.UserSetting_GENERAL:
+			setting.Value = &v1pb.UserSetting_GeneralSetting_{
+				GeneralSetting: getDefaultUserGeneralSetting(),
+			}
 		case storepb.UserSetting_WEBHOOKS:
 			setting.Value = &v1pb.UserSetting_WebhooksSetting_{
 				WebhooksSetting: &v1pb.UserSetting_WebhooksSetting{
@@ -1301,10 +1305,7 @@ func convertUserSettingFromStore(storeSetting *storepb.UserSetting, user *store.
 				},
 			}
 		default:
-			// Default to general setting
-			setting.Value = &v1pb.UserSetting_GeneralSetting_{
-				GeneralSetting: getDefaultUserGeneralSetting(),
-			}
+			return nil
 		}
 		return setting
 	}
@@ -1349,10 +1350,7 @@ func convertUserSettingFromStore(storeSetting *storepb.UserSetting, user *store.
 			},
 		}
 	default:
-		// Default to general setting if unknown key
-		setting.Value = &v1pb.UserSetting_GeneralSetting_{
-			GeneralSetting: getDefaultUserGeneralSetting(),
-		}
+		return nil
 	}
 
 	return setting


### PR DESCRIPTION
## Summary
- Stop converting internal store-only user setting rows into public `generalSetting` responses.
- Keep the real `GENERAL` setting as the source of truth when listing user settings.
- Add a regression test covering mixed internal and public settings.

## Testing
- `go test ./server/router/api/v1/test -count=1`
- `go test ./server/router/api/v1/... -count=1`