### PR TITLE
Add remove completed tasks to memo actions

### DIFF
--- a/web/src/components/MemoActionMenu/MemoActionMenu.tsx
+++ b/web/src/components/MemoActionMenu/MemoActionMenu.tsx
@@ -11,6 +11,7 @@ import {
   ListChecksIcon,
   ListRestartIcon,
   MoreVerticalIcon,
+  Trash2Icon,
   TrashIcon,
 } from "lucide-react";
 import { useState } from "react";
@@ -55,6 +56,7 @@ const MemoActionMenu = (props: MemoActionMenuProps) => {
     handleCopyContent,
     handleCheckAllTaskListItemsClick,
     handleUncheckAllTaskListItemsClick,
+    handleRemoveCompletedTaskListItemsClick,
     handleDeleteMemoClick,
     confirmDeleteMemo,
   } = useMemoActionHandlers({
@@ -122,6 +124,10 @@ const MemoActionMenu = (props: MemoActionMenuProps) => {
               <DropdownMenuItem disabled={!hasCompletedTasks} onClick={handleUncheckAllTaskListItemsClick}>
                 <ListRestartIcon className="w-4 h-auto" />
                 {t("memo.task-actions.uncheck-all")}
+              </DropdownMenuItem>
+              <DropdownMenuItem disabled={!hasCompletedTasks} onClick={handleRemoveCompletedTaskListItemsClick}>
+                <Trash2Icon className="w-4 h-auto" />
+                {t("memo.task-actions.remove-completed")}
               </DropdownMenuItem>
             </DropdownMenuSubContent>
           </DropdownMenuSub>

--- a/web/src/components/MemoActionMenu/hooks.ts
+++ b/web/src/components/MemoActionMenu/hooks.ts
@@ -12,7 +12,7 @@ import { ROUTES } from "@/router/routes";
 import { State } from "@/types/proto/api/v1/common_pb";
 import type { Memo } from "@/types/proto/api/v1/memo_service_pb";
 import { useTranslate } from "@/utils/i18n";
-import { checkAllTasks, uncheckAllTasks } from "@/utils/markdown-task-actions";
+import { checkAllTasks, removeCompletedTasks, uncheckAllTasks } from "@/utils/markdown-task-actions";
 
 interface UseMemoActionHandlersOptions {
   memo: Memo;
@@ -128,6 +128,10 @@ export const useMemoActionHandlers = ({ memo, onEdit, setDeleteDialogOpen }: Use
     await updateMemoContent(uncheckAllTasks(memo.content), "Uncheck memo task list items");
   }, [memo.content, updateMemoContent]);
 
+  const handleRemoveCompletedTaskListItemsClick = useCallback(async () => {
+    await updateMemoContent(removeCompletedTasks(memo.content), "Remove completed memo task list items");
+  }, [memo.content, updateMemoContent]);
+
   const handleDeleteMemoClick = useCallback(() => {
     setDeleteDialogOpen(true);
   }, [setDeleteDialogOpen]);
@@ -157,6 +161,7 @@ export const useMemoActionHandlers = ({ memo, onEdit, setDeleteDialogOpen }: Use
     handleCopyContent,
     handleCheckAllTaskListItemsClick,
     handleUncheckAllTaskListItemsClick,
+    handleRemoveCompletedTaskListItemsClick,
     handleDeleteMemoClick,
     confirmDeleteMemo,
   };

--- a/web/src/locales/en-GB.json
+++ b/web/src/locales/en-GB.json
@@ -268,6 +268,7 @@
     "task-actions": {
       "check-all": "Check all tasks",
       "title": "Tasks",
+      "remove-completed": "Remove completed tasks",
       "uncheck-all": "Uncheck all tasks",
       "updated": "Tasks updated"
     }

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -298,6 +298,7 @@
     "task-actions": {
       "check-all": "Check all tasks",
       "title": "Tasks",
+      "remove-completed": "Remove completed tasks",
       "uncheck-all": "Uncheck all tasks",
       "updated": "Tasks updated"
     },

--- a/web/src/utils/markdown-task-actions.ts
+++ b/web/src/utils/markdown-task-actions.ts
@@ -16,6 +16,7 @@ interface MarkdownEdit extends SourceRange {
 interface ParsedTaskItem {
   checked: boolean;
   checkboxMarker: SourceRange;
+  lineRange: SourceRange;
 }
 
 interface LineInfo {
@@ -78,6 +79,10 @@ function parseTaskItems(markdown: string): ParsedTaskItem[] {
     if (startLine === undefined) {
       return;
     }
+    const endLine = node.position.end.line;
+    if (endLine === undefined) {
+      return;
+    }
 
     const lineInfo = getLineInfo(markdown, lineStarts, startLine);
     if (!lineInfo) {
@@ -96,6 +101,10 @@ function parseTaskItems(markdown: string): ParsedTaskItem[] {
       checkboxMarker: {
         start: markerStart,
         end: markerStart + 1,
+      },
+      lineRange: {
+        start: lineInfo.startOffset,
+        end: lineStarts[endLine] ?? markdown.length,
       },
     });
   });
@@ -138,10 +147,26 @@ function setAllTaskMarkers(markdown: string, checked: boolean): string {
   return applyMarkdownEdits(markdown, edits);
 }
 
+function removeCompletedTaskItems(markdown: string): string {
+  const edits = parseTaskItems(markdown)
+    .filter((task) => task.checked)
+    .map<MarkdownEdit>((task) => ({
+      start: task.lineRange.start,
+      end: task.lineRange.end,
+      replacement: "",
+    }));
+
+  return applyMarkdownEdits(markdown, edits);
+}
+
 export function uncheckAllTasks(markdown: string): string {
   return setAllTaskMarkers(markdown, false);
 }
 
 export function checkAllTasks(markdown: string): string {
   return setAllTaskMarkers(markdown, true);
+}
+
+export function removeCompletedTasks(markdown: string): string {
+  return removeCompletedTaskItems(markdown);
 }

--- a/web/tests/markdown-task-actions.test.ts
+++ b/web/tests/markdown-task-actions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { checkAllTasks, uncheckAllTasks } from "@/utils/markdown-task-actions";
+import { checkAllTasks, removeCompletedTasks, uncheckAllTasks } from "@/utils/markdown-task-actions";
 
 describe("checkAllTasks", () => {
   it("checks every unchecked task while preserving source formatting", () => {
@@ -19,7 +19,9 @@ describe("uncheckAllTasks", () => {
   it("unchecks every checked task while preserving source formatting", () => {
     const markdown = ["Intro", "- [x] first", "* [X] second", "  + [ ] nested", "1. [x] ordered", "Outro"].join("\n");
 
-    expect(uncheckAllTasks(markdown)).toBe(["Intro", "- [ ] first", "* [ ] second", "  + [ ] nested", "1. [ ] ordered", "Outro"].join("\n"));
+    expect(uncheckAllTasks(markdown)).toBe(
+      ["Intro", "- [ ] first", "* [ ] second", "  + [ ] nested", "1. [ ] ordered", "Outro"].join("\n"),
+    );
   });
 
   it("returns the original string when no checkbox markers need changing", () => {
@@ -33,6 +35,28 @@ describe("uncheckAllTasks", () => {
 
     expect(uncheckAllTasks(markdown)).toBe(
       ["```", "- [x] not a task", "```", "", "Inline `- [x] not a task` text", "", "- [ ] real task"].join("\n"),
+    );
+  });
+});
+
+describe("removeCompletedTasks", () => {
+  it("removes every completed task while preserving the remaining markdown", () => {
+    const markdown = ["Intro", "- [x] first", "  continuation", "- [ ] second", "Outro"].join("\n");
+
+    expect(removeCompletedTasks(markdown)).toBe(["Intro", "- [ ] second", "Outro"].join("\n"));
+  });
+
+  it("returns the original string when there are no completed tasks", () => {
+    const markdown = ["Intro", "- [ ] first", "Outro"].join("\n");
+
+    expect(removeCompletedTasks(markdown)).toBe(markdown);
+  });
+
+  it("ignores completed tasks inside fenced and inline code", () => {
+    const markdown = ["```", "- [x] not a task", "```", "", "Inline `- [x] not a task` text", "", "- [x] real task"].join("\n");
+
+    expect(removeCompletedTasks(markdown)).toBe(
+      ["```", "- [x] not a task", "```", "", "Inline `- [x] not a task` text", "", ""].join("\n"),
     );
   });
 });


### PR DESCRIPTION
- Remove completed task items from the memo task menu using the existing markdown task helpers.
- Add regression coverage for multi-line task removal and preserve code-block content.
