### PR TITLE
feat(web): add Catppuccin themes

### DIFF
--- a/web/src/components/MemoContent/CodeBlock.tsx
+++ b/web/src/components/MemoContent/CodeBlock.tsx
@@ -4,7 +4,7 @@ import { CheckIcon, CopyIcon } from "lucide-react";
 import { isValidElement, type ReactElement, type ReactNode, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { cn } from "@/lib/utils";
-import { getThemeWithFallback, resolveTheme } from "@/utils/theme";
+import { getThemeMode, getThemeWithFallback, resolveTheme } from "@/utils/theme";
 import { MermaidBlock } from "./MermaidBlock";
 import type { ReactMarkdownProps } from "./markdown/types";
 import { extractCodeContent, extractLanguage } from "./utils";
@@ -36,7 +36,7 @@ export const CodeBlock = ({ children, className, node: _node, ...props }: CodeBl
 
   const theme = getThemeWithFallback(userGeneralSetting?.theme);
   const resolvedTheme = resolveTheme(theme);
-  const isDarkTheme = resolvedTheme.includes("dark");
+  const isDarkTheme = getThemeMode(resolvedTheme) === "dark";
 
   // Dynamically load highlight.js theme based on app theme
   useEffect(() => {

--- a/web/src/components/MemoContent/MermaidBlock.tsx
+++ b/web/src/components/MemoContent/MermaidBlock.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { cn } from "@/lib/utils";
-import { getThemeWithFallback, resolveTheme, setupSystemThemeListener } from "@/utils/theme";
+import { getThemeMode, getThemeWithFallback, resolveTheme, setupSystemThemeListener } from "@/utils/theme";
 import { extractCodeContent } from "./utils";
 
 interface MermaidBlockProps {
@@ -11,7 +11,7 @@ interface MermaidBlockProps {
 
 type MermaidTheme = "default" | "dark";
 
-const toMermaidTheme = (appTheme: string): MermaidTheme => (appTheme === "default-dark" ? "dark" : "default");
+const toMermaidTheme = (appTheme: string): MermaidTheme => (getThemeMode(resolveTheme(appTheme)) === "dark" ? "dark" : "default");
 
 const formatErrorMessage = (err: unknown): string => {
   const msg = err instanceof Error ? err.message : "Failed to render diagram";

--- a/web/src/components/ThemeSelect.tsx
+++ b/web/src/components/ThemeSelect.tsx
@@ -14,6 +14,10 @@ const THEME_ICONS: Record<string, ReactElement> = {
   default: <Sun className="w-4 h-4" />,
   "default-dark": <Moon className="w-4 h-4" />,
   paper: <Palette className="w-4 h-4" />,
+  "catppuccin-latte": <Palette className="w-4 h-4" />,
+  "catppuccin-frappe": <Palette className="w-4 h-4" />,
+  "catppuccin-macchiato": <Palette className="w-4 h-4" />,
+  "catppuccin-mocha": <Palette className="w-4 h-4" />,
 };
 
 const ThemeSelect = ({ value, onValueChange, className }: ThemeSelectProps = {}) => {

--- a/web/src/components/map/map-utils.tsx
+++ b/web/src/components/map/map-utils.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import ReactDOMServer from "react-dom/server";
 import { TileLayer } from "react-leaflet";
 import { useAuth } from "@/contexts/AuthContext";
-import { resolveTheme } from "@/utils/theme";
+import { getThemeMode, resolveTheme } from "@/utils/theme";
 
 const TILE_URLS = {
   light: "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png",
@@ -13,7 +13,7 @@ const TILE_URLS = {
 
 export const ThemedTileLayer = () => {
   const { userGeneralSetting } = useAuth();
-  const isDark = useMemo(() => resolveTheme(userGeneralSetting?.theme || "system").includes("dark"), [userGeneralSetting?.theme]);
+  const isDark = useMemo(() => getThemeMode(resolveTheme(userGeneralSetting?.theme || "system")) === "dark", [userGeneralSetting?.theme]);
   return <TileLayer url={isDark ? TILE_URLS.dark : TILE_URLS.light} />;
 };
 

--- a/web/src/themes/catppuccin-frappe.css
+++ b/web/src/themes/catppuccin-frappe.css
@@ -1,0 +1,186 @@
+/*
+  Catppuccin Frappé theme for Memos
+  Based on the official Catppuccin style guide.
+*/
+
+:root {
+  --ctp-rosewater: #f2d5cf;
+  --ctp-flamingo: #eebebe;
+  --ctp-pink: #f4b8e4;
+  --ctp-mauve: #ca9ee6;
+  --ctp-red: #e78284;
+  --ctp-maroon: #ea999c;
+  --ctp-peach: #ef9f76;
+  --ctp-yellow: #e5c890;
+  --ctp-green: #a6d189;
+  --ctp-teal: #81c8be;
+  --ctp-sky: #99d1db;
+  --ctp-sapphire: #85c1dc;
+  --ctp-blue: #8caaee;
+  --ctp-lavender: #babbf1;
+  --ctp-text: #c6d0f5;
+  --ctp-subtext1: #b5bfe2;
+  --ctp-subtext0: #a5adce;
+  --ctp-overlay2: #949cbb;
+  --ctp-overlay1: #838ba7;
+  --ctp-overlay0: #737994;
+  --ctp-surface2: #626880;
+  --ctp-surface1: #51576d;
+  --ctp-surface0: #414559;
+  --ctp-base: #303446;
+  --ctp-mantle: #292c3c;
+  --ctp-crust: #232634;
+
+  /* Memos/Tailwind tokens */
+  --background: var(--ctp-base);
+  --foreground: var(--ctp-text);
+  --card: var(--ctp-mantle);
+  --card-foreground: var(--ctp-text);
+  --popover: var(--ctp-mantle);
+  --popover-foreground: var(--ctp-text);
+  --primary: var(--ctp-mauve);
+  --primary-foreground: var(--ctp-base);
+  --secondary: var(--ctp-surface0);
+  --secondary-foreground: var(--ctp-text);
+  --muted: var(--ctp-surface0);
+  --muted-foreground: var(--ctp-subtext0);
+  --accent: var(--ctp-surface1);
+  --accent-foreground: var(--ctp-text);
+  --destructive: var(--ctp-red);
+  --destructive-foreground: var(--ctp-base);
+  --border: var(--ctp-surface1);
+  --input: var(--ctp-surface2);
+  --ring: var(--ctp-mauve);
+  --sidebar: var(--ctp-mantle);
+  --sidebar-foreground: var(--ctp-subtext1);
+  --sidebar-accent: var(--ctp-surface0);
+  --sidebar-accent-foreground: var(--ctp-text);
+
+  color-scheme: dark;
+  caret-color: var(--ctp-rosewater);
+}
+
+/* Typography: text/subtext/overlay guidance */
+.text-muted-foreground,
+.text-secondary-foreground\/80,
+.text-foreground\/60,
+.text-foreground\/70,
+[class*="muted-foreground"] {
+  color: var(--ctp-subtext0) !important;
+}
+
+/* Links and URL-like actions: blue per Catppuccin guide. */
+a,
+a:visited,
+.markdown-body a,
+.memo-content a {
+  color: var(--ctp-blue) !important;
+}
+
+a:hover,
+.markdown-body a:hover,
+.memo-content a:hover {
+  color: var(--ctp-sapphire) !important;
+}
+
+/* Tags/pills: blue per guide, with base/on-accent text. */
+[class*="tag"],
+a[href*="tag"],
+.rounded-full.bg-primary,
+.bg-primary\/10 {
+  border-color: color-mix(in srgb, var(--ctp-blue) 45%, transparent) !important;
+}
+
+/* Selection: overlay2 at 25%, per guide. */
+::selection {
+  background: color-mix(in srgb, var(--ctp-overlay2) 25%, transparent);
+  color: var(--ctp-text);
+}
+
+/* Focus/cursor: rosewater cursor, mauve focus ring. */
+*:focus-visible {
+  outline-color: var(--ctp-mauve) !important;
+}
+
+input,
+textarea,
+select,
+[contenteditable="true"] {
+  caret-color: var(--ctp-rosewater);
+}
+
+/* Semantic states. */
+.text-green-500,
+.text-green-600,
+.text-emerald-500,
+.text-emerald-600,
+[class*="text-success"] {
+  color: var(--ctp-green) !important;
+}
+
+.text-yellow-500,
+.text-yellow-600,
+.text-amber-500,
+.text-amber-600,
+[class*="text-warning"] {
+  color: var(--ctp-yellow) !important;
+}
+
+.text-red-500,
+.text-red-600,
+.text-destructive,
+[class*="text-error"] {
+  color: var(--ctp-red) !important;
+}
+
+.bg-green-500,
+.bg-green-600,
+.bg-emerald-500,
+.bg-emerald-600,
+[class*="bg-success"] {
+  background-color: var(--ctp-green) !important;
+  color: var(--ctp-base) !important;
+}
+
+.bg-yellow-500,
+.bg-yellow-600,
+.bg-amber-500,
+.bg-amber-600,
+[class*="bg-warning"] {
+  background-color: var(--ctp-yellow) !important;
+  color: var(--ctp-base) !important;
+}
+
+.bg-red-500,
+.bg-red-600,
+.bg-destructive,
+[class*="bg-error"] {
+  background-color: var(--ctp-red) !important;
+  color: var(--ctp-base) !important;
+}
+
+/* Code blocks: surface pane with text, keeping syntax highlighting legible. */
+code:not(pre code),
+pre {
+  background-color: var(--ctp-surface0) !important;
+  color: var(--ctp-text) !important;
+  border-color: var(--ctp-surface1) !important;
+}
+
+pre code {
+  background: transparent !important;
+}
+
+/* Form and surface polish. */
+button,
+input,
+textarea,
+select {
+  border-color: var(--ctp-surface2);
+}
+
+hr,
+.border,
+[class*="border-border"] {
+  border-color: var(--ctp-surface1) !important;
+}

--- a/web/src/themes/catppuccin-latte.css
+++ b/web/src/themes/catppuccin-latte.css
@@ -1,0 +1,198 @@
+/*
+  Catppuccin theme for Memos
+  Light: Latte, Dark: Mocha
+  Based on the official Catppuccin style guide:
+  - background pane: base
+  - secondary panes: mantle/crust
+  - surfaces: surface0/surface1/surface2
+  - body text: text
+  - labels: subtext0/subtext1
+  - subtle text: overlay1
+  - links/tags: blue
+  - success: green, warnings: yellow, errors: red
+  - selection: overlay2 at 20-30%
+  - caret/cursor: rosewater
+*/
+
+:root {
+  /* Catppuccin Latte palette */
+  --ctp-rosewater: #dc8a78;
+  --ctp-flamingo: #dd7878;
+  --ctp-pink: #ea76cb;
+  --ctp-mauve: #8839ef;
+  --ctp-red: #d20f39;
+  --ctp-maroon: #e64553;
+  --ctp-peach: #fe640b;
+  --ctp-yellow: #df8e1d;
+  --ctp-green: #40a02b;
+  --ctp-teal: #179299;
+  --ctp-sky: #04a5e5;
+  --ctp-sapphire: #209fb5;
+  --ctp-blue: #1e66f5;
+  --ctp-lavender: #7287fd;
+  --ctp-text: #4c4f69;
+  --ctp-subtext1: #5c5f77;
+  --ctp-subtext0: #6c6f85;
+  --ctp-overlay2: #7c7f93;
+  --ctp-overlay1: #8c8fa1;
+  --ctp-overlay0: #9ca0b0;
+  --ctp-surface2: #acb0be;
+  --ctp-surface1: #bcc0cc;
+  --ctp-surface0: #ccd0da;
+  --ctp-base: #eff1f5;
+  --ctp-mantle: #e6e9ef;
+  --ctp-crust: #dce0e8;
+
+  /* Memos/Tailwind tokens */
+  --background: var(--ctp-base);
+  --foreground: var(--ctp-text);
+  --card: var(--ctp-mantle);
+  --card-foreground: var(--ctp-text);
+  --popover: var(--ctp-mantle);
+  --popover-foreground: var(--ctp-text);
+  --primary: var(--ctp-mauve);
+  --primary-foreground: var(--ctp-base);
+  --secondary: var(--ctp-surface0);
+  --secondary-foreground: var(--ctp-text);
+  --muted: var(--ctp-crust);
+  --muted-foreground: var(--ctp-subtext0);
+  --accent: var(--ctp-surface1);
+  --accent-foreground: var(--ctp-text);
+  --destructive: var(--ctp-red);
+  --destructive-foreground: var(--ctp-base);
+  --border: var(--ctp-surface1);
+  --input: var(--ctp-surface2);
+  --ring: var(--ctp-mauve);
+  --sidebar: var(--ctp-mantle);
+  --sidebar-foreground: var(--ctp-subtext1);
+  --sidebar-accent: var(--ctp-surface0);
+  --sidebar-accent-foreground: var(--ctp-text);
+
+  color-scheme: light;
+  caret-color: var(--ctp-rosewater);
+}
+
+/* Typography: text/subtext/overlay guidance */
+.text-muted-foreground,
+.text-secondary-foreground\/80,
+.text-foreground\/60,
+.text-foreground\/70,
+[class*="muted-foreground"] {
+  color: var(--ctp-subtext0) !important;
+}
+
+/* Links and URL-like actions: blue per Catppuccin guide. */
+a,
+a:visited,
+.markdown-body a,
+.memo-content a {
+  color: var(--ctp-blue) !important;
+}
+
+a:hover,
+.markdown-body a:hover,
+.memo-content a:hover {
+  color: var(--ctp-sapphire) !important;
+}
+
+/* Tags/pills: blue per guide, with base/on-accent text. */
+[class*="tag"],
+a[href*="tag"],
+.rounded-full.bg-primary,
+.bg-primary\/10 {
+  border-color: color-mix(in srgb, var(--ctp-blue) 45%, transparent) !important;
+}
+
+/* Selection: overlay2 at 25%, per guide. */
+::selection {
+  background: color-mix(in srgb, var(--ctp-overlay2) 25%, transparent);
+  color: var(--ctp-text);
+}
+
+/* Focus/cursor: rosewater cursor, mauve focus ring. */
+*:focus-visible {
+  outline-color: var(--ctp-mauve) !important;
+}
+
+input,
+textarea,
+select,
+[contenteditable="true"] {
+  caret-color: var(--ctp-rosewater);
+}
+
+/* Semantic states. */
+.text-green-500,
+.text-green-600,
+.text-emerald-500,
+.text-emerald-600,
+[class*="text-success"] {
+  color: var(--ctp-green) !important;
+}
+
+.text-yellow-500,
+.text-yellow-600,
+.text-amber-500,
+.text-amber-600,
+[class*="text-warning"] {
+  color: var(--ctp-yellow) !important;
+}
+
+.text-red-500,
+.text-red-600,
+.text-destructive,
+[class*="text-error"] {
+  color: var(--ctp-red) !important;
+}
+
+.bg-green-500,
+.bg-green-600,
+.bg-emerald-500,
+.bg-emerald-600,
+[class*="bg-success"] {
+  background-color: var(--ctp-green) !important;
+  color: var(--ctp-base) !important;
+}
+
+.bg-yellow-500,
+.bg-yellow-600,
+.bg-amber-500,
+.bg-amber-600,
+[class*="bg-warning"] {
+  background-color: var(--ctp-yellow) !important;
+  color: var(--ctp-base) !important;
+}
+
+.bg-red-500,
+.bg-red-600,
+.bg-destructive,
+[class*="bg-error"] {
+  background-color: var(--ctp-red) !important;
+  color: var(--ctp-base) !important;
+}
+
+/* Code blocks: surface pane with text, keeping syntax highlighting legible. */
+code:not(pre code),
+pre {
+  background-color: var(--ctp-surface0) !important;
+  color: var(--ctp-text) !important;
+  border-color: var(--ctp-surface1) !important;
+}
+
+pre code {
+  background: transparent !important;
+}
+
+/* Form and surface polish. */
+button,
+input,
+textarea,
+select {
+  border-color: var(--ctp-surface2);
+}
+
+hr,
+.border,
+[class*="border-border"] {
+  border-color: var(--ctp-surface1) !important;
+}

--- a/web/src/themes/catppuccin-macchiato.css
+++ b/web/src/themes/catppuccin-macchiato.css
@@ -1,0 +1,186 @@
+/*
+  Catppuccin Macchiato theme for Memos
+  Based on the official Catppuccin style guide.
+*/
+
+:root {
+  --ctp-rosewater: #f4dbd6;
+  --ctp-flamingo: #f0c6c6;
+  --ctp-pink: #f5bde6;
+  --ctp-mauve: #c6a0f6;
+  --ctp-red: #ed8796;
+  --ctp-maroon: #ee99a0;
+  --ctp-peach: #f5a97f;
+  --ctp-yellow: #eed49f;
+  --ctp-green: #a6da95;
+  --ctp-teal: #8bd5ca;
+  --ctp-sky: #91d7e3;
+  --ctp-sapphire: #7dc4e4;
+  --ctp-blue: #8aadf4;
+  --ctp-lavender: #b7bdf8;
+  --ctp-text: #cad3f5;
+  --ctp-subtext1: #b8c0e0;
+  --ctp-subtext0: #a5adcb;
+  --ctp-overlay2: #939ab7;
+  --ctp-overlay1: #8087a2;
+  --ctp-overlay0: #6e738d;
+  --ctp-surface2: #5b6078;
+  --ctp-surface1: #494d64;
+  --ctp-surface0: #363a4f;
+  --ctp-base: #24273a;
+  --ctp-mantle: #1e2030;
+  --ctp-crust: #181926;
+
+  /* Memos/Tailwind tokens */
+  --background: var(--ctp-base);
+  --foreground: var(--ctp-text);
+  --card: var(--ctp-mantle);
+  --card-foreground: var(--ctp-text);
+  --popover: var(--ctp-mantle);
+  --popover-foreground: var(--ctp-text);
+  --primary: var(--ctp-mauve);
+  --primary-foreground: var(--ctp-base);
+  --secondary: var(--ctp-surface0);
+  --secondary-foreground: var(--ctp-text);
+  --muted: var(--ctp-surface0);
+  --muted-foreground: var(--ctp-subtext0);
+  --accent: var(--ctp-surface1);
+  --accent-foreground: var(--ctp-text);
+  --destructive: var(--ctp-red);
+  --destructive-foreground: var(--ctp-base);
+  --border: var(--ctp-surface1);
+  --input: var(--ctp-surface2);
+  --ring: var(--ctp-mauve);
+  --sidebar: var(--ctp-mantle);
+  --sidebar-foreground: var(--ctp-subtext1);
+  --sidebar-accent: var(--ctp-surface0);
+  --sidebar-accent-foreground: var(--ctp-text);
+
+  color-scheme: dark;
+  caret-color: var(--ctp-rosewater);
+}
+
+/* Typography: text/subtext/overlay guidance */
+.text-muted-foreground,
+.text-secondary-foreground\/80,
+.text-foreground\/60,
+.text-foreground\/70,
+[class*="muted-foreground"] {
+  color: var(--ctp-subtext0) !important;
+}
+
+/* Links and URL-like actions: blue per Catppuccin guide. */
+a,
+a:visited,
+.markdown-body a,
+.memo-content a {
+  color: var(--ctp-blue) !important;
+}
+
+a:hover,
+.markdown-body a:hover,
+.memo-content a:hover {
+  color: var(--ctp-sapphire) !important;
+}
+
+/* Tags/pills: blue per guide, with base/on-accent text. */
+[class*="tag"],
+a[href*="tag"],
+.rounded-full.bg-primary,
+.bg-primary\/10 {
+  border-color: color-mix(in srgb, var(--ctp-blue) 45%, transparent) !important;
+}
+
+/* Selection: overlay2 at 25%, per guide. */
+::selection {
+  background: color-mix(in srgb, var(--ctp-overlay2) 25%, transparent);
+  color: var(--ctp-text);
+}
+
+/* Focus/cursor: rosewater cursor, mauve focus ring. */
+*:focus-visible {
+  outline-color: var(--ctp-mauve) !important;
+}
+
+input,
+textarea,
+select,
+[contenteditable="true"] {
+  caret-color: var(--ctp-rosewater);
+}
+
+/* Semantic states. */
+.text-green-500,
+.text-green-600,
+.text-emerald-500,
+.text-emerald-600,
+[class*="text-success"] {
+  color: var(--ctp-green) !important;
+}
+
+.text-yellow-500,
+.text-yellow-600,
+.text-amber-500,
+.text-amber-600,
+[class*="text-warning"] {
+  color: var(--ctp-yellow) !important;
+}
+
+.text-red-500,
+.text-red-600,
+.text-destructive,
+[class*="text-error"] {
+  color: var(--ctp-red) !important;
+}
+
+.bg-green-500,
+.bg-green-600,
+.bg-emerald-500,
+.bg-emerald-600,
+[class*="bg-success"] {
+  background-color: var(--ctp-green) !important;
+  color: var(--ctp-base) !important;
+}
+
+.bg-yellow-500,
+.bg-yellow-600,
+.bg-amber-500,
+.bg-amber-600,
+[class*="bg-warning"] {
+  background-color: var(--ctp-yellow) !important;
+  color: var(--ctp-base) !important;
+}
+
+.bg-red-500,
+.bg-red-600,
+.bg-destructive,
+[class*="bg-error"] {
+  background-color: var(--ctp-red) !important;
+  color: var(--ctp-base) !important;
+}
+
+/* Code blocks: surface pane with text, keeping syntax highlighting legible. */
+code:not(pre code),
+pre {
+  background-color: var(--ctp-surface0) !important;
+  color: var(--ctp-text) !important;
+  border-color: var(--ctp-surface1) !important;
+}
+
+pre code {
+  background: transparent !important;
+}
+
+/* Form and surface polish. */
+button,
+input,
+textarea,
+select {
+  border-color: var(--ctp-surface2);
+}
+
+hr,
+.border,
+[class*="border-border"] {
+  border-color: var(--ctp-surface1) !important;
+}

--- a/web/src/themes/catppuccin-mocha.css
+++ b/web/src/themes/catppuccin-mocha.css
@@ -1,0 +1,197 @@
+/*
+  Catppuccin theme for Memos
+  Light: Latte, Dark: Mocha
+  Based on the official Catppuccin style guide:
+  - background pane: base
+  - secondary panes: mantle/crust
+  - surfaces: surface0/surface1/surface2
+  - body text: text
+  - labels: subtext0/subtext1
+  - subtle text: overlay1
+  - links/tags: blue
+  - success: green, warnings: yellow, errors: red
+  - selection: overlay2 at 20-30%
+  - caret/cursor: rosewater
+*/
+
+:root {
+  /* Catppuccin Mocha palette */
+  --ctp-rosewater: #f5e0dc;
+  --ctp-flamingo: #f2cdcd;
+  --ctp-pink: #f5c2e7;
+  --ctp-mauve: #cba6f7;
+  --ctp-red: #f38ba8;
+  --ctp-maroon: #eba0ac;
+  --ctp-peach: #fab387;
+  --ctp-yellow: #f9e2af;
+  --ctp-green: #a6e3a1;
+  --ctp-teal: #94e2d5;
+  --ctp-sky: #89dceb;
+  --ctp-sapphire: #74c7ec;
+  --ctp-blue: #89b4fa;
+  --ctp-lavender: #b4befe;
+  --ctp-text: #cdd6f4;
+  --ctp-subtext1: #bac2de;
+  --ctp-subtext0: #a6adc8;
+  --ctp-overlay2: #9399b2;
+  --ctp-overlay1: #7f849c;
+  --ctp-overlay0: #6c7086;
+  --ctp-surface2: #585b70;
+  --ctp-surface1: #45475a;
+  --ctp-surface0: #313244;
+  --ctp-base: #1e1e2e;
+  --ctp-mantle: #181825;
+  --ctp-crust: #11111b;
+
+  --background: var(--ctp-base);
+  --foreground: var(--ctp-text);
+  --card: var(--ctp-mantle);
+  --card-foreground: var(--ctp-text);
+  --popover: var(--ctp-mantle);
+  --popover-foreground: var(--ctp-text);
+  --primary: var(--ctp-mauve);
+  --primary-foreground: var(--ctp-base);
+  --secondary: var(--ctp-surface0);
+  --secondary-foreground: var(--ctp-text);
+  --muted: var(--ctp-surface0);
+  --muted-foreground: var(--ctp-subtext0);
+  --accent: var(--ctp-surface1);
+  --accent-foreground: var(--ctp-text);
+  --destructive: var(--ctp-red);
+  --destructive-foreground: var(--ctp-base);
+  --border: var(--ctp-surface1);
+  --input: var(--ctp-surface2);
+  --ring: var(--ctp-mauve);
+  --sidebar: var(--ctp-mantle);
+  --sidebar-foreground: var(--ctp-subtext1);
+  --sidebar-accent: var(--ctp-surface0);
+  --sidebar-accent-foreground: var(--ctp-text);
+
+  color-scheme: dark;
+  caret-color: var(--ctp-rosewater);
+}
+
+/* Typography: text/subtext/overlay guidance */
+.text-muted-foreground,
+.text-secondary-foreground\/80,
+.text-foreground\/60,
+.text-foreground\/70,
+[class*="muted-foreground"] {
+  color: var(--ctp-subtext0) !important;
+}
+
+/* Links and URL-like actions: blue per Catppuccin guide. */
+a,
+a:visited,
+.markdown-body a,
+.memo-content a {
+  color: var(--ctp-blue) !important;
+}
+
+a:hover,
+.markdown-body a:hover,
+.memo-content a:hover {
+  color: var(--ctp-sapphire) !important;
+}
+
+/* Tags/pills: blue per guide, with base/on-accent text. */
+[class*="tag"],
+a[href*="tag"],
+.rounded-full.bg-primary,
+.bg-primary\/10 {
+  border-color: color-mix(in srgb, var(--ctp-blue) 45%, transparent) !important;
+}
+
+/* Selection: overlay2 at 25%, per guide. */
+::selection {
+  background: color-mix(in srgb, var(--ctp-overlay2) 25%, transparent);
+  color: var(--ctp-text);
+}
+
+/* Focus/cursor: rosewater cursor, mauve focus ring. */
+*:focus-visible {
+  outline-color: var(--ctp-mauve) !important;
+}
+
+input,
+textarea,
+select,
+[contenteditable="true"] {
+  caret-color: var(--ctp-rosewater);
+}
+
+/* Semantic states. */
+.text-green-500,
+.text-green-600,
+.text-emerald-500,
+.text-emerald-600,
+[class*="text-success"] {
+  color: var(--ctp-green) !important;
+}
+
+.text-yellow-500,
+.text-yellow-600,
+.text-amber-500,
+.text-amber-600,
+[class*="text-warning"] {
+  color: var(--ctp-yellow) !important;
+}
+
+.text-red-500,
+.text-red-600,
+.text-destructive,
+[class*="text-error"] {
+  color: var(--ctp-red) !important;
+}
+
+.bg-green-500,
+.bg-green-600,
+.bg-emerald-500,
+.bg-emerald-600,
+[class*="bg-success"] {
+  background-color: var(--ctp-green) !important;
+  color: var(--ctp-base) !important;
+}
+
+.bg-yellow-500,
+.bg-yellow-600,
+.bg-amber-500,
+.bg-amber-600,
+[class*="bg-warning"] {
+  background-color: var(--ctp-yellow) !important;
+  color: var(--ctp-base) !important;
+}
+
+.bg-red-500,
+.bg-red-600,
+.bg-destructive,
+[class*="bg-error"] {
+  background-color: var(--ctp-red) !important;
+  color: var(--ctp-base) !important;
+}
+
+/* Code blocks: surface pane with text, keeping syntax highlighting legible. */
+code:not(pre code),
+pre {
+  background-color: var(--ctp-surface0) !important;
+  color: var(--ctp-text) !important;
+  border-color: var(--ctp-surface1) !important;
+}
+
+pre code {
+  background: transparent !important;
+}
+
+/* Form and surface polish. */
+button,
+input,
+textarea,
+select {
+  border-color: var(--ctp-surface2);
+}
+
+hr,
+.border,
+[class*="border-border"] {
+  border-color: var(--ctp-surface1) !important;
+}

--- a/web/src/types/modules/setting.d.ts
+++ b/web/src/types/modules/setting.d.ts
@@ -1,1 +1,9 @@
-type Theme = "system" | "default" | "default-dark" | "paper";
+type Theme =
+  | "system"
+  | "default"
+  | "default-dark"
+  | "paper"
+  | "catppuccin-latte"
+  | "catppuccin-frappe"
+  | "catppuccin-macchiato"
+  | "catppuccin-mocha";

--- a/web/src/utils/theme.ts
+++ b/web/src/utils/theme.ts
@@ -1,3 +1,7 @@
+import catppuccinFrappeThemeContent from "../themes/catppuccin-frappe.css?raw";
+import catppuccinLatteThemeContent from "../themes/catppuccin-latte.css?raw";
+import catppuccinMacchiatoThemeContent from "../themes/catppuccin-macchiato.css?raw";
+import catppuccinMochaThemeContent from "../themes/catppuccin-mocha.css?raw";
 import defaultDarkThemeContent from "../themes/default-dark.css?raw";
 import paperThemeContent from "../themes/paper.css?raw";
 
@@ -5,10 +9,68 @@ import paperThemeContent from "../themes/paper.css?raw";
 // Types and Constants
 // ============================================================================
 
-const VALID_THEMES = ["system", "default", "default-dark", "paper"] as const;
+export type ThemeMode = "light" | "dark";
 
-export type Theme = (typeof VALID_THEMES)[number];
-export type ResolvedTheme = Exclude<Theme, "system">;
+interface ResolvedThemeConfig {
+  label: string;
+  mode: ThemeMode;
+  color: string;
+  content: string | null;
+}
+
+const RESOLVED_THEMES = {
+  default: {
+    label: "Light",
+    mode: "light",
+    color: "#faf9f5",
+    content: null,
+  },
+  "default-dark": {
+    label: "Dark",
+    mode: "dark",
+    color: "#1d1f23",
+    content: defaultDarkThemeContent,
+  },
+  paper: {
+    label: "Paper",
+    mode: "light",
+    color: "#f5ede4",
+    content: paperThemeContent,
+  },
+  "catppuccin-latte": {
+    label: "Catppuccin Latte",
+    mode: "light",
+    color: "#eff1f5",
+    content: catppuccinLatteThemeContent,
+  },
+  "catppuccin-frappe": {
+    label: "Catppuccin Frappé",
+    mode: "dark",
+    color: "#303446",
+    content: catppuccinFrappeThemeContent,
+  },
+  "catppuccin-macchiato": {
+    label: "Catppuccin Macchiato",
+    mode: "dark",
+    color: "#24273a",
+    content: catppuccinMacchiatoThemeContent,
+  },
+  "catppuccin-mocha": {
+    label: "Catppuccin Mocha",
+    mode: "dark",
+    color: "#1e1e2e",
+    content: catppuccinMochaThemeContent,
+  },
+} as const satisfies Record<string, ResolvedThemeConfig>;
+
+const SYSTEM_THEME = {
+  label: "Sync with system",
+} as const;
+
+const VALID_THEMES = ["system", ...Object.keys(RESOLVED_THEMES)] as const;
+
+export type ResolvedTheme = keyof typeof RESOLVED_THEMES;
+export type Theme = "system" | ResolvedTheme;
 
 export interface ThemeOption {
   value: string;
@@ -18,23 +80,9 @@ export interface ThemeOption {
 const STORAGE_KEY = "memos-theme";
 const STYLE_ELEMENT_ID = "instance-theme";
 
-const THEME_CONTENT: Record<ResolvedTheme, string | null> = {
-  default: null,
-  "default-dark": defaultDarkThemeContent,
-  paper: paperThemeContent,
-};
-
-const THEME_COLORS: Record<ResolvedTheme, string> = {
-  default: "#faf9f5",
-  "default-dark": "#1d1f23",
-  paper: "#f5ede4",
-};
-
 export const THEME_OPTIONS: ThemeOption[] = [
-  { value: "system", label: "Sync with system" },
-  { value: "default", label: "Light" },
-  { value: "default-dark", label: "Dark" },
-  { value: "paper", label: "Paper" },
+  { value: "system", label: SYSTEM_THEME.label },
+  ...Object.entries(RESOLVED_THEMES).map(([value, theme]) => ({ value, label: theme.label })),
 ];
 
 // ============================================================================
@@ -67,6 +115,10 @@ export const getSystemTheme = (): ResolvedTheme => {
 export const resolveTheme = (theme: string): ResolvedTheme => {
   const validTheme = validateTheme(theme);
   return validTheme === "system" ? getSystemTheme() : validTheme;
+};
+
+export const getThemeMode = (theme: ResolvedTheme): ThemeMode => {
+  return RESOLVED_THEMES[theme].mode;
 };
 
 // ============================================================================
@@ -150,11 +202,7 @@ const removeThemeStyle = (): void => {
 const injectThemeStyle = (theme: ResolvedTheme): void => {
   removeThemeStyle();
 
-  if (theme === "default") {
-    return; // Use base CSS for default theme
-  }
-
-  const css = THEME_CONTENT[theme];
+  const css = RESOLVED_THEMES[theme].content;
   if (css) {
     const style = document.createElement("style");
     style.id = STYLE_ELEMENT_ID;
@@ -178,19 +226,15 @@ const setThemeAttribute = (theme: ResolvedTheme): void => {
 const updateThemeColorMeta = (theme: ResolvedTheme): void => {
   const meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
   if (meta) {
-    meta.content = THEME_COLORS[theme];
+    meta.content = RESOLVED_THEMES[theme].color;
   }
-};
-
-const isDarkTheme = (theme: ResolvedTheme): boolean => {
-  return theme.endsWith("-dark") || theme.endsWith(".dark");
 };
 
 /**
  * Updates the browser native control color scheme to match the current theme.
  */
 const updateColorScheme = (theme: ResolvedTheme): void => {
-  document.documentElement.style.colorScheme = isDarkTheme(theme) ? "dark" : "light";
+  document.documentElement.style.colorScheme = getThemeMode(theme);
 };
 
 // ============================================================================
@@ -252,11 +296,7 @@ export const setupSystemThemeListener = (onThemeChange: () => void): (() => void
     return () => mediaQuery.removeEventListener("change", onThemeChange);
   }
 
-  // Legacy API (Safari < 14)
-  if (mediaQuery.addListener) {
-    mediaQuery.addListener(onThemeChange);
-    return () => mediaQuery.removeListener(onThemeChange);
-  }
-
-  return () => {};
+  // Legacy API fallback for older browsers
+  mediaQuery.addListener(onThemeChange);
+  return () => mediaQuery.removeListener(onThemeChange);
 };


### PR DESCRIPTION
## Summary

This PR adds the full set of official Catppuccin flavors as native Memos themes:

- **Catppuccin Latte**
- **Catppuccin Frappé**
- **Catppuccin Macchiato**
- **Catppuccin Mocha**

The themes are implemented as first-class theme CSS files under `web/src/themes/` and are available from the existing theme picker.

## Details

- Adds one CSS theme file per Catppuccin flavor.
- Maps Memos/Tailwind theme tokens to Catppuccin style-guide roles:
  - background pane → `base`
  - secondary panes → `mantle` / `crust`
  - surface elements → `surface0` / `surface1` / `surface2`
  - body text → `text`
  - labels and secondary text → `subtext0` / `subtext1`
  - subtle UI text → `overlay1`
  - links and tag-like elements → `blue`
  - destructive/error states → `red`
  - warnings → `yellow`
  - success states → `green`
  - selection background → `overlay2` at partial opacity
  - caret/cursor → `rosewater`
- Refactors theme metadata into a single registry containing each theme's:
  - label
  - light/dark mode
  - browser theme color
  - CSS content
- Exposes `getThemeMode()` so components no longer infer dark mode from theme name strings.
- Uses the shared theme metadata for:
  - native browser `color-scheme`
  - code block syntax highlighting
  - Mermaid diagram rendering
  - map tile selection
  - mobile/browser theme color metadata
- Extends persisted theme validation to accept the new theme IDs.

## Why

Catppuccin is a popular community color palette with four official flavors. Adding all of them natively gives users complete Catppuccin support without relying on instance-level custom CSS injection.

The theme registry refactor also makes future theme additions less brittle: dark/light behavior is now explicit metadata instead of ad-hoc checks like `theme.includes("dark")`.

## Testing

```bash
cd web
pnpm lint
```

Result: passed.
