### PR TITLE
fix(tags): require boundaries before tags

### DIFF
--- a/internal/markdown/markdown_test.go
+++ b/internal/markdown/markdown_test.go
@@ -383,6 +383,12 @@ func TestExtractTags(t *testing.T) {
 			expected: []string{"tag"},
 		},
 		{
+			name:     "tags require a boundary before the hash",
+			content:  "word#tag 1#numeric (#parentheses) [#brackets] \"#quotes\" +#symbol",
+			withExt:  true,
+			expected: []string{"parentheses", "brackets", "quotes", "symbol"},
+		},
+		{
 			name:     "multiple tags",
 			content:  "Text with #tag1 and #tag2",
 			withExt:  true,

--- a/internal/markdown/markdown_test.go
+++ b/internal/markdown/markdown_test.go
@@ -384,7 +384,7 @@ func TestExtractTags(t *testing.T) {
 		},
 		{
 			name:     "tags require a boundary before the hash",
-			content:  "word#tag 1#numeric (#parentheses) [#brackets] \"#quotes\" +#symbol",
+			content:  "word#tag 1#numeric word##tag ##tag (#parentheses) [#brackets] \"#quotes\" +#symbol",
 			withExt:  true,
 			expected: []string{"parentheses", "brackets", "quotes", "symbol"},
 		},

--- a/internal/markdown/parser/tag.go
+++ b/internal/markdown/parser/tag.go
@@ -71,7 +71,7 @@ func isValidTagRune(r rune) bool {
 }
 
 func isTagBoundary(r rune) bool {
-	return unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r)
+	return r != '#' && (unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r))
 }
 
 // Parse parses #tag syntax using Unicode-aware validation.

--- a/internal/markdown/parser/tag.go
+++ b/internal/markdown/parser/tag.go
@@ -70,6 +70,10 @@ func isValidTagRune(r rune) bool {
 	return false
 }
 
+func isTagBoundary(r rune) bool {
+	return unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r)
+}
+
 // Parse parses #tag syntax using Unicode-aware validation.
 // Tags support international characters and follow these rules:
 //   - Must start with # followed by valid tag characters
@@ -81,6 +85,11 @@ func (*tagParser) Parse(_ gast.Node, block text.Reader, _ parser.Context) gast.N
 
 	// Must start with #
 	if len(line) == 0 || line[0] != '#' {
+		return nil
+	}
+
+	prev := block.PrecendingCharacter()
+	if prev != '\n' && !isTagBoundary(prev) {
 		return nil
 	}
 

--- a/web/src/utils/remark-plugins/remark-tag.ts
+++ b/web/src/utils/remark-plugins/remark-tag.ts
@@ -20,6 +20,10 @@ function isAsciiPunctuation(char: string): boolean {
   );
 }
 
+function isTagBoundary(char: string): boolean {
+  return char === "" || /^(?:\p{White_Space}|\p{P}|\p{S})$/u.test(char);
+}
+
 /**
  * Apply CommonMark backslash-unescaping to a raw source slice, tracking which
  * resulting characters came from an escape. `\#` yields a `#` flagged escaped,
@@ -60,7 +64,7 @@ function parseSegments(chars: string[], escaped: boolean[]): Segment[] {
       const prevChar = i > 0 ? chars[i - 1] : "";
       const nextChar = chars[i + 1];
 
-      if (prevChar === "#" || nextChar === "#" || nextChar === " ") {
+      if (prevChar === "#" || !isTagBoundary(prevChar) || nextChar === "#" || nextChar === " ") {
         segments.push({ type: "text", value: chars[i] });
         i++;
         continue;

--- a/web/tests/remark-tag.test.tsx
+++ b/web/tests/remark-tag.test.tsx
@@ -20,6 +20,18 @@ describe("remarkTag", () => {
     expect(html).toContain('data-tag="memo-tag"');
   });
 
+  it("requires a boundary before tags", () => {
+    const html = renderMarkdown('word#tag 1#numeric #standalone (#parentheses) [#brackets] "#quotes" +#symbol');
+
+    expect(html).not.toContain('data-tag="tag"');
+    expect(html).not.toContain('data-tag="numeric"');
+    expect(html).toContain('data-tag="standalone"');
+    expect(html).toContain('data-tag="parentheses"');
+    expect(html).toContain('data-tag="brackets"');
+    expect(html).toContain('data-tag="quotes"');
+    expect(html).toContain('data-tag="symbol"');
+  });
+
   it("does not turn link text or reference link fragments into tags", () => {
     const html = renderMarkdown(
       [


### PR DESCRIPTION
Fixes #6087.

## Summary

Tags were incorrectly recognized inside words, for example `word#tag`.

- Require a valid boundary before `#` in the backend parser and read-only renderer.
- Keep tags valid at the start of text and after whitespace, punctuation, or symbols.
- Keep frontend and backend behavior aligned.
- Leave autocomplete and valid tag characters unchanged.

## Validation

- `go test ./internal/markdown -run TestExtractTags -count=1`
- `go test ./internal/markdown/... -count=1`
- `go vet ./internal/markdown/...`
- `cd web && pnpm test tests/remark-tag.test.tsx`
- `cd web && pnpm lint`
- `cd web && pnpm build`
- `git diff --check`