### PR TITLE
feat(frontend): add Quiet Notebook theme and three-column layout

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -9,10 +9,16 @@
     <link rel="icon" type="image/webp" href="/logo.webp" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-    <meta name="theme-color" content="#faf9f5" />
+    <meta name="theme-color" content="#f4ede0" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+SC:wght@400;500;600;700&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600&family=Noto+Serif+SC:wght@500;600&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
     <!-- memos.metadata.head -->
     <title>Memos</title>
   </head>

--- a/web/src/components/MemoExplorer/TagsSection.tsx
+++ b/web/src/components/MemoExplorer/TagsSection.tsx
@@ -37,8 +37,8 @@ const TagsSection = (props: Props) => {
   };
 
   return (
-    <div className="w-full flex flex-col justify-start items-start mt-3 px-1 h-auto shrink-0 flex-nowrap">
-      <div className="flex flex-row justify-between items-center w-full gap-1 mb-1 text-sm leading-6 text-muted-foreground select-none">
+    <div className="w-full flex flex-col justify-start items-start mt-5 px-1 h-auto shrink-0 flex-nowrap">
+      <div className="flex flex-row justify-between items-center w-full gap-1 mb-2 text-[11px] leading-6 text-muted-foreground select-none uppercase tracking-[0.12em] font-semibold">
         <span>{t("common.tags")}</span>
         {tags.length > 0 && (
           <Popover>
@@ -69,16 +69,16 @@ const TagsSection = (props: Props) => {
                 <div
                   key={tag}
                   className={cn(
-                    "shrink-0 w-auto max-w-full text-sm rounded-md leading-6 flex flex-row justify-start items-center select-none cursor-pointer transition-colors",
-                    "hover:opacity-80",
-                    isActive ? "text-primary" : "text-muted-foreground",
+                    "shrink-0 w-auto max-w-full text-sm rounded-md leading-6 flex flex-row justify-start items-center select-none cursor-pointer transition-colors px-2 py-0.5",
+                    "hover:bg-muted",
+                    isActive ? "bg-accent text-accent-foreground" : "text-muted-foreground",
                   )}
                   onClick={() => handleTagClick(tag)}
                 >
-                  <HashIcon className="w-4 h-auto shrink-0" />
+                  <HashIcon className={cn("w-4 h-auto shrink-0", isActive ? "" : "text-primary opacity-70")} />
                   <div className="inline-flex flex-nowrap ml-0.5 gap-0.5 max-w-[calc(100%-16px)]">
                     <span className={cn("truncate", isActive ? "font-medium" : "")}>{tag}</span>
-                    {amount > 1 && <span className="opacity-60 shrink-0">({amount})</span>}
+                    {amount > 1 && <span className="opacity-60 shrink-0 font-mono text-xs ml-1">{amount}</span>}
                   </div>
                 </div>
               );

--- a/web/src/components/MemoView/constants.ts
+++ b/web/src/components/MemoView/constants.ts
@@ -1,4 +1,4 @@
 export const MEMO_CARD_BASE_CLASSES =
-  "relative group flex flex-col justify-start items-start bg-card w-full px-4 py-3 mb-2 gap-2 text-card-foreground rounded-lg border border-border transition-colors";
+  "memo-card relative group flex flex-col justify-start items-start bg-card w-full px-5 py-4 mb-2 gap-2 text-card-foreground rounded-xl border border-border shadow-sm hover:shadow transition-all";
 
 export const RELATIVE_TIME_THRESHOLD_MS = 1000 * 60 * 60 * 24;

--- a/web/src/components/Navigation.tsx
+++ b/web/src/components/Navigation.tsx
@@ -91,10 +91,10 @@ const Navigation = (props: Props) => {
             <NavLink
               className={({ isActive }) =>
                 cn(
-                  "px-2 py-2 rounded-2xl border flex flex-row items-center text-lg text-sidebar-foreground transition-colors",
+                  "nav-rail-item px-2 py-2 rounded-2xl border flex flex-row items-center text-lg text-sidebar-foreground transition-colors",
                   collapsed ? "" : "w-full px-4",
                   isActive
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground border-sidebar-accent-border drop-shadow"
+                    ? "is-active bg-sidebar-accent text-sidebar-accent-foreground border-sidebar-accent-border drop-shadow"
                     : "border-transparent hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:border-sidebar-accent-border opacity-80",
                 )
               }

--- a/web/src/components/SearchBar.tsx
+++ b/web/src/components/SearchBar.tsx
@@ -34,16 +34,19 @@ const SearchBar = () => {
 
   return (
     <div className="relative w-full h-auto flex flex-row justify-start items-center">
-      <SearchIcon className="absolute left-2 w-4 h-auto opacity-40 text-sidebar-foreground" />
+      <SearchIcon className="absolute left-3 w-4 h-auto opacity-50 text-sidebar-foreground" />
       <input
-        className={cn("w-full text-sidebar-foreground leading-6 bg-sidebar border border-border text-sm rounded-lg p-1 pl-8 outline-0")}
+        className={cn(
+          "w-full text-sidebar-foreground leading-6 bg-card border border-border text-sm rounded-lg py-2 pl-9 pr-9 outline-0 shadow-xs",
+          "transition-shadow focus:shadow-sm",
+        )}
         placeholder={t("memo.search-placeholder")}
         value={queryText}
         onChange={onTextChange}
         onKeyDown={onKeyDown}
         ref={inputRef}
       />
-      <MemoDisplaySettingMenu className="absolute right-2 top-2 text-sidebar-foreground" />
+      <MemoDisplaySettingMenu className="absolute right-2 top-2.5 text-sidebar-foreground" />
     </div>
   );
 };

--- a/web/src/components/StatisticsView/MonthNavigator.tsx
+++ b/web/src/components/StatisticsView/MonthNavigator.tsx
@@ -48,7 +48,7 @@ export const MonthNavigator = memo(({ visibleMonth, onMonthChange, activityStats
         <DialogTrigger asChild>
           <button
             type="button"
-            className="py-0.5 text-sm text-foreground font-medium transition-colors hover:text-foreground/80 select-none"
+            className="month-navigator-title py-0.5 text-sm text-foreground font-semibold transition-colors hover:text-foreground/80 select-none"
           >
             {monthLabel}
           </button>

--- a/web/src/layouts/MainLayout.tsx
+++ b/web/src/layouts/MainLayout.tsx
@@ -12,9 +12,12 @@ import { Routes } from "@/router";
 
 const ARCHIVED_ROUTE = "/archived";
 const PROFILE_ROUTE = "/u/:username";
-const DESKTOP_EXPLORER_WIDTH_CLASS = "w-64";
-const DESKTOP_EXPLORER_CLASS_NAME = cn("sticky top-0 h-svh shrink-0 border-r border-border transition-all", DESKTOP_EXPLORER_WIDTH_CLASS);
-const MAIN_CONTENT_CLASS_NAME = "w-full min-h-full min-w-0 flex-1";
+const DESKTOP_EXPLORER_WIDTH_CLASS = "w-72";
+const DESKTOP_EXPLORER_CLASS_NAME = cn(
+  "memo-explorer-panel sticky top-0 h-svh shrink-0 border-l border-border transition-all hidden lg:block",
+  DESKTOP_EXPLORER_WIDTH_CLASS,
+);
+const MAIN_CONTENT_CLASS_NAME = "w-full min-h-full min-w-0 flex-1 order-1";
 
 const MainLayout = () => {
   const md = useMediaQuery("md");
@@ -71,16 +74,16 @@ const MainLayout = () => {
   return (
     <section className="@container w-full min-h-full flex flex-col justify-start items-center md:flex-row md:items-start">
       {!md && <MobileHeader>{showMemoExplorer && <MemoExplorerDrawer {...memoExplorerProps} />}</MobileHeader>}
-      {md && showMemoExplorer && (
-        <div className={DESKTOP_EXPLORER_CLASS_NAME}>
-          <MemoExplorer className="px-3 py-6" {...memoExplorerProps} />
-        </div>
-      )}
       <div className={MAIN_CONTENT_CLASS_NAME}>
-        <div className={cn("w-full mx-auto px-4 sm:px-6 md:pt-6 pb-8")}>
+        <div className={cn("w-full mx-auto px-4 sm:px-6 md:pt-6 pb-8 max-w-3xl")}>
           <Outlet />
         </div>
       </div>
+      {md && showMemoExplorer && (
+        <div className={DESKTOP_EXPLORER_CLASS_NAME}>
+          <MemoExplorer className="px-4 py-6" {...memoExplorerProps} />
+        </div>
+      )}
     </section>
   );
 };

--- a/web/src/themes/notebook-dark.css
+++ b/web/src/themes/notebook-dark.css
@@ -1,0 +1,157 @@
+/* ─────────────────────────────────────────────
+   memos · Quiet Notebook (dark)
+   ───────────────────────────────────────────── */
+
+:root {
+  --notebook-bg: #1a1612;
+  --notebook-bg-sunk: #15110e;
+  --notebook-surface: #221d18;
+  --notebook-surface-2: #2a241e;
+  --notebook-line: rgba(255, 235, 200, 0.08);
+  --notebook-line-strong: rgba(255, 235, 200, 0.16);
+
+  --notebook-ink: #ebe3d3;
+  --notebook-ink-2: #b8ac96;
+  --notebook-ink-3: #8a7e6a;
+  --notebook-ink-4: #5b5145;
+
+  --notebook-accent: #e26b54;
+  --notebook-accent-soft: #3a241c;
+  --notebook-accent-ink: #f0aa97;
+
+  --background: var(--notebook-bg);
+  --foreground: var(--notebook-ink);
+  --card: var(--notebook-surface);
+  --card-foreground: var(--notebook-ink);
+  --popover: var(--notebook-surface);
+  --popover-foreground: var(--notebook-ink);
+  --primary: var(--notebook-accent);
+  --primary-foreground: #1a1612;
+  --secondary: var(--notebook-surface-2);
+  --secondary-foreground: var(--notebook-ink);
+  --muted: var(--notebook-surface-2);
+  --muted-foreground: var(--notebook-ink-3);
+  --accent: var(--notebook-accent-soft);
+  --accent-foreground: var(--notebook-accent-ink);
+  --destructive: #c84a3a;
+  --destructive-foreground: #ffffff;
+  --border: var(--notebook-line);
+  --input: var(--notebook-line-strong);
+  --ring: var(--notebook-accent);
+  --sidebar: var(--notebook-bg);
+  --sidebar-foreground: var(--notebook-ink-2);
+  --sidebar-accent: var(--notebook-surface);
+  --sidebar-accent-foreground: var(--notebook-ink);
+
+  --font-sans:
+    "Inter", "Noto Sans SC", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-serif: "Source Serif 4", "Source Han Serif SC", "Noto Serif SC", Georgia, Cambria, "Times New Roman", Times, serif;
+  --font-mono:
+    "JetBrains Mono", "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  --radius: 0.875rem;
+
+  --shadow-xs: 0 1px 0 rgba(0, 0, 0, 0.4);
+  --shadow-sm: 0 1px 0 rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.25);
+  --shadow: 0 1px 0 rgba(0, 0, 0, 0.4), 0 2px 6px rgba(0, 0, 0, 0.25), 0 12px 24px -16px rgba(0, 0, 0, 0.5);
+  --shadow-md: 0 8px 18px -4px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 8px 18px -4px rgba(0, 0, 0, 0.45), 0 24px 40px -20px rgba(0, 0, 0, 0.6);
+  --shadow-xl: 0 24px 60px -20px rgba(0, 0, 0, 0.7);
+  --shadow-2xl: 0 24px 60px -20px rgba(0, 0, 0, 0.7);
+}
+
+/* ─── Typography polish ─── */
+body,
+html {
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "cv11", "ss01", "ss03";
+  letter-spacing: -0.005em;
+}
+
+/* Page titles use serif */
+.notebook-title,
+h1.notebook-title,
+.notebook h1 {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--notebook-ink);
+}
+
+/* Mono details */
+.notebook-mono,
+[data-notebook-mono] {
+  font-family: var(--font-mono);
+  font-feature-settings: "tnum";
+}
+
+/* ─── Memo card paper feel ─── */
+[data-theme="notebook-dark"] article.bg-card,
+[data-theme="notebook-dark"] .memo-card {
+  border: 1px solid var(--notebook-line);
+  border-radius: 14px;
+  box-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.4),
+    0 2px 6px rgba(0, 0, 0, 0.25),
+    0 12px 24px -16px rgba(0, 0, 0, 0.5);
+  transition:
+    box-shadow 180ms ease,
+    transform 180ms ease,
+    border-color 180ms ease;
+}
+[data-theme="notebook-dark"] article.bg-card:hover,
+[data-theme="notebook-dark"] .memo-card:hover {
+  box-shadow: 0 8px 18px -4px rgba(0, 0, 0, 0.45);
+  border-color: var(--notebook-line-strong);
+}
+
+/* ─── Left rail (Navigation) terracotta active indicator ─── */
+[data-theme="notebook-dark"] .nav-rail-item {
+  position: relative;
+}
+[data-theme="notebook-dark"] .nav-rail-item.is-active::before {
+  content: "";
+  position: absolute;
+  left: -10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 18px;
+  background: var(--notebook-accent);
+  border-radius: 0 3px 3px 0;
+}
+
+/* ─── Memo Editor surface ─── */
+[data-theme="notebook-dark"] .memo-editor,
+[data-theme="notebook-dark"] .memo-editor-container {
+  background: var(--notebook-surface);
+  border: 1px solid var(--notebook-line);
+  border-radius: 14px;
+  box-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.4),
+    0 2px 6px rgba(0, 0, 0, 0.25);
+  transition:
+    box-shadow 200ms ease,
+    border-color 200ms ease;
+}
+[data-theme="notebook-dark"] .memo-editor:focus-within,
+[data-theme="notebook-dark"] .memo-editor-container:focus-within {
+  box-shadow: 0 8px 18px -4px rgba(0, 0, 0, 0.45);
+  border-color: var(--notebook-line-strong);
+}
+
+/* ─── Right side panel (Memo Explorer) ─── */
+[data-theme="notebook-dark"] .memo-explorer-panel {
+  background: var(--notebook-bg);
+  border-left: 1px solid var(--notebook-line);
+  border-right: 0;
+}
+
+/* ─── Calendar tweaks: slightly serif title ─── */
+[data-theme="notebook-dark"] .month-navigator-title {
+  font-family: var(--font-serif);
+  letter-spacing: -0.01em;
+}

--- a/web/src/themes/notebook.css
+++ b/web/src/themes/notebook.css
@@ -1,0 +1,208 @@
+/* ─────────────────────────────────────────────
+   memos · Quiet Notebook (light)
+   Warm paper palette + terracotta accent.
+   ───────────────────────────────────────────── */
+
+:root {
+  /* Warm paper palette */
+  --notebook-bg: #f4ede0;
+  --notebook-bg-sunk: #ece4d3;
+  --notebook-surface: #fffdf7;
+  --notebook-surface-2: #f8f2e3;
+  --notebook-line: rgba(60, 40, 20, 0.08);
+  --notebook-line-strong: rgba(60, 40, 20, 0.14);
+
+  --notebook-ink: #2a241d;
+  --notebook-ink-2: #5b5043;
+  --notebook-ink-3: #8a7e6e;
+  --notebook-ink-4: #b8ad9b;
+
+  --notebook-accent: #c84a3a;
+  --notebook-accent-soft: #f4ddd6;
+  --notebook-accent-ink: #9c3526;
+
+  /* Map design tokens to app tokens (shadcn / tailwind v4) */
+  --background: var(--notebook-bg);
+  --foreground: var(--notebook-ink);
+  --card: var(--notebook-surface);
+  --card-foreground: var(--notebook-ink);
+  --popover: var(--notebook-surface);
+  --popover-foreground: var(--notebook-ink);
+  --primary: var(--notebook-accent);
+  --primary-foreground: #ffffff;
+  --secondary: var(--notebook-surface-2);
+  --secondary-foreground: var(--notebook-ink);
+  --muted: var(--notebook-surface-2);
+  --muted-foreground: var(--notebook-ink-3);
+  --accent: var(--notebook-accent-soft);
+  --accent-foreground: var(--notebook-accent-ink);
+  --destructive: #b03525;
+  --destructive-foreground: #ffffff;
+  --border: var(--notebook-line);
+  --input: var(--notebook-line-strong);
+  --ring: var(--notebook-accent);
+  --sidebar: var(--notebook-bg);
+  --sidebar-foreground: var(--notebook-ink-2);
+  --sidebar-accent: var(--notebook-surface);
+  --sidebar-accent-foreground: var(--notebook-ink);
+
+  --font-sans:
+    "Inter", "Noto Sans SC", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-serif: "Source Serif 4", "Source Han Serif SC", "Noto Serif SC", Georgia, Cambria, "Times New Roman", Times, serif;
+  --font-mono:
+    "JetBrains Mono", "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  --radius: 0.875rem;
+
+  --shadow-xs: 0 1px 0 rgba(60, 40, 20, 0.04);
+  --shadow-sm: 0 1px 0 rgba(60, 40, 20, 0.04), 0 2px 6px rgba(60, 40, 20, 0.04);
+  --shadow: 0 1px 0 rgba(60, 40, 20, 0.04), 0 2px 6px rgba(60, 40, 20, 0.04), 0 12px 24px -16px rgba(60, 40, 20, 0.1);
+  --shadow-md: 0 2px 0 rgba(60, 40, 20, 0.04), 0 8px 18px -4px rgba(60, 40, 20, 0.12);
+  --shadow-lg: 0 2px 0 rgba(60, 40, 20, 0.04), 0 8px 18px -4px rgba(60, 40, 20, 0.12), 0 24px 40px -20px rgba(60, 40, 20, 0.18);
+  --shadow-xl: 0 24px 60px -20px rgba(60, 40, 20, 0.3);
+  --shadow-2xl: 0 24px 60px -20px rgba(60, 40, 20, 0.3);
+}
+
+/* ─── Typography polish ─── */
+body,
+html {
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "cv11", "ss01", "ss03";
+  letter-spacing: -0.005em;
+}
+
+/* Page titles use serif */
+.notebook-title,
+h1.notebook-title,
+.notebook h1 {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--notebook-ink);
+}
+
+/* Mono details */
+.notebook-mono,
+[data-notebook-mono] {
+  font-family: var(--font-mono);
+  font-feature-settings: "tnum";
+}
+
+/* ─── Memo card paper feel ─── */
+[data-theme="notebook"] article.bg-card,
+[data-theme="notebook"] .memo-card {
+  border: 1px solid var(--notebook-line);
+  border-radius: 14px;
+  box-shadow:
+    0 1px 0 rgba(60, 40, 20, 0.04),
+    0 2px 6px rgba(60, 40, 20, 0.04),
+    0 12px 24px -16px rgba(60, 40, 20, 0.1);
+  transition:
+    box-shadow 180ms ease,
+    transform 180ms ease,
+    border-color 180ms ease;
+}
+[data-theme="notebook"] article.bg-card:hover,
+[data-theme="notebook"] .memo-card:hover {
+  box-shadow:
+    0 2px 0 rgba(60, 40, 20, 0.04),
+    0 8px 18px -4px rgba(60, 40, 20, 0.12);
+  border-color: var(--notebook-line-strong);
+}
+
+/* ─── Left rail (Navigation) terracotta active indicator ─── */
+[data-theme="notebook"] .nav-rail-item {
+  position: relative;
+}
+[data-theme="notebook"] .nav-rail-item.is-active::before {
+  content: "";
+  position: absolute;
+  left: -10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 18px;
+  background: var(--notebook-accent);
+  border-radius: 0 3px 3px 0;
+}
+
+/* ─── Logo serif "m" ─── */
+[data-theme="notebook"] .notebook-logo {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: #ffffff;
+  background: var(--notebook-accent);
+  box-shadow: var(--shadow);
+}
+
+/* ─── Generic helpers used by redesign ─── */
+[data-theme="notebook"] .notebook-divider-dashed {
+  border-top: 1px dashed var(--notebook-line);
+}
+[data-theme="notebook"] .notebook-section-eyebrow {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--notebook-ink-3);
+  font-weight: 600;
+}
+
+/* ─── Tags inline ─── */
+[data-theme="notebook"] .memo-content .tag-link,
+[data-theme="notebook"] .tag-pill {
+  color: var(--notebook-accent);
+  background: var(--notebook-accent-soft);
+  padding: 1px 6px;
+  border-radius: 5px;
+  font-size: 0.88em;
+}
+
+/* ─── Compose / editor surface ─── */
+[data-theme="notebook"] .memo-editor,
+[data-theme="notebook"] .memo-editor-container {
+  background: var(--notebook-surface);
+  border: 1px solid var(--notebook-line);
+  border-radius: 14px;
+  box-shadow:
+    0 1px 0 rgba(60, 40, 20, 0.04),
+    0 2px 6px rgba(60, 40, 20, 0.04),
+    0 12px 24px -16px rgba(60, 40, 20, 0.1);
+  transition:
+    box-shadow 200ms ease,
+    border-color 200ms ease;
+}
+[data-theme="notebook"] .memo-editor:focus-within,
+[data-theme="notebook"] .memo-editor-container:focus-within {
+  box-shadow:
+    0 2px 0 rgba(60, 40, 20, 0.04),
+    0 8px 18px -4px rgba(60, 40, 20, 0.12),
+    0 24px 40px -20px rgba(60, 40, 20, 0.18);
+  border-color: var(--notebook-line-strong);
+}
+
+/* ─── Right side panel (Memo Explorer) ─── */
+[data-theme="notebook"] .memo-explorer-panel {
+  background: var(--notebook-bg);
+  border-left: 1px solid var(--notebook-line);
+  border-right: 0;
+}
+
+/* ─── Calendar tweaks: slightly serif title ─── */
+[data-theme="notebook"] .month-navigator-title {
+  font-family: var(--font-serif);
+  letter-spacing: -0.01em;
+}
+
+/* ─── Settings panel ─── */
+[data-theme="notebook"] .settings-panel-card {
+  background: var(--notebook-surface);
+  border: 1px solid var(--notebook-line);
+  border-radius: 14px;
+  box-shadow:
+    0 1px 0 rgba(60, 40, 20, 0.04),
+    0 2px 6px rgba(60, 40, 20, 0.04);
+}

--- a/web/src/utils/theme.ts
+++ b/web/src/utils/theme.ts
@@ -1,11 +1,13 @@
 import defaultDarkThemeContent from "../themes/default-dark.css?raw";
+import notebookThemeContent from "../themes/notebook.css?raw";
+import notebookDarkThemeContent from "../themes/notebook-dark.css?raw";
 import paperThemeContent from "../themes/paper.css?raw";
 
 // ============================================================================
 // Types and Constants
 // ============================================================================
 
-const VALID_THEMES = ["system", "default", "default-dark", "paper"] as const;
+const VALID_THEMES = ["system", "default", "default-dark", "paper", "notebook", "notebook-dark"] as const;
 
 export type Theme = (typeof VALID_THEMES)[number];
 export type ResolvedTheme = Exclude<Theme, "system">;
@@ -22,16 +24,22 @@ const THEME_CONTENT: Record<ResolvedTheme, string | null> = {
   default: null,
   "default-dark": defaultDarkThemeContent,
   paper: paperThemeContent,
+  notebook: notebookThemeContent,
+  "notebook-dark": notebookDarkThemeContent,
 };
 
 const THEME_COLORS: Record<ResolvedTheme, string> = {
   default: "#faf9f5",
   "default-dark": "#1d1f23",
   paper: "#f5ede4",
+  notebook: "#f4ede0",
+  "notebook-dark": "#1a1612",
 };
 
 export const THEME_OPTIONS: ThemeOption[] = [
   { value: "system", label: "Sync with system" },
+  { value: "notebook", label: "Notebook" },
+  { value: "notebook-dark", label: "Notebook (Dark)" },
   { value: "default", label: "Light" },
   { value: "default-dark", label: "Dark" },
   { value: "paper", label: "Paper" },
@@ -55,9 +63,9 @@ const validateTheme = (theme: string): Theme => {
  */
 export const getSystemTheme = (): ResolvedTheme => {
   if (typeof window !== "undefined" && window.matchMedia?.("(prefers-color-scheme: dark)").matches) {
-    return "default-dark";
+    return "notebook-dark";
   }
-  return "default";
+  return "notebook";
 };
 
 /**


### PR DESCRIPTION
Implements the warm-paper "Quiet Notebook" redesign:

- Add `notebook` and `notebook-dark` themes mapping the design's terracotta
  + cream/ink palette to existing shadcn tokens
- Load Inter / Source Serif 4 / Noto Sans SC / JetBrains Mono via Google Fonts
- Make notebook the default for new users (system theme resolution)
- Move the MemoExplorer (calendar, stats, tags) to the right side and widen the main content column to match the three-column shell
- Add terracotta active indicator and `.nav-rail-item` hook on Navigation
- Polish memo cards with paper-feel shadows and 14px rounded corners
- Polish SearchBar surface, tag pills, calendar serif title, and TagsSection eyebrow header

https://claude.ai/code/session_01L4ksV2qVpEkBfeXQDyuBj6