### PR TITLE
fix: avoid update event on memo create attachments

### DIFF
--- a/server/router/api/v1/memo_service.go
+++ b/server/router/api/v1/memo_service.go
@@ -130,11 +130,7 @@ func (s *APIV1Service) CreateMemo(ctx context.Context, request *v1pb.CreateMemoR
 	attachments := []*store.Attachment{}
 
 	if len(request.Memo.Attachments) > 0 {
-		_, err := s.SetMemoAttachments(ctx, &v1pb.SetMemoAttachmentsRequest{
-			Name:        fmt.Sprintf("%s%s", MemoNamePrefix, memo.UID),
-			Attachments: request.Memo.Attachments,
-		})
-		if err != nil {
+		if err := s.setMemoAttachmentsInternal(ctx, user, memo, request.Memo.Attachments); err != nil {
 			return nil, errors.Wrap(err, "failed to set memo attachments")
 		}
 
@@ -147,11 +143,7 @@ func (s *APIV1Service) CreateMemo(ctx context.Context, request *v1pb.CreateMemoR
 		attachments = a
 	}
 	if len(request.Memo.Relations) > 0 {
-		_, err := s.SetMemoRelations(ctx, &v1pb.SetMemoRelationsRequest{
-			Name:      fmt.Sprintf("%s%s", MemoNamePrefix, memo.UID),
-			Relations: request.Memo.Relations,
-		})
-		if err != nil {
+		if err := s.setMemoRelationsInternal(ctx, memo, request.Memo.Relations); err != nil {
 			return nil, errors.Wrap(err, "failed to set memo relations")
 		}
 	}

--- a/server/router/api/v1/sse_service_test.go
+++ b/server/router/api/v1/sse_service_test.go
@@ -113,6 +113,48 @@ func TestCreateMemoComment_NoDuplicateSSEBroadcast(t *testing.T) {
 		"expected memo.comment.created, got: %s", events[0])
 }
 
+func TestCreateMemoWithAttachment_NoDuplicateUpdatedSSEBroadcast(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t)
+
+	user, err := svc.Store.CreateUser(ctx, &store.User{
+		Username: "user", Role: store.RoleAdmin, Email: "user@example.com",
+	})
+	require.NoError(t, err)
+	uctx := userCtx(ctx, user.ID)
+
+	attachment, err := svc.CreateAttachment(uctx, &v1pb.CreateAttachmentRequest{
+		Attachment: &v1pb.Attachment{
+			Filename: "test.txt",
+			Size:     5,
+			Type:     "text/plain",
+			Content:  []byte("hello"),
+		},
+	})
+	require.NoError(t, err)
+
+	client := svc.SSEHub.Subscribe(user.ID, store.RoleAdmin)
+	defer svc.SSEHub.Unsubscribe(client)
+
+	memo, err := svc.CreateMemo(uctx, &v1pb.CreateMemoRequest{
+		Memo: &v1pb.Memo{
+			Content:    "memo with initial attachment",
+			Visibility: v1pb.Visibility_PUBLIC,
+			Attachments: []*v1pb.Attachment{
+				{Name: attachment.Name},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	events := collectEventsFor(client.events, 150*time.Millisecond)
+
+	require.Len(t, events, 1, "expected exactly one SSE event for memo creation with attachment, got: %v", events)
+	assert.Contains(t, events[0], `"memo.created"`)
+	assert.Contains(t, events[0], memo.Name)
+	assert.NotContains(t, events[0], `"memo.updated"`)
+}
+
 // ---- Reaction SSE events carry correct visibility / parent fields ----
 
 func TestUpsertMemoReaction_SSEEvent(t *testing.T) {


### PR DESCRIPTION
## Summary
- Link initial memo attachments and relations through internal helpers during `CreateMemo`.
- Preserve `memo.updated` side effects for explicit attachment/relation updates after creation.
- Add a regression test for creating a memo with an initial attachment.

## Root cause
`CreateMemo` called `SetMemoAttachments` and `SetMemoRelations` for initial memo data. Those public setters intentionally touch `updated_ts` and dispatch memo-updated side effects, so a single create request with an attachment could emit both `memos.memo.updated` and `memos.memo.created`.

Fixes #5953.

## Test plan
- `go test ./server/router/api/v1 -run 'TestCreateMemoWithAttachment_NoDuplicateUpdatedSSEBroadcast|TestSetMemoAttachments_EmitsMemoUpdatedSSEEvent|TestSetMemoRelations_EmitsMemoUpdatedSSEEvent' -count=1`
- `go test ./server/router/api/v1/test -run TestSetMemoAttachments -count=1`
- `go test ./server/router/api/v1/... -count=1`