### PR TITLE
fix(memo): populate parent relation in comment webhook payload

### DIFF
--- a/server/router/api/v1/memo_comment_relations_test.go
+++ b/server/router/api/v1/memo_comment_relations_test.go
@@ -1,0 +1,47 @@
+package v1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/usememos/memos/proto/gen/api/v1"
+	"github.com/usememos/memos/store"
+)
+
+// TestCreateMemoComment_ReturnsParentRelation verifies that the memo returned by
+// CreateMemoComment carries the COMMENT relation to its parent memo. The comment
+// memo is converted before the relation is created, so without an explicit reload
+// the returned memo (and the memo.comment.created webhook payload built from it)
+// would have an empty Relations slice. Regression test for usememos/memos#6081.
+func TestCreateMemoComment_ReturnsParentRelation(t *testing.T) {
+	ctx := context.Background()
+	svc := newIntegrationService(t)
+
+	author, err := svc.Store.CreateUser(ctx, &store.User{
+		Username: "author", Role: store.RoleAdmin, Email: "author@example.com",
+	})
+	require.NoError(t, err)
+	authorCtx := userCtx(ctx, author.ID)
+
+	parent, err := svc.CreateMemo(authorCtx, &v1pb.CreateMemoRequest{
+		Memo: &v1pb.Memo{Content: "parent memo", Visibility: v1pb.Visibility_PUBLIC},
+	})
+	require.NoError(t, err)
+
+	comment, err := svc.CreateMemoComment(authorCtx, &v1pb.CreateMemoCommentRequest{
+		Name:    parent.Name,
+		Comment: &v1pb.Memo{Content: "a comment", Visibility: v1pb.Visibility_PUBLIC},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, comment.Relations, 1, "comment memo should carry its parent relation")
+	rel := comment.Relations[0]
+	assert.Equal(t, v1pb.MemoRelation_COMMENT, rel.Type)
+	require.NotNil(t, rel.Memo)
+	require.NotNil(t, rel.RelatedMemo)
+	assert.Equal(t, comment.Name, rel.Memo.Name)
+	assert.Equal(t, parent.Name, rel.RelatedMemo.Name)
+}

--- a/server/router/api/v1/memo_service.go
+++ b/server/router/api/v1/memo_service.go
@@ -701,6 +701,17 @@ func (s *APIV1Service) CreateMemoComment(ctx context.Context, request *v1pb.Crea
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create memo relation")
 	}
+
+	// The comment memo was converted before the relation above existed, so its
+	// Relations slice is empty. Reload the relations now so that both the API
+	// response and the memo.comment.created webhook payload carry the relation
+	// to the parent memo.
+	relations, err := s.loadMemoRelations(ctx, memo)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to load memo relations")
+	}
+	memoComment.Relations = relations
+
 	creator, err := ResolveUserByName(ctx, s.Store, memoComment.Creator)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid memo creator")


### PR DESCRIPTION
### What

When a comment is created, the `memos.memo.comment.created` webhook payload — and the `CreateMemoComment` API response — omit the `relations` property, so consumers can't tell which memo the comment belongs to. Reported in #6081.

### Why

In `CreateMemoComment` the comment memo is converted to its API form inside `CreateMemo`, which snapshots relations at that moment. The comment→parent relation is only `UpsertMemoRelation`'d afterwards, so the already-converted `memoComment` (used both for the webhook dispatch and as the return value) still has an empty `relations` slice. Subsequent `updated`/`deleted` events reload from the store, which is why they show the relation — exactly the asymmetry described in the issue.

### Change

After the relation is upserted, reload the comment memo's relations and attach them to the returned memo. Both the API response and the `comment.created` webhook payload now include the parent relation. No proto/schema changes.

### Scope / not included

- The generic `memos.memo.created` event fired for the comment memo still has no relations, because it is emitted inside `CreateMemo` before the relation exists; changing that would mean reordering the create flow and is left out deliberately.
- The issue's secondary suggestion (reactions should emit `memo.updated`) is a separate behavior change and is intentionally out of scope here.

### Testing

Added `TestCreateMemoComment_ReturnsParentRelation` (in-memory SQLite service test). Fails before the change (0 relations), passes after. `go test -race ./server/router/api/v1/` green; `go vet` and `gofmt` clean.

Addresses #6081 (the comment-webhook relations part; the reactions sub-request is left for separate tracking).

---
*Disclosure: prepared with AI assistance (Claude); the author has reviewed and verified the change and tests.*
