### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/internal/ai/audio/webm.go
+++ b/internal/ai/audio/webm.go
@@ -98,10 +98,7 @@ func WebMOpusToWAV(input []byte) ([]byte, error) {
 		}
 	}
 
-	skip := preSkip * channels
-	if skip > len(pcm) {
-		skip = len(pcm)
-	}
+	skip := min(preSkip*channels, len(pcm))
 	pcm = pcm[skip:]
 
 	return encodeWAV(pcm, opusOutputSampleRate, channels), nil

--- a/server/router/api/v1/memo_service.go
+++ b/server/router/api/v1/memo_service.go
@@ -236,10 +236,7 @@ func (s *APIV1Service) ListMemos(ctx context.Context, request *v1pb.ListMemosReq
 			return nil, status.Errorf(codes.InvalidArgument, "invalid page token: %v", err)
 		}
 		limit = normalizePageSize(pageToken.Limit)
-		offset = int(pageToken.Offset)
-		if offset < 0 {
-			offset = 0
-		}
+		offset = max(int(pageToken.Offset), 0)
 	} else {
 		limit = normalizePageSize(request.PageSize)
 	}
@@ -782,10 +779,7 @@ func (s *APIV1Service) ListMemoComments(ctx context.Context, request *v1pb.ListM
 			return nil, status.Errorf(codes.InvalidArgument, "invalid page token: %v", err)
 		}
 		limit = normalizePageSize(pageToken.Limit)
-		offset = int(pageToken.Offset)
-		if offset < 0 {
-			offset = 0
-		}
+		offset = max(int(pageToken.Offset), 0)
 	} else {
 		limit = normalizePageSize(request.PageSize)
 	}

--- a/store/db/mysql/user_delete.go
+++ b/store/db/mysql/user_delete.go
@@ -524,10 +524,7 @@ func deleteUserBatches[T any](values []T, size int) [][]T {
 
 	batches := make([][]T, 0, (len(values)+size-1)/size)
 	for start := 0; start < len(values); start += size {
-		end := start + size
-		if end > len(values) {
-			end = len(values)
-		}
+		end := min(start+size, len(values))
 		batches = append(batches, values[start:end])
 	}
 	return batches

--- a/store/db/postgres/user_delete.go
+++ b/store/db/postgres/user_delete.go
@@ -487,10 +487,7 @@ func deleteUserBatches[T any](values []T, size int) [][]T {
 
 	batches := make([][]T, 0, (len(values)+size-1)/size)
 	for start := 0; start < len(values); start += size {
-		end := start + size
-		if end > len(values) {
-			end = len(values)
-		}
+		end := min(start+size, len(values))
 		batches = append(batches, values[start:end])
 	}
 	return batches

--- a/store/db/sqlite/user_delete.go
+++ b/store/db/sqlite/user_delete.go
@@ -487,10 +487,7 @@ func deleteUserBatches[T any](values []T, size int) [][]T {
 
 	batches := make([][]T, 0, (len(values)+size-1)/size)
 	for start := 0; start < len(values); start += size {
-		end := start + size
-		if end > len(values) {
-			end = len(values)
-		}
+		end := min(start+size, len(values))
 		batches = append(batches, values[start:end])
 	}
 	return batches


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.