### PR TITLE
fix: support <meta name=description> in link previews

### DIFF
--- a/internal/httpgetter/html_meta.go
+++ b/internal/httpgetter/html_meta.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -204,7 +205,7 @@ func extractHTMLMeta(resp io.Reader) *HTMLMeta {
 func extractMetaProperty(token html.Token, prop string) (content string, ok bool) {
 	content, ok = "", false
 	for _, attr := range token.Attr {
-		if (attr.Key == "property" || attr.Key == "name") && attr.Val == prop {
+		if (attr.Key == "property" || attr.Key == "name") && strings.EqualFold(attr.Val, prop) {
 			ok = true
 		}
 		if attr.Key == "content" {

--- a/internal/httpgetter/html_meta.go
+++ b/internal/httpgetter/html_meta.go
@@ -204,7 +204,7 @@ func extractHTMLMeta(resp io.Reader) *HTMLMeta {
 func extractMetaProperty(token html.Token, prop string) (content string, ok bool) {
 	content, ok = "", false
 	for _, attr := range token.Attr {
-		if attr.Key == "property" && attr.Val == prop {
+		if (attr.Key == "property" || attr.Key == "name") && attr.Val == prop {
 			ok = true
 		}
 		if attr.Key == "content" {

--- a/internal/httpgetter/html_meta.go
+++ b/internal/httpgetter/html_meta.go
@@ -176,11 +176,6 @@ func extractHTMLMeta(resp io.Reader) *HTMLMeta {
 				token := tokenizer.Token()
 				htmlMeta.Title = token.Data
 			} else if token.DataAtom == atom.Meta {
-				description, ok := extractMetaProperty(token, "description")
-				if ok {
-					htmlMeta.Description = description
-				}
-
 				ogTitle, ok := extractMetaProperty(token, "og:title")
 				if ok {
 					htmlMeta.Title = ogTitle
@@ -194,6 +189,11 @@ func extractHTMLMeta(resp io.Reader) *HTMLMeta {
 				ogImage, ok := extractMetaProperty(token, "og:image")
 				if ok {
 					htmlMeta.Image = ogImage
+				}
+
+				description, ok := extractMetaProperty(token, "description")
+				if ok && htmlMeta.Description == "" {
+					htmlMeta.Description = description
 				}
 			}
 		}

--- a/internal/httpgetter/html_meta_test.go
+++ b/internal/httpgetter/html_meta_test.go
@@ -55,6 +55,40 @@ func TestGetHTMLMeta(t *testing.T) {
 	}, *metadata)
 }
 
+func TestGetHTMLMetaWithNameOnly(t *testing.T) {
+	originalHTTPClient := httpClient
+	t.Cleanup(func() {
+		httpClient = originalHTTPClient
+	})
+
+	httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "http://93.184.216.34/blog", req.URL.String())
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
+				Body: io.NopCloser(strings.NewReader(`<!doctype html>
+<html>
+<head>
+  <title>Sample Page</title>
+  <meta name="description" content="This description should appear in the link preview.">
+</head>
+<body>Hello</body>
+</html>`)),
+				Request: req,
+			}, nil
+		}),
+	}
+
+	metadata, err := GetHTMLMeta("http://93.184.216.34/blog")
+	require.NoError(t, err)
+	require.Equal(t, HTMLMeta{
+		Title:       "Sample Page",
+		Description: "This description should appear in the link preview.",
+		Image:       "",
+	}, *metadata)
+}
+
 func TestGetHTMLMetaForInternal(t *testing.T) {
 	// test for internal IP
 	if _, err := GetHTMLMeta("http://192.168.0.1"); !errors.Is(err, ErrInternalIP) {

--- a/internal/httpgetter/html_meta_test.go
+++ b/internal/httpgetter/html_meta_test.go
@@ -89,6 +89,40 @@ func TestGetHTMLMetaWithNameOnly(t *testing.T) {
 	}, *metadata)
 }
 
+func TestGetHTMLMetaWithNameCaseInsensitive(t *testing.T) {
+	originalHTTPClient := httpClient
+	t.Cleanup(func() {
+		httpClient = originalHTTPClient
+	})
+
+	httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			require.Equal(t, "http://93.184.216.34/blog", req.URL.String())
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
+				Body: io.NopCloser(strings.NewReader(`<!doctype html>
+<html>
+<head>
+  <title>Sample Page</title>
+  <meta name="Description" content="Case insensitive description match.">
+</head>
+<body>Hello</body>
+</html>`)),
+				Request: req,
+			}, nil
+		}),
+	}
+
+	metadata, err := GetHTMLMeta("http://93.184.216.34/blog")
+	require.NoError(t, err)
+	require.Equal(t, HTMLMeta{
+		Title:       "Sample Page",
+		Description: "Case insensitive description match.",
+		Image:       "",
+	}, *metadata)
+}
+
 func TestGetHTMLMetaForInternal(t *testing.T) {
 	// test for internal IP
 	if _, err := GetHTMLMeta("http://192.168.0.1"); !errors.Is(err, ErrInternalIP) {


### PR DESCRIPTION
## Summary

The  function only matched <meta property=...> (OpenGraph) attributes and ignored <meta name=...> (standard HTML). This caused link previews to silently drop descriptions for pages that use the standard HTML <meta name="description"\u003e tag without OpenGraph fallback.

## Root Cause

In , the condition was:


This never matched <meta name="description"\u003e because the attribute key is , not .

## Fix

Updated the condition to match both attribute styles:


## Testing

- Added regression test  that uses HTML with **only** <meta name=...> tags (no OpenGraph fallback).
- All existing tests continue to pass.
=== RUN   TestGetHTMLMeta
--- PASS: TestGetHTMLMeta (0.00s)
=== RUN   TestGetHTMLMetaWithNameOnly
--- PASS: TestGetHTMLMetaWithNameOnly (0.00s)
=== RUN   TestGetHTMLMetaForInternal
--- PASS: TestGetHTMLMetaForInternal (0.00s)
=== RUN   TestHTTPClientHasTimeout
--- PASS: TestHTTPClientHasTimeout (0.00s)
=== RUN   TestSecureDialContextRejectsResolvedInternalIP
--- PASS: TestSecureDialContextRejectsResolvedInternalIP (0.00s)
=== RUN   TestSecureDialContextDialsResolvedIP
--- PASS: TestSecureDialContextDialsResolvedIP (0.00s)
PASS
ok  	github.com/usememos/memos/internal/httpgetter	(cached)

## Related

Fixes #5980
Prior attempt: #5822 (closed stale, file has since moved from  to )