### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/internal/scheduler/parser.go
+++ b/internal/scheduler/parser.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -208,12 +209,7 @@ type listMatcher struct {
 }
 
 func (m *listMatcher) matches(value int) bool {
-	for _, v := range m.values {
-		if v == value {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(m.values, value)
 }
 
 // stepMatcher matches values at regular intervals.


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.