### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Don't want to install yet? Try our [live demo](https://demo.usememos.com/) first
 - **Pre-built Binaries** - Available for Linux, macOS, and Windows
 - **Kubernetes** - Helm charts and manifests available
 - **Build from Source** - For development and customization
+- **Managed Hosting** - [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/memos)
 
 See our [installation guide](https://usememos.com/docs/deploy) for detailed instructions.
 


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Memos to our marketplace, so this PR adds a small "Deploy with Zenith" link under the "Other Installation Methods" list (links to https://zenith.hosting/host/memos).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting