### PR TITLE
fix(frontend): use correct url path for memos in sitemap.xml

### DIFF
--- a/server/router/frontend/frontend.go
+++ b/server/router/frontend/frontend.go
@@ -109,7 +109,7 @@ func (s *FrontendService) getSitemapXML(c *echo.Context) error {
 	urls := make([]sitemapURL, 0, len(memos))
 	for _, memo := range memos {
 		urls = append(urls, sitemapURL{
-			Loc: instanceURL + "/m/" + memo.UID,
+			Loc: instanceURL + "/memos/" + memo.UID,
 		})
 	}
 


### PR DESCRIPTION
Newer Memos versions use `/memos/<UID>` instead of `/m/<UID>`. Sitemap generation doesn't reflect this change, and URLs result in 404.

This fix replaces `/m/` with `/memos/`.