### PR TITLE
feat: add configurable --log-level flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ web/dist
 # Build artifacts
 build/
 bin/
-memos
+/memos
 
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ web/dist
 # Build artifacts
 build/
 bin/
-/memos
+memos
 
 .DS_Store
 

--- a/cmd/memos/log.go
+++ b/cmd/memos/log.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func parseSlogLevel(s string) (slog.Level, error) {
+	switch strings.ToLower(s) {
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, errors.Errorf("unknown log level %q: must be debug, info, warn, or error", s)
+	}
+}
+
+func newLogger(level slog.Level, w io.Writer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: level}))
+}

--- a/cmd/memos/log_test.go
+++ b/cmd/memos/log_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestParseSlogLevel(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantLevel slog.Level
+		wantErr   bool
+	}{
+		{"debug", slog.LevelDebug, false},
+		{"info", slog.LevelInfo, false},
+		{"warn", slog.LevelWarn, false},
+		{"error", slog.LevelError, false},
+		{"DEBUG", slog.LevelDebug, false},
+		{"INFO", slog.LevelInfo, false},
+		{"WARN", slog.LevelWarn, false},
+		{"ERROR", slog.LevelError, false},
+		{"invalid", slog.LevelInfo, true},
+		{"", slog.LevelInfo, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseSlogLevel(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseSlogLevel(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.wantLevel {
+				t.Errorf("parseSlogLevel(%q) = %v, want %v", tt.input, got, tt.wantLevel)
+			}
+		})
+	}
+}
+
+func TestNewLoggerLevelFiltering(t *testing.T) {
+	tests := []struct {
+		level          slog.Level
+		logAt          slog.Level
+		msg            string
+		shouldAppear   bool
+	}{
+		// debug passes all
+		{slog.LevelDebug, slog.LevelDebug, "debug-msg", true},
+		{slog.LevelDebug, slog.LevelInfo, "info-msg", true},
+		{slog.LevelDebug, slog.LevelWarn, "warn-msg", true},
+		{slog.LevelDebug, slog.LevelError, "error-msg", true},
+		// info suppresses debug
+		{slog.LevelInfo, slog.LevelDebug, "debug-suppressed", false},
+		{slog.LevelInfo, slog.LevelInfo, "info-visible", true},
+		{slog.LevelInfo, slog.LevelWarn, "warn-visible", true},
+		// warn suppresses debug+info
+		{slog.LevelWarn, slog.LevelDebug, "debug-suppressed", false},
+		{slog.LevelWarn, slog.LevelInfo, "info-suppressed", false},
+		{slog.LevelWarn, slog.LevelWarn, "warn-visible", true},
+		{slog.LevelWarn, slog.LevelError, "error-visible", true},
+		// error suppresses everything below
+		{slog.LevelError, slog.LevelDebug, "debug-suppressed", false},
+		{slog.LevelError, slog.LevelInfo, "info-suppressed", false},
+		{slog.LevelError, slog.LevelWarn, "warn-suppressed", false},
+		{slog.LevelError, slog.LevelError, "error-visible", true},
+	}
+
+	for _, tt := range tests {
+		var buf bytes.Buffer
+		logger := newLogger(tt.level, &buf)
+		logger.Log(nil, tt.logAt, tt.msg)
+
+		appeared := strings.Contains(buf.String(), tt.msg)
+		if appeared != tt.shouldAppear {
+			t.Errorf("level=%s logAt=%s msg=%q: appeared=%v want=%v",
+				tt.level, tt.logAt, tt.msg, appeared, tt.shouldAppear)
+		}
+	}
+}
+
+func TestNewLoggerOutputFormat(t *testing.T) {
+	var buf bytes.Buffer
+	logger := newLogger(slog.LevelDebug, &buf)
+	logger.Info("hello-world", "key", "value")
+
+	out := buf.String()
+	if !strings.Contains(out, "hello-world") {
+		t.Errorf("expected message in output, got: %s", out)
+	}
+	if !strings.Contains(out, "key=value") {
+		t.Errorf("expected key=value attr in output, got: %s", out)
+	}
+	if !strings.Contains(out, "INFO") {
+		t.Errorf("expected level in output, got: %s", out)
+	}
+}
+
+func TestNewLoggerDoesNotMutateGlobalDefault(t *testing.T) {
+	original := slog.Default()
+	var buf bytes.Buffer
+	_ = newLogger(slog.LevelError, &buf)
+	if slog.Default() != original {
+		t.Error("newLogger must not change slog.Default()")
+	}
+}

--- a/cmd/memos/log_test.go
+++ b/cmd/memos/log_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"strings"
 	"testing"
