### PR TITLE
fix: implement pagination for ListUsers API

### DIFF
--- a/server/router/api/v1/test/user_service_test.go
+++ b/server/router/api/v1/test/user_service_test.go
@@ -1,0 +1,98 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/usememos/memos/proto/gen/api/v1"
+)
+
+func TestListUsersPagination(t *testing.T) {
+	ctx := context.Background()
+
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+
+	// Create admin user.
+	admin, err := ts.CreateHostUser(ctx, "admin")
+	require.NoError(t, err)
+
+	adminCtx := ts.CreateUserContext(ctx, admin.ID)
+
+	// Create additional users.
+	for i := 0; i < 5; i++ {
+		_, err := ts.CreateHostUser(ctx, fmt.Sprintf("user-%d", i))
+		require.NoError(t, err)
+	}
+
+	// First page.
+	firstPage, err := ts.Service.ListUsers(adminCtx, &v1pb.ListUsersRequest{
+		PageSize: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, firstPage.Users, 2)
+	require.Equal(t, int32(6), firstPage.TotalSize)
+	require.NotEmpty(t, firstPage.NextPageToken)
+
+	// Second page.
+	secondPage, err := ts.Service.ListUsers(adminCtx, &v1pb.ListUsersRequest{
+		PageSize:  2,
+		PageToken: firstPage.NextPageToken,
+	})
+	require.NoError(t, err)
+	require.Len(t, secondPage.Users, 2)
+	require.Equal(t, int32(6), secondPage.TotalSize)
+	require.NotEqual(t, firstPage.NextPageToken, secondPage.NextPageToken)
+
+	// Third page.
+	thirdPage, err := ts.Service.ListUsers(adminCtx, &v1pb.ListUsersRequest{
+		PageSize:  2,
+		PageToken: secondPage.NextPageToken,
+	})
+	require.NoError(t, err)
+	require.Len(t, thirdPage.Users, 2)
+	require.Equal(t, int32(6), thirdPage.TotalSize)
+	require.Empty(t, thirdPage.NextPageToken)
+}
+
+func TestListUsersInvalidPageToken(t *testing.T) {
+	ctx := context.Background()
+
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+
+	admin, err := ts.CreateHostUser(ctx, "admin")
+	require.NoError(t, err)
+
+	adminCtx := ts.CreateUserContext(ctx, admin.ID)
+
+	_, err = ts.Service.ListUsers(adminCtx, &v1pb.ListUsersRequest{
+		PageToken: "abc",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid page token")
+}
+
+func TestListUsersPageTokenOutOfRange(t *testing.T) {
+	ctx := context.Background()
+
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+
+	admin, err := ts.CreateHostUser(ctx, "admin")
+	require.NoError(t, err)
+
+	adminCtx := ts.CreateUserContext(ctx, admin.ID)
+
+	_, err = ts.CreateHostUser(ctx, "user1")
+	require.NoError(t, err)
+
+	_, err = ts.Service.ListUsers(adminCtx, &v1pb.ListUsersRequest{
+		PageToken: "999",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid page token")
+}

--- a/server/router/api/v1/user_service.go
+++ b/server/router/api/v1/user_service.go
@@ -89,15 +89,52 @@ func (s *APIV1Service) ListUsers(ctx context.Context, request *v1pb.ListUsersReq
 		return nil, status.Errorf(codes.Internal, "failed to list users: %v", err)
 	}
 
-	// TODO: Implement proper ordering, and pagination
-	// For now, return all users with basic structure
+	// Implement pagination
+	pageSize := int(request.PageSize)
+	if pageSize <= 0 {
+		pageSize = 50
+	}
+	if pageSize > 1000 {
+		pageSize = 1000
+	}
+
+	offset := 0
+	if request.PageToken != "" {
+		if parsed, err := fmt.Sscanf(request.PageToken, "%d", &offset); err != nil || parsed != 1 {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid page token")
+		}
+	}
+
+	totalSize := len(users)
+
+	if offset < 0 || offset > totalSize {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid page token")
+	}
+
+	end := offset + pageSize
+	if end > totalSize {
+		end = totalSize
+	}
+
+	pagedUsers := users[offset:end]
+
+	// Apply in-memory pagination until store-level pagination and ordering are implemented.
 	response := &v1pb.ListUsersResponse{
 		Users:     []*v1pb.User{},
-		TotalSize: int32(len(users)),
+		TotalSize: int32(totalSize),
 	}
-	for _, user := range users {
-		response.Users = append(response.Users, convertUserFromStore(user, currentUser))
+
+	for _, user := range pagedUsers {
+		response.Users = append(
+			response.Users,
+			convertUserFromStore(user, currentUser),
+		)
 	}
+
+	if end < totalSize {
+		response.NextPageToken = fmt.Sprintf("%d", end)
+	}
+
 	return response, nil
 }
 


### PR DESCRIPTION
## Summary

Implement pagination support for `ListUsers`.

### Changes

* Add support for `page_size` with:

  * default value of `50`
  * maximum value of `1000`
* Add support for `page_token` as an offset-based token.
* Return `next_page_token` when additional pages are available.
* Return `InvalidArgument` for malformed or out-of-range page tokens.
* Return paginated users instead of the full user list.
* Preserve `total_size` in the response.

### Notes

Pagination is currently implemented in memory because `store.FindUser` does not yet support database-level pagination or ordering. This can be improved in a future change.

### Tests Added

* `TestListUsersPagination`
* `TestListUsersInvalidPageToken`
* `TestListUsersPageTokenOutOfRange`

### Verification

```bash
go test ./server/router/api/v1/...
go test ./server/router/api/v1/test/...
gofmt -w server/router/api/v1/user_service.go
gofmt -w server/router/api/v1/test/user_service_test.go
```
