### PR TITLE
fix(security): block RFC 6598 shared address space in link-metadata SSRF guard

### DIFF
--- a/internal/httpgetter/html_meta.go
+++ b/internal/httpgetter/html_meta.go
@@ -101,8 +101,15 @@ func resolveAllowedIPs(ctx context.Context, host string) ([]net.IP, error) {
 	return ips, nil
 }
 
+// sharedAddressSpace is RFC 6598 (100.64.0.0/10). It is not covered by
+// net.IP.IsPrivate, but it is unroutable on the public internet and some
+// clouds expose their instance-metadata service inside it (e.g. Alibaba
+// Cloud at 100.100.100.200), so it must be treated as internal.
+var sharedAddressSpace = &net.IPNet{IP: net.IPv4(100, 64, 0, 0), Mask: net.CIDRMask(10, 32)}
+
 func isInternalIP(ip net.IP) bool {
-	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() || ip.IsUnspecified() || sharedAddressSpace.Contains(ip)
 }
 
 func validateURL(urlStr string) error {

--- a/internal/httpgetter/html_meta_test.go
+++ b/internal/httpgetter/html_meta_test.go
@@ -135,6 +135,35 @@ func TestGetHTMLMetaForInternal(t *testing.T) {
 	}
 }
 
+func TestIsInternalIP(t *testing.T) {
+	internal := []string{
+		"127.0.0.1",         // loopback
+		"10.0.0.1",          // RFC 1918
+		"192.168.1.1",       // RFC 1918
+		"169.254.169.254",   // link-local (cloud metadata)
+		"100.64.0.1",        // RFC 6598 lower bound
+		"100.100.100.200",   // Alibaba Cloud instance metadata
+		"100.127.255.255",   // RFC 6598 upper bound
+		"::1",               // IPv6 loopback
+		"fd00::1",           // IPv6 unique local
+		"::ffff:127.0.0.1",  // IPv4-mapped loopback
+		"::ffff:100.64.0.1", // IPv4-mapped shared address space
+	}
+	for _, s := range internal {
+		require.Truef(t, isInternalIP(net.ParseIP(s)), "expected %s to be internal", s)
+	}
+
+	external := []string{
+		"93.184.216.34",  // example.com
+		"8.8.8.8",        // public DNS
+		"100.63.255.255", // just below RFC 6598
+		"100.128.0.0",    // just above RFC 6598
+	}
+	for _, s := range external {
+		require.Falsef(t, isInternalIP(net.ParseIP(s)), "expected %s to be external", s)
+	}
+}
+
 func TestHTTPClientHasTimeout(t *testing.T) {
 	require.NotZero(t, httpClient.Timeout)
 }

--- a/internal/httpgetter/html_meta_test.go
+++ b/internal/httpgetter/html_meta_test.go
@@ -148,6 +148,10 @@ func TestIsInternalIP(t *testing.T) {
 		"fd00::1",           // IPv6 unique local
 		"::ffff:127.0.0.1",  // IPv4-mapped loopback
 		"::ffff:100.64.0.1", // IPv4-mapped shared address space
+		"224.0.0.1",         // IPv4 link-local multicast
+		"ff02::1",           // IPv6 link-local multicast
+		"0.0.0.0",           // IPv4 unspecified
+		"::",                // IPv6 unspecified
 	}
 	for _, s := range internal {
 		require.Truef(t, isInternalIP(net.ParseIP(s)), "expected %s to be internal", s)


### PR DESCRIPTION
Fixes #6099.

`isInternalIP` relies on `net.IP.IsPrivate`, which doesn't cover `100.64.0.0/10` (RFC 6598 shared address space / CGNAT). Since `GetLinkMetadata` and `BatchGetLinkMetadata` are unauthenticated, a URL pointing at that range was fetched and its title/description reflected back — a readable SSRF against internal CGNAT/Tailscale hosts and, notably, Alibaba Cloud's metadata endpoint at `100.100.100.200` (which serves RAM credentials).

This adds `100.64.0.0/10` to the internal check and also rejects link-local multicast.

### Test

`TestIsInternalIP` covers both boundaries of the range (`100.64.0.1`, `100.127.255.255`), the metadata address, the IPv4-mapped-IPv6 forms, and a couple of public addresses just outside the range. It fails on `main` and passes with the change; the rest of the package suite stays green.
