### PR TITLE
feat(api): implement ListUsers pagination

### DIFF
--- a/server/router/api/v1/test/user_service_pagination_test.go
+++ b/server/router/api/v1/test/user_service_pagination_test.go
@@ -1,0 +1,57 @@
+package test
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	apiv1 "github.com/usememos/memos/proto/gen/api/v1"
+)
+
+func TestListUsersPaginates(t *testing.T) {
+	ctx := context.Background()
+
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+
+	// Create 3 users
+	for i := 0; i < 3; i++ {
+		_, err := ts.CreateRegularUser(ctx, fmt.Sprintf("pagination-user-%d", i))
+		require.NoError(t, err)
+	}
+
+	admin, err := ts.CreateAdminUser(ctx, "admin-paginator")
+	require.NoError(t, err)
+	adminCtx := ts.CreateUserContext(ctx, admin.ID)
+
+	// Fetch first page, limited to 2
+	firstPage, err := ts.Service.ListUsers(adminCtx, &apiv1.ListUsersRequest{PageSize: 2})
+	require.NoError(t, err)
+	require.NotEmpty(t, firstPage.NextPageToken)
+
+	// Fetch second page
+	secondPage, err := ts.Service.ListUsers(adminCtx, &apiv1.ListUsersRequest{
+		PageSize: 2,
+		PageToken: firstPage.NextPageToken,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, secondPage.Users)
+	
+	// Negative offset test
+	pageTokenBytes, err := proto.Marshal(&apiv1.PageToken{Offset: -1})
+	require.NoError(t, err)
+	badToken := base64.StdEncoding.EncodeToString(pageTokenBytes)
+
+	_, err = ts.Service.ListUsers(adminCtx, &apiv1.ListUsersRequest{
+		PageToken: badToken,
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Contains(t, err.Error(), "offset must not be negative")
+}

--- a/server/router/api/v1/user_service.go
+++ b/server/router/api/v1/user_service.go
@@ -72,6 +72,9 @@ func (s *APIV1Service) ListUsers(ctx context.Context, request *v1pb.ListUsersReq
 			return nil, status.Errorf(codes.InvalidArgument, "invalid page token: %v", err)
 		}
 		offset = int(pageToken.Offset)
+		if offset < 0 {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid page token: offset must not be negative")
+		}
 		userFind.Offset = &offset
 	}
 

--- a/server/router/api/v1/user_service.go
+++ b/server/router/api/v1/user_service.go
@@ -61,25 +61,29 @@ func (s *APIV1Service) ListUsers(ctx context.Context, request *v1pb.ListUsersReq
 		}
 	}
 	
-	limit := int(request.PageSize)
-	if limit <= 0 {
-		limit = 50
-	} else if limit > 1000 {
-		limit = 1000
-	}
-	userFind.Limit = &limit
-	
+	limit := normalizePageSize(request.PageSize)
+	limitPlusOne := limit + 1
+	userFind.Limit = &limitPlusOne
+
+	var offset int
 	if request.PageToken != "" {
-		offset, err := strconv.Atoi(request.PageToken)
-		if err != nil {
+		var pageToken v1pb.PageToken
+		if err := unmarshalPageToken(request.PageToken, &pageToken); err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid page token: %v", err)
 		}
+		offset = int(pageToken.Offset)
 		userFind.Offset = &offset
 	}
 
 	users, err := s.Store.ListUsers(ctx, userFind)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to list users: %v", err)
+	}
+
+	var hasNextPage bool
+	if len(users) > limit {
+		users = users[:limit]
+		hasNextPage = true
 	}
 
 	response := &v1pb.ListUsersResponse{
@@ -89,15 +93,15 @@ func (s *APIV1Service) ListUsers(ctx context.Context, request *v1pb.ListUsersReq
 	for _, user := range users {
 		response.Users = append(response.Users, convertUserFromStore(user, currentUser))
 	}
-	
-	if len(users) == limit {
-		nextOffset := 0
-		if request.PageToken != "" {
-			nextOffset, _ = strconv.Atoi(request.PageToken)
+
+	if hasNextPage {
+		nextPageToken, err := getPageToken(limit, offset+limit)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to get next page token: %v", err)
 		}
-		response.NextPageToken = strconv.Itoa(nextOffset + limit)
+		response.NextPageToken = nextPageToken
 	}
-	
+
 	return response, nil
 }
 

--- a/server/router/api/v1/user_service.go
+++ b/server/router/api/v1/user_service.go
@@ -60,14 +60,28 @@ func (s *APIV1Service) ListUsers(ctx context.Context, request *v1pb.ListUsersReq
 			userFind.Username = &username
 		}
 	}
+	
+	limit := int(request.PageSize)
+	if limit <= 0 {
+		limit = 50
+	} else if limit > 1000 {
+		limit = 1000
+	}
+	userFind.Limit = &limit
+	
+	if request.PageToken != "" {
+		offset, err := strconv.Atoi(request.PageToken)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid page token: %v", err)
+		}
+		userFind.Offset = &offset
+	}
 
 	users, err := s.Store.ListUsers(ctx, userFind)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to list users: %v", err)
 	}
 
