### PR TITLE
Allow apostrophes in tag names

### DIFF
--- a/internal/markdown/parser/tag.go
+++ b/internal/markdown/parser/tag.go
@@ -67,6 +67,11 @@ func isValidTagRune(r rune) bool {
 		return true
 	}
 
+	// Allow apostrophes used inside words, without allowing all punctuation.
+	if r == '\'' || r == '\u2019' {
+		return true
+	}
+
 	return false
 }
 

--- a/internal/markdown/parser/tag_test.go
+++ b/internal/markdown/parser/tag_test.go
@@ -151,6 +151,24 @@ func TestTagParser(t *testing.T) {
 			shouldParse: true,
 		},
 		{
+			name:        "Ukrainian tag with ASCII apostrophe",
+			input:       "#сім'я",
+			expectedTag: "сім'я",
+			shouldParse: true,
+		},
+		{
+			name:        "Ukrainian tag with right single quote",
+			input:       "#сім’я",
+			expectedTag: "сім’я",
+			shouldParse: true,
+		},
+		{
+			name:        "Ukrainian tag with modifier letter apostrophe",
+			input:       "#сімʼя",
+			expectedTag: "сімʼя",
+			shouldParse: true,
+		},
+		{
 			name:        "mixed Chinese and ASCII",
 			input:       "#测试test123",
 			expectedTag: "测试test123",

--- a/web/src/utils/tag-grammar.ts
+++ b/web/src/utils/tag-grammar.ts
@@ -4,13 +4,14 @@
  * can't drift.
  *
  * A tag character is any Unicode letter, mark, number, or symbol, plus
- * `_ - / &`. The mark class (`\p{M}`) keeps combining marks — Indic vowel
+ * `_ - / &` and apostrophes used inside words. The mark class (`\p{M}`) keeps
+ * combining marks — Indic vowel
  * signs, Arabic harakat, Hebrew niqqud, decomposed accents — attached to the
  * base letters they belong to, so a tag like `#കവിത` isn't cut short at its
  * first vowel sign.
  * A tag run is capped at MAX_TAG_LENGTH characters.
  */
-export const TAG_CHAR_CLASS = "[\\p{L}\\p{M}\\p{N}\\p{S}_\\-/&]";
+export const TAG_CHAR_CLASS = "[\\p{L}\\p{M}\\p{N}\\p{S}_\\-/&\\u0027\\u2019]";
 
 export const MAX_TAG_LENGTH = 100;
 

--- a/web/tests/remark-tag.test.tsx
+++ b/web/tests/remark-tag.test.tsx
@@ -79,6 +79,15 @@ describe("remarkTag", () => {
     expect(html).not.toContain('data-tag="കവ"');
   });
 
+  it("tags Ukrainian words containing apostrophes", () => {
+    const html = renderMarkdown("#сім'я #сім’я #сімʼя");
+
+    expect(html).toContain('data-tag="сім&#x27;я"');
+    expect(html).toContain('data-tag="сім’я"');
+    expect(html).toContain('data-tag="сімʼя"');
+    expect(html).not.toContain('data-tag="сім"');
+  });
+
   it("still tags a hash that shares a text node with an entity reference", () => {
     // The source slice ("...&amp;...") differs from the decoded value, so the
     // escape-aware path bows out and the tag is detected the original way.


### PR DESCRIPTION
Fixes #6078.

This updates frontend and backend tag parsing to allow apostrophes commonly used inside words:

- ASCII apostrophe `'`
- right single quote `’`

The existing modifier letter apostrophe `ʼ` continues to work through Unicode letter matching.

The change is intentionally narrow and does not allow punctuation broadly inside tags. For example, comma still terminates the tag.

Validation:
- `cd web && env PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm install --frozen-lockfile`
- `cd web && env PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm test tests/remark-tag.test.tsx`
- `env GOCACHE="$PWD/.gocache" GOPATH="$PWD/.gopath" go test ./internal/markdown/parser -run TestTagParser -count=1`
- `env GOCACHE="$PWD/.gocache" GOPATH="$PWD/.gopath" go test ./internal/markdown -run TestExtractTags -count=1`
- `git diff --check`

Manual/sanity checks:
- `#сім'я` parses as `сім'я`
- `#сім’я` parses as `сім’я`
- `#сімʼя` still parses as `сімʼя`
- `#сім,я` still parses as `сім`
