### PR TITLE
fix(tags): include combining marks in tag character class

### DIFF
--- a/web/src/utils/tag-grammar.ts
+++ b/web/src/utils/tag-grammar.ts
@@ -4,10 +4,14 @@
  * tagMarkdown.ts) and the read-only renderer (utils/remark-plugins/remark-tag.ts)
  * so they can't drift.
  *
- * A tag character is any Unicode letter, number, or symbol, plus `_ - / &`.
+ * A tag character is any Unicode letter, mark, number, or symbol, plus
+ * `_ - / &`. The mark class (`\p{M}`) keeps combining marks — Indic vowel
+ * signs, Arabic harakat, Hebrew niqqud, decomposed accents — attached to the
+ * base letters they belong to, so a tag like `#കവിത` isn't cut short at its
+ * first vowel sign.
  * A tag run is capped at MAX_TAG_LENGTH characters.
  */
-export const TAG_CHAR_CLASS = "[\\p{L}\\p{N}\\p{S}_\\-/&]";
+export const TAG_CHAR_CLASS = "[\\p{L}\\p{M}\\p{N}\\p{S}_\\-/&]";
 
 export const MAX_TAG_LENGTH = 100;
 

--- a/web/tests/editor-tag.test.ts
+++ b/web/tests/editor-tag.test.ts
@@ -43,6 +43,16 @@ describe("Tag mark", () => {
     expect(tagged?.marks?.find((m) => m.type === "tag")?.attrs?.tag).toBe("work/project-1");
   });
 
+  it("includes combining marks in a tag run", () => {
+    // Malayalam കവിത carries a spacing combining vowel sign (U+0D3F, \p{M});
+    // the tag must cover the whole word, not stop at the first mark.
+    expect(firstParagraphChildren("#കവിത")[0]).toMatchObject({
+      type: "text",
+      text: "#കവിത",
+      marks: [{ type: "tag", attrs: { tag: "കവിത" } }],
+    });
+  });
+
   it("does not turn headings into tags", () => {
     expect(parseMarkdown("# heading").content?.[0]?.type).toBe("heading");
   });

--- a/web/tests/remark-tag.test.tsx
+++ b/web/tests/remark-tag.test.tsx
@@ -70,6 +70,15 @@ describe("remarkTag", () => {
     expect(html).toContain('data-tag="second"');
   });
 
+  it("tags a whole word containing combining marks", () => {
+    // Malayalam കവിത = ka, va, vowel-sign-i (U+0D3F, a spacing combining mark),
+    // ta. The vowel sign is a \p{M} character, so the tag must not stop at കവ.
+    const html = renderMarkdown("#കവിത");
+
+    expect(html).toContain('data-tag="കവിത"');
+    expect(html).not.toContain('data-tag="കവ"');
+  });
+
   it("still tags a hash that shares a text node with an entity reference", () => {
     // The source slice ("...&amp;...") differs from the decoded value, so the
     // escape-aware path bows out and the tag is detected the original way.


### PR DESCRIPTION
Tags written in scripts that use combining marks were truncated at the first mark. Malayalam #കവിത was recognized only as #കവ, leaving the trailing vowel sign and following letters as untagged text.


`web/src/utils/tag-grammar.ts` defines a tag character as a letter (`\p{L}`),
number (`\p{N}`), or symbol (`\p{S}`), but **not** a mark (`\p{M}`). In many
scripts a word interleaves base letters with combining marks:

| Code point | Char | Category | In old class? |
|-----------|------|----------|---------------|
| U+0D15 | ക | Lo | yes |
| U+0D35 | വ | Lo | yes |
| U+0D3F | ി | **Mc** | **no** |
| U+0D24 | ത | Lo | yes |

The lexer stops at the vowel sign. This affects Indic scripts, Arabic/Persian
harakat, Hebrew niqqud, and decomposed (NFD) Latin/Greek/Cyrillic accents.

Add \p{M} to TAG_CHAR_CLASS. Add unit tests too.

| Before | After |
|-----------|-----------|
|<img width="401" height="237" alt="image" src="https://github.com/user-attachments/assets/2df7a841-7c36-4961-bab2-cd548e2f7000" />| <img width="402" height="238" alt="image" src="https://github.com/user-attachments/assets/c7d05f4c-5f73-4a1d-a864-645fceb0969c" /> |