-	// TODO: Implement proper ordering, and pagination
-	// For now, return all users with basic structure
 	response := &v1pb.ListUsersResponse{
 		Users:     []*v1pb.User{},
 		TotalSize: int32(len(users)),
@@ -75,6 +89,15 @@ func (s *APIV1Service) ListUsers(ctx context.Context, request *v1pb.ListUsersReq
 	for _, user := range users {
 		response.Users = append(response.Users, convertUserFromStore(user, currentUser))
 	}
+	
+	if len(users) == limit {
+		nextOffset := 0
+		if request.PageToken != "" {
+			nextOffset, _ = strconv.Atoi(request.PageToken)
+		}
+		response.NextPageToken = strconv.Itoa(nextOffset + limit)
+	}
+	
 	return response, nil
 }
 

--- a/store/db/mysql/user.go
+++ b/store/db/mysql/user.go
@@ -147,9 +147,11 @@ func (d *DB) ListUsers(ctx context.Context, find *store.FindUser) ([]*store.User
 	query := "SELECT `id`, `username`, `role`, `email`, `nickname`, `password_hash`, `avatar_url`, `description`, UNIX_TIMESTAMP(`created_ts`), UNIX_TIMESTAMP(`updated_ts`), `row_status` FROM `user` WHERE " + strings.Join(where, " AND ") + " ORDER BY " + strings.Join(orderBy, ", ")
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)
-	}
-	if v := find.Offset; v != nil {
-		query += fmt.Sprintf(" OFFSET %d", *v)
+		if v := find.Offset; v != nil {
+			query += fmt.Sprintf(" OFFSET %d", *v)
+		}
+	} else if find.Offset != nil {
+		return nil, errors.Errorf("offset provided without limit")
 	}
 	rows, err := d.db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/store/db/mysql/user.go
+++ b/store/db/mysql/user.go
@@ -148,6 +148,9 @@ func (d *DB) ListUsers(ctx context.Context, find *store.FindUser) ([]*store.User
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)
 	}
+	if v := find.Offset; v != nil {
+		query += fmt.Sprintf(" OFFSET %d", *v)
+	}
 	rows, err := d.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err

