### PR TITLE
fix(scheduler): treat cron weekday 7 as Sunday

### DIFF
--- a/internal/scheduler/parser.go
+++ b/internal/scheduler/parser.go
@@ -123,7 +123,17 @@ func (s *Schedule) matches(t time.Time) bool {
 		s.minutes.matches(t.Minute()) &&
 		s.hours.matches(t.Hour()) &&
 		s.months.matches(int(t.Month())) &&
-		(s.days.matches(t.Day()) || s.weekdays.matches(int(t.Weekday())))
+		(s.days.matches(t.Day()) || s.matchesWeekday(t.Weekday()))
+}
+
+// matchesWeekday reports whether the weekday field matches wd. Cron accepts both
+// 0 and 7 as Sunday, but time.Weekday only ranges 0 (Sunday) to 6 (Saturday), so
+// a Sunday must also be checked against 7 to honor expressions written that way.
+func (s *Schedule) matchesWeekday(wd time.Weekday) bool {
+	if s.weekdays.matches(int(wd)) {
+		return true
+	}
+	return wd == time.Sunday && s.weekdays.matches(7)
 }
 
 // parseField parses a single cron field (supports *, ranges, lists, steps).

--- a/internal/scheduler/parser_test.go
+++ b/internal/scheduler/parser_test.go
@@ -125,3 +125,41 @@ func TestScheduleNextWithTimezone(t *testing.T) {
 		t.Errorf("Next(%v) = %v, expected %v", from, next, expected)
 	}
 }
+
+func TestScheduleWeekdaySevenIsSunday(t *testing.T) {
+	// Cron treats both 0 and 7 as Sunday, but time.Weekday never returns 7,
+	// so a schedule written with 7 must still fire on Sundays.
+	//
+	// Combine day-of-month 1 with weekday 7 so the day-of-month clause does not
+	// mask the weekday behavior for the (non-first-of-month) days exercised here.
+	// 2025-01-05 is a Sunday and 2025-01-06 is a Monday.
+	sunday := time.Date(2025, 1, 5, 0, 0, 0, 0, time.UTC)
+	monday := time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC)
+
+	seven, err := ParseCronExpression("0 0 1 * 7")
+	if err != nil {
+		t.Fatalf("failed to parse expression: %v", err)
+	}
+	if !seven.matches(sunday) {
+		t.Errorf("weekday 7 should match Sunday %v", sunday)
+	}
+	if seven.matches(monday) {
+		t.Errorf("weekday 7 should not match Monday %v", monday)
+	}
+
+	// Regression: weekday 0 (the canonical Sunday) keeps working.
+	zero, err := ParseCronExpression("0 0 1 * 0")
+	if err != nil {
+		t.Fatalf("failed to parse expression: %v", err)
+	}
+	if !zero.matches(sunday) {
+		t.Errorf("weekday 0 should match Sunday %v", sunday)
+	}
+
+	// End-to-end via the public Next: from a Thursday, the next fire of
+	// "0 0 1 * 7" is the upcoming Sunday (Jan 5), earlier than the next 1st.
+	from := time.Date(2025, 1, 2, 10, 0, 0, 0, time.UTC)
+	if next := seven.Next(from); !next.Equal(sunday) {
+		t.Errorf("Next(%v) = %v, expected Sunday %v", from, next, sunday)
+	}
+}


### PR DESCRIPTION
Cron expressions accept both `0` and `7` for Sunday, and `ParseCronExpression` already validates weekday values across the documented `0-7` range (`8` is rejected). However, `Schedule.matches` compared the weekday field against `time.Weekday`, which only ranges 0 (Sunday) to 6 (Saturday) and never returns 7 — so a schedule written with `7` (e.g. `0 0 * * 7`) never fired on Sundays.

This checks the weekday matcher against `7` as well when the day is Sunday, so both spellings behave identically. The change is additive for the Sunday case and leaves all other weekdays untouched. It works across all field types (exact, range like `5-7`, list, step, wildcard).

**Test:** `TestScheduleWeekdaySevenIsSunday` asserts `0 0 1 * 7` matches Sunday 2025-01-05 (not Monday the 6th) and that `Next(2025-01-02)` returns the Jan 5 Sunday rather than skipping to Feb 1. Fails before, passes after; `gofmt` / `go vet` clean.

Prepared with AI assistance (Claude) and reviewed/verified by me.
