### PR TITLE
fix: keep apostrophes inside tags

### DIFF
--- a/internal/markdown/parser/tag.go
+++ b/internal/markdown/parser/tag.go
@@ -67,6 +67,14 @@ func isValidTagRune(r rune) bool {
 		return true
 	}
 
+	// Allow apostrophes, which occur inside words and names in many languages
+	// (e.g. Ukrainian сім'я, French aujourd'hui, names like O'Brien). Covers the
+	// ASCII apostrophe as well as the curly single quotes produced by autocorrect.
+	// The modifier-letter apostrophe (U+02BC) is already covered by unicode.IsLetter.
+	if r == '\'' || r == '‘' || r == '’' {
+		return true
+	}
+
 	return false
 }
 

--- a/internal/markdown/parser/tag_test.go
+++ b/internal/markdown/parser/tag_test.go
@@ -186,6 +186,36 @@ func TestTagParser(t *testing.T) {
 			expectedTag: "family👨‍👩‍👧‍👦",
 			shouldParse: true,
 		},
+		{
+			name:        "apostrophe inside tag (ASCII ', Ukrainian сім'я)",
+			input:       "#сім'я",
+			expectedTag: "сім'я",
+			shouldParse: true,
+		},
+		{
+			name:        "apostrophe inside tag (curly ’, autocorrected)",
+			input:       "#сім’я",
+			expectedTag: "сім’я",
+			shouldParse: true,
+		},
+		{
+			name:        "apostrophe in name (O'Brien)",
+			input:       "#O'Brien",
+			expectedTag: "O'Brien",
+			shouldParse: true,
+		},
+		{
+			name:        "modifier letter apostrophe ʼ (U+02BC, regression guard)",
+			input:       "#сімʼя",
+			expectedTag: "сімʼя",
+			shouldParse: true,
+		},
+		{
+			name:        "apostrophe then space stops the tag",
+			input:       "#сім'я тест",
+			expectedTag: "сім'я",
+			shouldParse: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/web/src/utils/tag-grammar.ts
+++ b/web/src/utils/tag-grammar.ts
@@ -4,13 +4,15 @@
  * can't drift.
  *
  * A tag character is any Unicode letter, mark, number, or symbol, plus
- * `_ - / &`. The mark class (`\p{M}`) keeps combining marks — Indic vowel
- * signs, Arabic harakat, Hebrew niqqud, decomposed accents — attached to the
- * base letters they belong to, so a tag like `#കവിത` isn't cut short at its
- * first vowel sign.
+ * `_ - / &` and apostrophes. The mark class (`\p{M}`) keeps combining marks —
+ * Indic vowel signs, Arabic harakat, Hebrew niqqud, decomposed accents —
+ * attached to the base letters they belong to, so a tag like `#കവിത` isn't cut
+ * short at its first vowel sign. The apostrophes (ASCII `'` plus the curly
+ * `‘ ’` autocorrect produces) keep intra-word apostrophes — Ukrainian `#сім'я`,
+ * French `#aujourd'hui`, names like `#O'Brien` — from cutting the tag short.
  * A tag run is capped at MAX_TAG_LENGTH characters.
  */
-export const TAG_CHAR_CLASS = "[\\p{L}\\p{M}\\p{N}\\p{S}_\\-/&]";
+export const TAG_CHAR_CLASS = "[\\p{L}\\p{M}\\p{N}\\p{S}_\\-/&'‘’]";
 
 export const MAX_TAG_LENGTH = 100;
 

--- a/web/tests/remark-tag.test.tsx
+++ b/web/tests/remark-tag.test.tsx
@@ -87,4 +87,20 @@ describe("remarkTag", () => {
     expect(html).toContain('data-tag="cartoon"');
     expect(html).toContain("Tom &amp; Jerry");
   });
+
+  it("keeps an apostrophe inside a tag", () => {
+    // Ukrainian сім'я (family) and names like O'Brien contain an apostrophe
+    // between letters; the tag must not stop at the apostrophe. Covers the ASCII
+    // apostrophe and the curly quote (’, U+2019) autocorrect produces.
+    const html = renderMarkdown("#сім'я and #O'Brien and #сім’я");
+
+    // renderToStaticMarkup HTML-escapes the ASCII apostrophe to &#x27; (it
+    // renders as ' in the browser); the curly ’ is emitted as-is.
+    expect(html).toContain(`data-tag="сім&#x27;я"`);
+    expect(html).toContain(`data-tag="O&#x27;Brien"`);
+    expect(html).toContain(`data-tag="сім’я"`);
+    // The tag must not stop at the apostrophe.
+    expect(html).not.toContain('data-tag="сім"');
+    expect(html).not.toContain('data-tag="O"');
+  });
 });


### PR DESCRIPTION
## What

Fixes #6078 — an apostrophe inside a tag truncates it. `#сім'я` (Ukrainian for *family*) becomes `#сім`, `#O'Brien` becomes `#O`.

## Why

A tag character is validated by Unicode category. The apostrophe is punctuation — `'` (U+0027) is `Po`, and the curly quotes autocorrect produces (`'` U+2019, `'` U+2018) are `Pf`/`Pi` — none of which pass the letter/mark/number/symbol test, so the tag scan stops at the apostrophe.

(Interestingly, the *modifier-letter* apostrophe `ʼ` U+02BC is category `Lm` and already worked via `unicode.IsLetter`, but no keyboard produces it by default.)

## Change

Allow the ASCII apostrophe and the two curly single quotes in both definitions of the tag grammar, keeping backend and frontend in sync:

- **Backend:** `isValidTagRune` in `internal/markdown/parser/tag.go`
- **Frontend:** `TAG_CHAR_CLASS` in `web/src/utils/tag-grammar.ts` (the single source shared by the editor, renderer, autocomplete, and serialize round-trip)

This is consistent with how the grammar already treats `-`, `_`, `/`, `&`.

### Note for reviewers
This means a trailing/possessive apostrophe is now part of the tag (e.g. `#client's` → `client's`), matching the existing behaviour for the other allowed non-alphanumeric characters. If you'd prefer an interior-only rule (apostrophe kept only *between* two tag characters), I'm happy to switch — it's a bigger change on the frontend since it can't be expressed as a plain character-class member.

## Tests
- Go: added apostrophe cases (ASCII, curly, `O'Brien`, trailing-stops-at-space) plus a U+02BC regression guard in `tag_test.go`
- Frontend: added a renderer test in `remark-tag.test.tsx`
- `go test -race ./internal/...` ✅  ·  `cd web && pnpm lint && pnpm test` (244 tests) ✅