### PR TITLE
fix(web): improve username validation error

### DIFF
--- a/web/src/lib/error.ts
+++ b/web/src/lib/error.ts
@@ -1,3 +1,9 @@
+import { Code, ConnectError } from "@connectrpc/connect";
+
+export function isInvalidUsernameError(error: unknown): boolean {
+  return error instanceof ConnectError && error.code === Code.InvalidArgument && error.rawMessage.startsWith("invalid username:");
+}
+
 export function getErrorMessage(error: unknown, fallback = "Unknown error"): string {
   if (error instanceof Error) {
     return error.message;

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -351,6 +351,7 @@
     "failed-to-embed-memo": "Failed to embed memo",
     "fill-all": "Please fill in all fields.",
     "fill-all-required-fields": "Please fill all required fields",
+    "invalid-username": "Username must be 1–36 characters, contain only letters, numbers, or hyphens, start and end with a letter or number, and not contain only numbers.",
     "maximum-upload-size-is": "Maximum allowed upload size is {{size}} MiB",
     "memo-not-found": "Memo not found.",
     "new-password-not-match": "New passwords do not match.",

--- a/web/src/pages/SignUp.tsx
+++ b/web/src/pages/SignUp.tsx
@@ -13,7 +13,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useInstance } from "@/contexts/InstanceContext";
 import useLoading from "@/hooks/useLoading";
 import useNavigateTo from "@/hooks/useNavigateTo";
-import { handleError } from "@/lib/error";
+import { handleError, isInvalidUsernameError } from "@/lib/error";
 import { ROUTES } from "@/router/routes";
 import { User_Role, UserSchema } from "@/types/proto/api/v1/user_service_pb";
 import { AUTH_REDIRECT_PARAM, getSafeRedirectPath } from "@/utils/auth-redirect";
@@ -80,9 +80,13 @@ const SignUp = () => {
       await initInstance();
       navigateTo(redirectTarget || ROUTES.HOME, { replace: true });
     } catch (error: unknown) {
-      handleError(error, toast.error, {
-        fallbackMessage: "Sign up failed",
-      });
+      if (isInvalidUsernameError(error)) {
+        toast.error(t("message.invalid-username"));
+      } else {
+        handleError(error, toast.error, {
+          fallbackMessage: "Sign up failed",
+        });
+      }
     }
     actionBtnLoadingState.setFinish();
   };

--- a/web/src/pages/SignUp.tsx
+++ b/web/src/pages/SignUp.tsx
@@ -81,6 +81,7 @@ const SignUp = () => {
       navigateTo(redirectTarget || ROUTES.HOME, { replace: true });
     } catch (error: unknown) {
       if (isInvalidUsernameError(error)) {
+        console.error(error);
         toast.error(t("message.invalid-username"));
       } else {
         handleError(error, toast.error, {

--- a/web/tests/error.test.ts
+++ b/web/tests/error.test.ts
@@ -1,0 +1,21 @@
+import { Code, ConnectError } from "@connectrpc/connect";
+import { describe, expect, it } from "vitest";
+import { isInvalidUsernameError } from "@/lib/error";
+
+describe("isInvalidUsernameError", () => {
+  it("recognizes the username validation response", () => {
+    const error = new ConnectError("invalid username: word.word", Code.InvalidArgument);
+
+    expect(isInvalidUsernameError(error)).toBe(true);
+  });
+
+  it("does not hide unrelated invalid argument responses", () => {
+    const error = new ConnectError("password must not be empty", Code.InvalidArgument);
+
+    expect(isInvalidUsernameError(error)).toBe(false);
+  });
+
+  it("does not treat plain errors as server validation responses", () => {
+    expect(isInvalidUsernameError(new Error("invalid username: word.word"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the raw Connect RPC username-validation error on sign-up with clear, translation-ready guidance.
- Keep the backend as the source of truth for username validation instead of duplicating its regular expression in the frontend.
- Preserve the existing fallback behavior for unrelated sign-up errors.

## Root cause

The sign-up page passed every server error to the generic error handler. Connect RPC prefixes its public error message with the transport code, so an invalid username such as `word.word` surfaced as `[invalid_argument] invalid username: word.word` instead of explaining the accepted format.

This change recognizes only the backend's invalid-username response and presents the current rule in user-facing language. It does not broaden the accepted username syntax.

## Verification

- `cd web && pnpm lint`
- `cd web && pnpm test` — 48 test files, 207 tests passed
- `cd web && pnpm build`
- `git diff --check`

Fixes #6075
