### PR TITLE
chore: fix coderabbit logo for light and dark theme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@
       </td>
       <td align="center" width="50%">
         <a href="https://coderabbit.link/usememos" target="_blank" rel="noopener">
-          <img alt="CodeRabbit" height="44" src="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg" />
+        <picture>
+            <source media="(prefers-color-scheme: dark)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/White_Typemark_79b9189d19.svg">
+            
+            <source media="(prefers-color-scheme: light)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg">
+            
+            <img alt="CodeRabbit" height="44" src="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg" />
+          </picture>
           <br/>
           <span>Cut code review time &amp; bugs in half, instantly.</span>
         </a>

--- a/README.md
+++ b/README.md
@@ -12,12 +12,10 @@
       <td align="center" width="50%">
         <a href="https://coderabbit.link/usememos" target="_blank" rel="noopener">
         <picture>
-            <source media="(prefers-color-scheme: dark)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/White_Typemark_79b9189d19.svg">
-            
-            <source media="(prefers-color-scheme: light)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg">
-            
-            <img alt="CodeRabbit" height="44" src="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg" />
-          </picture>
+          <source media="(prefers-color-scheme: dark)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/White_Typemark_79b9189d19.svg">
+          <source media="(prefers-color-scheme: light)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg">
+          <img alt="CodeRabbit" height="44" src="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg" />
+        </picture>
           <br/>
           <span>Cut code review time &amp; bugs in half, instantly.</span>
         </a>


### PR DESCRIPTION
Add light and dark theme logo

<img width="1576" height="364" alt="Screenshot 2026-05-14 at 22 08 42" src="https://github.com/user-attachments/assets/4c4f10c2-14a6-42c4-ad15-597c80f7ec4d" />