--- a/store/db/mysql/user.go
+++ b/store/db/mysql/user.go
@@ -83,7 +83,7 @@ func (d *DB) UpdateUser(ctx context.Context, update *store.UpdateUser) (*store.U
 
 func (d *DB) ListUsers(ctx context.Context, find *store.FindUser) ([]*store.User, error) {
 	where, args := []string{"1 = 1"}, []any{}
-	orderBy := []string{"`created_ts` DESC", "`row_status` DESC"}
+	orderBy := []string{"`created_ts` DESC", "`row_status` DESC", "`id` DESC"}
 
 	if len(find.Filters) > 0 {
 		return nil, errors.Errorf("user filters are not supported")
@@ -141,6 +141,7 @@ func (d *DB) ListUsers(ctx context.Context, find *store.FindUser) ([]*store.User
 			"CHAR_LENGTH(`username`) ASC",
 			"`created_ts` DESC",
 			"`row_status` DESC",
+			"`id` DESC",
 		}
 		args = append(args, query, query+"%", query+"%")
 	}

--- a/store/db/postgres/user.go
+++ b/store/db/postgres/user.go
@@ -157,6 +157,9 @@ func (d *DB) ListUsers(ctx context.Context, find *store.FindUser) ([]*store.User
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)
 	}
+	if v := find.Offset; v != nil {
+		query += fmt.Sprintf(" OFFSET %d", *v)
+	}
 	rows, err := d.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err

--- a/store/db/postgres/user.go
+++ b/store/db/postgres/user.go
@@ -86,7 +86,7 @@ func (d *DB) UpdateUser(ctx context.Context, update *store.UpdateUser) (*store.U
 
 func (d *DB) ListUsers(ctx context.Context, find *store.FindUser) ([]*store.User, error) {
 	where, args := []string{"1 = 1"}, []any{}
-	orderBy := []string{"created_ts DESC", "row_status DESC"}
+	orderBy := []string{"created_ts DESC", "row_status DESC", "id DESC"}
 
 	if len(find.Filters) > 0 {
 		return nil, errors.Errorf("user filters are not supported")
@@ -136,6 +136,7 @@ func (d *DB) ListUsers(ctx context.Context, find *store.FindUser) ([]*store.User
 			"LENGTH(username) ASC",
 			"created_ts DESC",
 			"row_status DESC",
+			"id DESC",
 		}
 		args = append(args, query, query+"%", query+"%")
 	}

--- a/store/db/postgres/user.go
+++ b/store/db/postgres/user.go
@@ -156,9 +156,11 @@ func (d *DB) ListUsers(ctx context.Context, find *store.FindUser) ([]*store.User
 		WHERE ` + strings.Join(where, " AND ") + ` ORDER BY ` + strings.Join(orderBy, ", ")
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)
-	}
-	if v := find.Offset; v != nil {
-		query += fmt.Sprintf(" OFFSET %d", *v)
+		if v := find.Offset; v != nil {
+			query += fmt.Sprintf(" OFFSET %d", *v)
+		}
+	} else if find.Offset != nil {
+		return nil, errors.Errorf("offset provided without limit")
 	}
 	rows, err := d.db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/store/db/sqlite/user.go
+++ b/store/db/sqlite/user.go
@@ -87,7 +87,7 @@ func (d *DB) UpdateUser(ctx context.Context, update *store.UpdateUser) (*store.U
 
 func (d *DB) ListUsers(ctx context.Context, find *store.FindUser) ([]*store.User, error) {
 	where, args := []string{"1 = 1"}, []any{}
-	orderBy := []string{"created_ts DESC", "row_status DESC"}
+	orderBy := []string{"created_ts DESC", "row_status DESC", "id DESC"}
 
 	if len(find.Filters) > 0 {
 		return nil, errors.Errorf("user filters are not supported")
@@ -145,6 +145,7 @@ func (d *DB) ListUsers(ctx context.Context, find *store.FindUser) ([]*store.User
 			"LENGTH(username) ASC",
 			"created_ts DESC",
 			"row_status DESC",
+			"id DESC",
 		}
 		args = append(args, query, query+"%", query+"%")
 	}

--- a/store/db/sqlite/user.go
+++ b/store/db/sqlite/user.go
@@ -168,8 +168,8 @@ func (d *DB) ListUsers(ctx context.Context, find *store.FindUser) ([]*store.User
 		if v := find.Offset; v != nil {
 			query += fmt.Sprintf(" OFFSET %d", *v)
 		}
-	} else if v := find.Offset; v != nil {
-		query += fmt.Sprintf(" LIMIT -1 OFFSET %d", *v)
+	} else if find.Offset != nil {
+		return nil, errors.Errorf("offset provided without limit")
 	}
 
 	rows, err := d.db.QueryContext(ctx, query, args...)

--- a/store/db/sqlite/user.go
+++ b/store/db/sqlite/user.go
@@ -166,6 +166,9 @@ func (d *DB) ListUsers(ctx context.Context, find *store.FindUser) ([]*store.User
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)
 	}
+	if v := find.Offset; v != nil {
+		query += fmt.Sprintf(" OFFSET %d", *v)
+	}
 
 	rows, err := d.db.QueryContext(ctx, query, args...)
 	if err != nil {

--- a/store/db/sqlite/user.go
+++ b/store/db/sqlite/user.go
@@ -165,9 +165,11 @@ func (d *DB) ListUsers(ctx context.Context, find *store.FindUser) ([]*store.User
 		WHERE ` + strings.Join(where, " AND ") + ` ORDER BY ` + strings.Join(orderBy, ", ")
 	if v := find.Limit; v != nil {
 		query += fmt.Sprintf(" LIMIT %d", *v)
-	}
-	if v := find.Offset; v != nil {
-		query += fmt.Sprintf(" OFFSET %d", *v)
+		if v := find.Offset; v != nil {
+			query += fmt.Sprintf(" OFFSET %d", *v)
+		}
+	} else if v := find.Offset; v != nil {
+		query += fmt.Sprintf(" LIMIT -1 OFFSET %d", *v)
 	}
 
 	rows, err := d.db.QueryContext(ctx, query, args...)

--- a/store/user.go
+++ b/store/user.go
@@ -75,6 +75,9 @@ type FindUser struct {
 
 	// The maximum number of users to return.
 	Limit *int
+
+	// The number of users to skip.
+	Offset *int
 }
 
 type DeleteUser struct {


### PR DESCRIPTION
Implemented proper pagination support for `ListUsers`.\n\n- Added support for `request.PageSize` and `request.PageToken` in `server/router/api/v1/user_service.go`.\n- Handled the new `Offset` property on the `FindUser` schema across DB drivers (SQLite, PostgreSQL, MySQL).