### PR TITLE
fix(editor): Add Tab/Shift+Tab handling in markdown list editing

### DIFF
--- a/web/src/components/MemoEditor/Editor/useListCompletion.ts
+++ b/web/src/components/MemoEditor/Editor/useListCompletion.ts
@@ -1,5 +1,5 @@
 import { type RefObject, useEffect, useRef } from "react";
-import { detectLastListItem, generateListContinuation } from "@/utils/markdown-list-detection";
+import { detectLastListItem, generateListContinuation, renumberOrderedLists } from "@/utils/markdown-list-detection";
 import { EditorRefActions } from ".";
 
 interface UseListCompletionOptions {
@@ -38,7 +38,7 @@ export function useListCompletion({ editorRef, editorActions, isInIME }: UseList
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Enter" || isInIMERef.current || event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) {
+      if ((event.key !== "Enter" && event.key !== "Tab") || isInIMERef.current || event.ctrlKey || event.metaKey || event.altKey) {
         return;
       }
 
@@ -50,26 +50,72 @@ export function useListCompletion({ editorRef, editorActions, isInIME }: UseList
 
       const actions = editorActionsRef.current;
       const cursorPosition = actions.getCursorPosition();
-      const contentBeforeCursor = actions.getContent().substring(0, cursorPosition);
-      const listInfo = detectLastListItem(contentBeforeCursor);
+      const content = actions.getContent();
+      const contentBeforeCursor = content.substring(0, cursorPosition);
+      const lines = contentBeforeCursor.split("\n");
+      const fullLines = content.split("\n");
+      let currentLineNum = lines.length - 1;
+      const lastLineContent = fullLines[currentLineNum];
 
-      if (!listInfo.type) return;
+      const listInfo = detectLastListItem(lastLineContent);
+
+      if (!listInfo.type) {
+        if (event.key === "Tab" && !event.shiftKey) {
+          event.preventDefault();
+          actions.insertText("    ");
+        }
+        return;
+      }
 
       event.preventDefault();
 
-      const lines = contentBeforeCursor.split("\n");
-      const currentLine = lines[lines.length - 1];
+      const lastLineContentBeforeCursor = lines[currentLineNum];
+      const lineStartPos = cursorPosition - lastLineContentBeforeCursor.length;
+      let offsetInLine = cursorPosition - lineStartPos;
+      let cursorOffsetAdjustment: number = 0;
+      if (event.key === "Enter") {
+        if (isEmptyListItem(lastLineContentBeforeCursor)) {
+          actions.removeText(lineStartPos, lastLineContentBeforeCursor.length);
+        } else {
+          const continuation = offsetInLine > listInfo.indent ? generateListContinuation(listInfo) : "";
+          actions.insertText("\n" + continuation);
+          cursorOffsetAdjustment = continuation.length;
+          currentLineNum += 1;
+          offsetInLine = 0;
+          console.debug("adjust:", cursorOffsetAdjustment);
+          setTimeout(() => actions.scrollToCursor(), 0);
+        }
+      } else if (event.key === "Tab") {
+        const contentLines = content.split("\n");
+        const fullLine = contentLines[currentLineNum];
+        const leadingSpaces = fullLine.match(/^(\s*)/)?.[1]?.length ?? 0;
 
-      if (isEmptyListItem(currentLine)) {
-        const lineStartPos = cursorPosition - currentLine.length;
-        actions.removeText(lineStartPos, currentLine.length);
-      } else {
-        const continuation = generateListContinuation(listInfo);
-        actions.insertText("\n" + continuation);
+        let newLine: string;
 
-        // Auto-scroll to keep cursor visible after inserting list item
-        setTimeout(() => actions.scrollToCursor(), 0);
+        if (event.shiftKey) {
+          const spacesToRemove = Math.min(4, leadingSpaces);
+          newLine = fullLine.slice(spacesToRemove);
+          cursorOffsetAdjustment = -spacesToRemove;
+        } else {
+          const spacesToAdd = 4 - (leadingSpaces % 4);
+          newLine = " ".repeat(spacesToAdd) + fullLine;
+          cursorOffsetAdjustment = spacesToAdd;
+        }
+
+        actions.setLine(currentLineNum, newLine);
       }
+      const dirtyContent = actions.getContent();
+      const newContent = renumberOrderedLists(dirtyContent);
+      actions.setContent(newContent);
+
+      const finalLines = newContent.split("\n");
+      let newCursorPos = 0;
+      for (let i = 0; i < currentLineNum; i++) {
+        newCursorPos += finalLines[i].length + 1;
+      }
+      const newOffsetInLine = Math.max(0, Math.min(offsetInLine + cursorOffsetAdjustment, finalLines[currentLineNum]?.length ?? 0));
+      newCursorPos += newOffsetInLine;
+      actions.setCursorPosition(newCursorPos);
     };
 
     editor.addEventListener("compositionend", handleCompositionEnd);

--- a/web/src/components/MemoEditor/Editor/useListCompletion.ts
+++ b/web/src/components/MemoEditor/Editor/useListCompletion.ts
@@ -17,6 +17,22 @@ const EMPTY_LIST_PATTERNS = [
 
 const isEmptyListItem = (line: string) => EMPTY_LIST_PATTERNS.some((pattern) => pattern.test(line));
 
+function getMarkerWidthDelta(oldLine: string, newLine: string): number {
+  const getNumericMarkerLen = (line: string): number | null => {
+    const match = line.match(/^\s*\d+[.)]/);
+    return match ? match[0].trim().length : null;
+  };
+
+  const oldNum = getNumericMarkerLen(oldLine);
+  const newNum = getNumericMarkerLen(newLine);
+
+  if (oldNum !== null && newNum !== null) {
+    return newNum - oldNum;
+  }
+
+  return 0;
+}
+
 export function useListCompletion({ editorRef, editorActions, isInIME }: UseListCompletionOptions) {
   const isInIMERef = useRef(isInIME);
   isInIMERef.current = isInIME;
@@ -71,8 +87,8 @@ export function useListCompletion({ editorRef, editorActions, isInIME }: UseList
 
       const lastLineContentBeforeCursor = lines[currentLineNum];
       const lineStartPos = cursorPosition - lastLineContentBeforeCursor.length;
-      let offsetInLine = cursorPosition - lineStartPos;
-      let cursorOffsetAdjustment: number = 0;
+      const offsetInLine = cursorPosition - lineStartPos;
+      let cursorOffsetAdjustment = 0;
       if (event.key === "Enter") {
         if (isEmptyListItem(lastLineContentBeforeCursor)) {
           actions.removeText(lineStartPos, lastLineContentBeforeCursor.length);
@@ -81,24 +97,20 @@ export function useListCompletion({ editorRef, editorActions, isInIME }: UseList
           actions.insertText("\n" + continuation);
           cursorOffsetAdjustment = continuation.length;
           currentLineNum += 1;
-          offsetInLine = 0;
-          console.debug("adjust:", cursorOffsetAdjustment);
           setTimeout(() => actions.scrollToCursor(), 0);
         }
       } else if (event.key === "Tab") {
-        const contentLines = content.split("\n");
-        const fullLine = contentLines[currentLineNum];
-        const leadingSpaces = fullLine.match(/^(\s*)/)?.[1]?.length ?? 0;
+        const leadingSpaces = lastLineContent.match(/^(\s*)/)?.[1]?.length ?? 0;
 
         let newLine: string;
 
         if (event.shiftKey) {
           const spacesToRemove = Math.min(4, leadingSpaces);
-          newLine = fullLine.slice(spacesToRemove);
+          newLine = lastLineContent.slice(spacesToRemove);
           cursorOffsetAdjustment = -spacesToRemove;
         } else {
           const spacesToAdd = 4 - (leadingSpaces % 4);
-          newLine = " ".repeat(spacesToAdd) + fullLine;
+          newLine = " ".repeat(spacesToAdd) + lastLineContent;
           cursorOffsetAdjustment = spacesToAdd;
         }
 
@@ -113,7 +125,9 @@ export function useListCompletion({ editorRef, editorActions, isInIME }: UseList
       for (let i = 0; i < currentLineNum; i++) {
         newCursorPos += finalLines[i].length + 1;
       }
-      const newOffsetInLine = Math.max(0, Math.min(offsetInLine + cursorOffsetAdjustment, finalLines[currentLineNum]?.length ?? 0));
+      const finalLine = finalLines[currentLineNum] ?? "";
+      const markerWidthDelta = getMarkerWidthDelta(lastLineContent, finalLine);
+      const newOffsetInLine = Math.max(0, Math.min(offsetInLine + cursorOffsetAdjustment + markerWidthDelta, finalLine.length));
       newCursorPos += newOffsetInLine;
       actions.setCursorPosition(newCursorPos);
     };

--- a/web/src/utils/markdown-list-detection.ts
+++ b/web/src/utils/markdown-list-detection.ts
@@ -72,6 +72,7 @@ export function renumberOrderedLists(content: string): string {
     const line = lines[i];
 
     if (line.trim() === "") {
+      counters.clear();
       continue;
     }
 

--- a/web/src/utils/markdown-list-detection.ts
+++ b/web/src/utils/markdown-list-detection.ts
@@ -2,17 +2,14 @@ export interface ListItemInfo {
   type: "task" | "unordered" | "ordered" | null;
   symbol?: string; // For task/unordered lists: "- ", "* ", "+ "
   number?: number; // For ordered lists: 1, 2, 3, etc.
-  indent?: string; // Leading whitespace
+  indent: number; // Whitespace count
 }
 
 // Detect the list item type of the last line before cursor
-export function detectLastListItem(contentBeforeCursor: string): ListItemInfo {
-  const lines = contentBeforeCursor.split("\n");
-  const lastLine = lines[lines.length - 1];
-
-  // Extract indentation
+export function detectLastListItem(lastLine: string): ListItemInfo {
   const indentMatch = lastLine.match(/^(\s*)/);
-  const indent = indentMatch ? indentMatch[1] : "";
+  const leadingSpaces = indentMatch ? indentMatch[1] : "";
+  const indent = leadingSpaces.length;
 
   // Task list: - [ ] or - [x] or - [X]
   const taskMatch = lastLine.match(/^(\s*)([-*+])\s+\[([ xX])\]\s+/);
@@ -52,7 +49,7 @@ export function detectLastListItem(contentBeforeCursor: string): ListItemInfo {
 
 // Generate the text to insert when pressing Enter on a list item
 export function generateListContinuation(listInfo: ListItemInfo): string {
-  const indent = listInfo.indent || "";
+  const indent = " ".repeat(listInfo.indent);
 
   switch (listInfo.type) {
     case "task":
@@ -64,4 +61,40 @@ export function generateListContinuation(listInfo: ListItemInfo): string {
     default:
       return indent;
   }
+}
+
+export function renumberOrderedLists(content: string): string {
+  const lines = content.split("\n");
+  const orderedListRegex = /^(\s*)(\d+)([.)])\s+/;
+  const counters: Map<number, number> = new Map();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (line.trim() === "") {
+      counters.clear();
+      continue;
+    }
+
+    const match = line.match(orderedListRegex);
+    if (!match) {
+      counters.clear();
+      continue;
+    }
+
+    const leadingSpaces = match[1];
+    const order = match[2];
+    const delimiter = match[3];
+    const indentLevel = Math.floor(leadingSpaces.length / 4);
+    for (const key of [...counters.keys()]) {
+      if (key > indentLevel) counters.delete(key);
+    }
+    const currentCounter = (counters.get(indentLevel) || 0) + 1;
+    counters.set(indentLevel, currentCounter);
+
+    const prefix = leadingSpaces + order + delimiter + " ";
+    lines[i] = leadingSpaces + currentCounter + delimiter + " " + line.slice(prefix.length);
+  }
+
+  return lines.join("\n");
 }

--- a/web/src/utils/markdown-list-detection.ts
+++ b/web/src/utils/markdown-list-detection.ts
@@ -72,13 +72,11 @@ export function renumberOrderedLists(content: string): string {
     const line = lines[i];
 
     if (line.trim() === "") {
-      counters.clear();
       continue;
     }
 
     const match = line.match(orderedListRegex);
     if (!match) {
-      counters.clear();
       continue;
     }
 

--- a/web/tests/memo-editor-list-indent.test.tsx
+++ b/web/tests/memo-editor-list-indent.test.tsx
@@ -131,4 +131,15 @@ describe("memo editor list indent (Tab/Shift+Tab)", () => {
 
     expect(textarea.value).toBe("1. first\n2. nested a\n3. second\n    1. nested b");
   });
+
+  it("preserve ordered-list counters across nested non-ordered lines.", () => {
+    const textarea = renderEditor("1. first\n    - child\n2. second");
+
+    const curosrBeforeNestedA = "1. first\n    - child".length;
+    textarea.setSelectionRange(curosrBeforeNestedA, curosrBeforeNestedA);
+
+    simulateKeyDown(textarea, "Tab", true);
+
+    expect(textarea.value).toBe("1. first\n- child\n2. second");
+  });
 });

--- a/web/tests/memo-editor-list-indent.test.tsx
+++ b/web/tests/memo-editor-list-indent.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Editor from "@/components/MemoEditor/Editor";
+
+vi.mock("@/components/MemoEditor/Editor/TagSuggestions", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/MemoEditor/Editor/SlashCommands", () => ({
+  default: () => null,
+}));
+
+function simulateKeyDown(textarea: HTMLTextAreaElement, key: string, shiftKey = false) {
+  fireEvent.keyDown(textarea, {
+    key,
+    shiftKey,
+    keyCode: key === "Tab" ? 9 : undefined,
+    which: key === "Tab" ? 9 : undefined,
+  });
+}
+
+function renderEditor(initialContent: string) {
+  render(
+    <Editor
+      className=""
+      initialContent={initialContent}
+      placeholder="memo"
+      onContentChange={vi.fn()}
+      onPaste={vi.fn()}
+    />,
+  );
+  return screen.getByPlaceholderText("memo") as HTMLTextAreaElement;
+}
+
+describe("memo editor list indent (Tab/Shift+Tab)", () => {
+  it("inserts 4 spaces on Tab when not on a list line", () => {
+    const textarea = renderEditor("hello world");
+    textarea.setSelectionRange(5, 5);
+
+    simulateKeyDown(textarea, "Tab");
+
+    expect(textarea.value).toBe("hello     world");
+    expect(textarea.selectionStart).toBe(9);
+    expect(textarea.selectionEnd).toBe(9);
+  });
+
+  it("indents an unordered list item with Tab", () => {
+    const textarea = renderEditor("- item");
+    textarea.setSelectionRange(0, 0);
+
+    simulateKeyDown(textarea, "Tab");
+
+    expect(textarea.value).toBe("    - item");
+  });
+
+  it("indents an unordered list item with spaces cannot be multiple of 4", () => {
+    const textarea = renderEditor("  - item");
+    textarea.setSelectionRange(0, 0);
+
+    simulateKeyDown(textarea, "Tab");
+
+    expect(textarea.value).toBe("    - item");
+  });
+
+  it("dedents an indented unordered list item with Shift+Tab", () => {
+    const textarea = renderEditor("    - item");
+    textarea.setSelectionRange(6, 6);
+
+    simulateKeyDown(textarea, "Tab", true);
+
+    expect(textarea.value).toBe("- item");
+  });
+
+  it("indents an ordered list item and renumbers subsequent items", () => {
+    const textarea = renderEditor("1. first\n2. second\n3. third");
+    const secondLineStart = "1. first\n".length;
+    textarea.setSelectionRange(secondLineStart + 4, secondLineStart + 4);
+
+    simulateKeyDown(textarea, "Tab");
+
+    expect(textarea.value).toBe("1. first\n    1. second\n2. third");
+  });
+
+  it("dedents an indented ordered list item and renumbers", () => {
+    const textarea = renderEditor("1. first\n    1. second\n2. third");
+    const cursorAfterSedond = "1. first\n    1. second".length;
+    textarea.setSelectionRange(cursorAfterSedond, cursorAfterSedond);
+
+    simulateKeyDown(textarea, "Tab", true);
+
+    expect(textarea.value).toBe("1. first\n2. second\n3. third");
+  });
+
+  it("indents a task list item with Tab preserving format", () => {
+    const textarea = renderEditor("- [ ] todo item");
+    textarea.setSelectionRange(6, 6);
+
+    simulateKeyDown(textarea, "Tab");
+
+    expect(textarea.value).toBe("    - [ ] todo item");
+  });
+
+  it("preserves relative cursor position after indent", () => {
+    const textarea = renderEditor("- item");
+    const cursorAfterIt = "- it".length;
+    textarea.setSelectionRange(cursorAfterIt, cursorAfterIt);
+
+    simulateKeyDown(textarea, "Tab");
+
+    expect(textarea.value).toBe("    - item");
+    expect(textarea.selectionStart).toBe("- it".length + 4);
+    expect(textarea.selectionEnd).toBe("- it".length + 4);
+  });
+
+  it("does not change an unindented list item on Shift+Tab", () => {
+    const textarea = renderEditor("- item");
+    textarea.setSelectionRange(4, 4);
+
+    simulateKeyDown(textarea, "Tab", true);
+
+    expect(textarea.value).toBe("- item");
+  });
+
+  it("renumbers nested lists independently per parent item", () => {
+    const textarea = renderEditor("1. first\n    2. nested a\n2. second\n    3. nested b");
+
+    const curosrBeforeNestedA = "1. first\n    2. ".length;
+    textarea.setSelectionRange(curosrBeforeNestedA, curosrBeforeNestedA);
+
+    simulateKeyDown(textarea, "Tab", true);
+
+    expect(textarea.value).toBe("1. first\n2. nested a\n3. second\n    1. nested b");
+  });
+});

--- a/web/tests/memo-editor-list-indent.test.tsx
+++ b/web/tests/memo-editor-list-indent.test.tsx
@@ -142,4 +142,41 @@ describe("memo editor list indent (Tab/Shift+Tab)", () => {
 
     expect(textarea.value).toBe("1. first\n- child\n2. second");
   });
+
+  it("preserves cursor position when renumbering changes marker width", () => {
+    const textarea = renderEditor(
+      "1. a\n2. b\n3. c\n4. d\n5. e\n6. f\n7. g\n8. h\n9. i\n10. tenth",
+    );
+
+    const tenthLineStart = "1. a\n2. b\n3. c\n4. d\n5. e\n6. f\n7. g\n8. h\n9. i\n".length;
+    const cursorInTenthContent = tenthLineStart + "10. t".length;
+    textarea.setSelectionRange(cursorInTenthContent, cursorInTenthContent);
+
+    simulateKeyDown(textarea, "Tab");
+
+    const newTenthLineStart = "1. a\n2. b\n3. c\n4. d\n5. e\n6. f\n7. g\n8. h\n9. i\n".length;
+    const expectedCursor = newTenthLineStart + "    1. t".length;
+    expect(textarea.selectionStart).toBe(expectedCursor);
+    expect(textarea.selectionEnd).toBe(expectedCursor);
+  });
+
+  it("preserves cursor position on Shift+Tab when renumbering widens the marker", () => {
+    const textarea = renderEditor(
+      "1. a\n2. b\n3. c\n4. d\n5. e\n6. f\n7. g\n8. h\n9. i\n    1. tenth",
+    );
+
+    const tenthLineStart = "1. a\n2. b\n3. c\n4. d\n5. e\n6. f\n7. g\n8. h\n9. i\n".length;
+    const cursorInContent = tenthLineStart + "    1. t".length;
+    textarea.setSelectionRange(cursorInContent, cursorInContent);
+
+    simulateKeyDown(textarea, "Tab", true);
+
+    const newTenthLineStart = "1. a\n2. b\n3. c\n4. d\n5. e\n6. f\n7. g\n8. h\n9. i\n".length;
+    const expectedCursor = newTenthLineStart + "10. t".length;
+    expect(textarea.value).toBe(
+      "1. a\n2. b\n3. c\n4. d\n5. e\n6. f\n7. g\n8. h\n9. i\n10. tenth",
+    );
+    expect(textarea.selectionStart).toBe(expectedCursor);
+    expect(textarea.selectionEnd).toBe(expectedCursor);
+  });
 });


### PR DESCRIPTION
1. Refactored the list detection logic, changing indent to numbers.
2. Added a utility function for automatically renumbering ordered lists.
3. Extended the Tab/Shift+Tab shortcut to support list indentation/unindentation.
4. Added test cases related to list indentation.

<img width="378" height="414" alt="presentation" src="https://github.com/user-attachments/assets/51bb14fa-f20d-4210-9beb-875079cf7e51" />
