### PR TITLE
fix(web): align radio button group indicator

### DIFF
--- a/web/src/components/ui/radio-group.tsx
+++ b/web/src/components/ui/radio-group.tsx
@@ -17,7 +17,7 @@ function RadioGroupItem({ className, ...props }: Radio.Root.Props) {
       )}
       {...props}
     >
-      <Radio.Indicator data-slot="radio-group-indicator" className="relative flex items-center justify-center">
+      <Radio.Indicator data-slot="radio-group-indicator" className="relative flex size-full items-center justify-center">
         <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
       </Radio.Indicator>
     </Radio.Root>


### PR DESCRIPTION
This PR fixes a visual alignment issue on the custom Radio Button component. Currently, the checked indicator (the center dot) is misplaced. 

**Screenhosts**

| Before | After |
| -------- | -------- |
| <img width="320" alt="setting-member-create-user-before" src="https://github.com/user-attachments/assets/fb57160c-9a80-48bf-b65c-6e7df6de7e32" /> | <img width="320" alt="setting-member-create-user-after" src="https://github.com/user-attachments/assets/ffd9a1d5-e168-4251-97f5-47fd043b6d6c" /> |
| <img width="320" alt="setting-storage-before" src="https://github.com/user-attachments/assets/734a0095-9323-4dff-b2f0-5ec0ec57bdc7" /> | <img width="320" alt="setting-storage-after" src="https://github.com/user-attachments/assets/a514160d-e247-4b3f-8a00-e04ca54de1ce" /> |