### PR TITLE
feat(web): add untagged shortcut filter example

### DIFF
--- a/web/src/pages/Shortcuts.tsx
+++ b/web/src/pages/Shortcuts.tsx
@@ -62,6 +62,12 @@ const shortcutExamples = [
     icon: TagsIcon,
   },
   {
+    title: "Untagged",
+    filter: "size(tags) == 0",
+    description: "Memos without any tags.",
+    icon: TagsIcon,
+  },
+  {
     title: "Archive tree",
     filter: 'tags.exists(t, t.startsWith("archive"))',
     description: "Match hierarchical tags by prefix.",
@@ -155,6 +161,7 @@ const filterFields = [
   "sets.contains(tags, [...])",
   "sets.intersects(tags, [...])",
   "sets.equivalent(tags, [...])",
+  "size(tags) == ...",
   "size(content) > ...",
   "has_task_list",
   "has_incomplete_tasks",


### PR DESCRIPTION
## Summary

- Add an "Untagged" example to the Shortcut filters guide using `size(tags) == 0`.
- Add `size(tags) == ...` to the supported fields list so users can discover tag-count filters in the UI.

## Why

Discussion #6038 asks how to find memos without tags. A maintainer answered that users can create a Shortcut with `size(tags) == 0`. This PR makes that maintainer-recommended recipe available directly in the in-app Shortcut filters examples.

## Verification

- `cd web && pnpm lint`
- `cd web && pnpm test`
- `git diff --check`