@@ -40,10 +41,10 @@ func TestParseSlogLevel(t *testing.T) {
 
 func TestNewLoggerLevelFiltering(t *testing.T) {
 	tests := []struct {
-		level          slog.Level
-		logAt          slog.Level
-		msg            string
-		shouldAppear   bool
+		level        slog.Level
+		logAt        slog.Level
+		msg          string
+		shouldAppear bool
 	}{
 		// debug passes all
 		{slog.LevelDebug, slog.LevelDebug, "debug-msg", true},
@@ -69,7 +70,7 @@ func TestNewLoggerLevelFiltering(t *testing.T) {
 	for _, tt := range tests {
 		var buf bytes.Buffer
 		logger := newLogger(tt.level, &buf)
-		logger.Log(nil, tt.logAt, tt.msg)
+		logger.Log(context.TODO(), tt.logAt, tt.msg)
 
 		appeared := strings.Contains(buf.String(), tt.msg)
 		if appeared != tt.shouldAppear {

--- a/cmd/memos/main.go
+++ b/cmd/memos/main.go
@@ -33,9 +33,6 @@ var (
 	rootCmd = &cobra.Command{
 		Use:   "memos",
 		Short: `An open source, lightweight note-taking service. Easily capture and share your great thoughts.`,
-		PersistentPreRun: func(_ *cobra.Command, _ []string) {
-			initSlogDefault()
-		},
 		Run: func(_ *cobra.Command, _ []string) {
 			instanceProfile := &profile.Profile{
 				Demo:        viper.GetBool("demo"),
@@ -114,6 +111,8 @@ var (
 )
 
 func init() {
+	cobra.OnInitialize(initSlogDefault)
+
 	viper.SetDefault("demo", false)
 	viper.SetDefault("driver", "sqlite")
 	viper.SetDefault("port", 8081)

--- a/cmd/memos/main.go
+++ b/cmd/memos/main.go
@@ -21,10 +21,21 @@ import (
 	"github.com/usememos/memos/store/db"
 )
 
+func initSlogDefault() {
+	level, err := parseSlogLevel(viper.GetString("log-level"))
+	if err != nil {
+		slog.Warn("invalid log-level value, defaulting to info", "error", err)
+	}
+	slog.SetDefault(newLogger(level, os.Stderr))
+}
+
 var (
 	rootCmd = &cobra.Command{
 		Use:   "memos",
 		Short: `An open source, lightweight note-taking service. Easily capture and share your great thoughts.`,
+		PersistentPreRun: func(_ *cobra.Command, _ []string) {
+			initSlogDefault()
+		},
 		Run: func(_ *cobra.Command, _ []string) {
 			instanceProfile := &profile.Profile{
 				Demo:        viper.GetBool("demo"),
@@ -116,6 +127,7 @@ func init() {
 	rootCmd.PersistentFlags().String("dsn", "", "database source name(aka. DSN)")
 	rootCmd.PersistentFlags().String("instance-url", "", "the url of your memos instance")
 	rootCmd.PersistentFlags().Bool("allow-private-webhooks", false, "allow webhook URLs to resolve to private/reserved IP addresses")
+	rootCmd.PersistentFlags().String("log-level", "info", "log verbosity level (debug, info, warn, error)")
 
 	if err := viper.BindPFlag("demo", rootCmd.PersistentFlags().Lookup("demo")); err != nil {
 		panic(err)
@@ -142,6 +154,9 @@ func init() {
 		panic(err)
 	}
 	if err := viper.BindPFlag("allow-private-webhooks", rootCmd.PersistentFlags().Lookup("allow-private-webhooks")); err != nil {
+		panic(err)
+	}
+	if err := viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level")); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
## Summary

Closes #5927

Every user interaction currently logs at INFO severity with no way to reduce verbosity. This adds a `--log-level` flag so operators running Memos in Docker can filter noise without rebuilding.

- Adds `--log-level` persistent flag with default `info` (debug / info / warn / error)
- Env var `MEMOS_LOG_LEVEL` works automatically via Viper's `AutomaticEnv`
- Invalid values fall back to `info` with a one-time warning log
- Fixes `.gitignore`: changed `memos` → `/memos` to anchor the compiled-binary ignore rule to the repo root (the old pattern was accidentally ignoring the `cmd/memos/` source directory for new files)

## Usage

```bash
# Flag
memos --log-level warn

# Environment variable (Docker / docker-compose)
MEMOS_LOG_LEVEL=error memos
```

```yaml
# docker-compose.yml
environment:
  - MEMOS_LOG_LEVEL=warn
```

## Test plan

- [x] `TestParseSlogLevel` — all 4 levels, uppercase variants, empty string, invalid input (10 cases)
- [x] `TestNewLoggerLevelFiltering` — every (handler-level, log-level) boundary pair confirms real filtering (15 cases)
- [x] `TestNewLoggerOutputFormat` — verifies TextHandler emits message, attributes, and level label
- [x] `TestNewLoggerDoesNotMutateGlobalDefault` — guards against accidental global state mutation
- [x] `go build ./cmd/memos/...` passes
- [x] `go vet ./cmd/memos/...` clean
- [x] `--log-level` appears in `--help` with correct default