### PR TITLE
feat(web): add wide memo content layout

### DIFF
--- a/web/src/components/MemoDisplaySettingMenu.tsx
+++ b/web/src/components/MemoDisplaySettingMenu.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { MAX_COLUMNS_VALUES, type MemoMaxColumns, useView } from "@/contexts/ViewContext";
+import { CONTENT_WIDTH_VALUES, MAX_COLUMNS_VALUES, type MemoContentWidth, type MemoMaxColumns, useView } from "@/contexts/ViewContext";
 import { cn } from "@/lib/utils";
 import { useTranslate } from "@/utils/i18n";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
@@ -30,15 +30,18 @@ function MemoDisplaySettingMenu({ className }: Props) {
     compactMode,
     linkPreview,
     maxColumns,
+    contentWidth,
     setTimeBasis,
     toggleSortOrder,
     setCompactMode,
     setLinkPreview,
     setMaxColumns,
+    setContentWidth,
   } = useView();
   // Multi-column grids always render compact tiles, so the toggle is shown as on and locked
   // there; it only becomes a real choice at a single column.
   const compactLocked = maxColumns !== 1;
+  const contentWidthLocked = maxColumns !== 1;
 
   const timeBasisOptions = useMemo(
     () => [
@@ -52,6 +55,14 @@ function MemoDisplaySettingMenu({ className }: Props) {
       { value: "false", label: t("memo.newest-first") },
       { value: "true", label: t("memo.oldest-first") },
     ],
+    [t],
+  );
+  const contentWidthOptions = useMemo(
+    () =>
+      CONTENT_WIDTH_VALUES.map((value) => ({
+        value,
+        label: t(`memo.content-width-${value}` as `memo.content-width-${MemoContentWidth}`),
+      })),
     [t],
   );
 
@@ -113,6 +124,28 @@ function MemoDisplaySettingMenu({ className }: Props) {
           <div className="w-full flex flex-row justify-between items-center">
             <span className="text-sm shrink-0 mr-3 text-foreground">{t("memo.link-preview")}</span>
             <Switch checked={linkPreview} onCheckedChange={setLinkPreview} />
+          </div>
+          <div className="w-full flex flex-row justify-between items-center">
+            <span className={cn("text-sm shrink-0 mr-3", contentWidthLocked ? "text-muted-foreground" : "text-foreground")}>
+              {t("memo.content-width")}
+            </span>
+            <Select
+              value={contentWidth}
+              items={contentWidthOptions}
+              onValueChange={(value) => setContentWidth(value === "wide" ? "wide" : "standard")}
+              disabled={contentWidthLocked}
+            >
+              <SelectTrigger size="sm" className="w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {contentWidthOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
           <div className="w-full flex flex-row justify-between items-center border-t border-border/50 pt-2">
             <span className="text-sm shrink-0 mr-3 text-foreground">{t("memo.layout")}</span>

--- a/web/src/components/PagedMemoList/PagedMemoList.tsx
+++ b/web/src/components/PagedMemoList/PagedMemoList.tsx
@@ -6,7 +6,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useInstance } from "@/contexts/InstanceContext";
 import { useMemoFilterContext } from "@/contexts/MemoFilterContext";
 import { useNewMemo } from "@/contexts/NewMemoContext";
-import { useView } from "@/contexts/ViewContext";
+import { type MemoContentWidth, useView } from "@/contexts/ViewContext";
 import { useDelayedFlag } from "@/hooks/useDelayedFlag";
 import { useInfiniteMemos } from "@/hooks/useMemoQueries";
 import { hoistMemoToFront } from "@/hooks/useMemoSorting";
@@ -27,6 +27,11 @@ export const getMemoKey = (memo: Memo) => `${memo.name}-${memo.updateTime}`;
 // Columns never stretch past this, so 2 columns on a wide monitor stay readable and the
 // grid centers in the leftover space instead of filling it.
 const MAX_COLUMN_WIDTH = 420;
+
+const SINGLE_COLUMN_WIDTH_CLASSES = {
+  standard: "max-w-2xl",
+  wide: "max-w-5xl",
+} satisfies Record<MemoContentWidth, string>;
 
 const Loader = () => (
   <div className="w-full flex flex-row justify-center items-center py-8">
@@ -116,7 +121,7 @@ const PagedMemoList = (props: Props) => {
   const { isInitialized: authInitialized } = useAuth();
   const { isInitialized: instanceInitialized } = useInstance();
   const { filters } = useMemoFilterContext();
-  const { maxColumns, compactMode } = useView();
+  const { maxColumns, compactMode, contentWidth } = useView();
   // maxColumns is a ceiling: 1 = single reading column, 0 = as many as fit. The single
   // column renders in normal document flow; anything wider becomes the packed grid.
   const multiColumn = maxColumns !== 1;
@@ -250,7 +255,9 @@ const PagedMemoList = (props: Props) => {
   const children = (
     <MentionResolutionProvider contents={contents} userNames={userNames}>
       <div ref={layoutMeasureRef} className="w-full">
-        <div className={cn("flex flex-col justify-start w-full mx-auto", useGrid ? "max-w-none" : "max-w-2xl")}>
+        <div
+          className={cn("flex flex-col justify-start w-full mx-auto", useGrid ? "max-w-none" : SINGLE_COLUMN_WIDTH_CLASSES[contentWidth])}
+        >
           {/* During initial load, show the spinner only after the delay; render nothing before then to avoid a flash. */}
           {isDisplayPending ? (
             showLoader ? (

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -66,11 +66,13 @@ function SelectContent({
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Positioner
+        data-slot="select-positioner"
         align={align}
         alignItemWithTrigger={alignItemWithTrigger}
         alignOffset={alignOffset}
         side={side}
         sideOffset={sideOffset}
+        className="isolate z-dropdown"
       >
         <SelectPrimitive.Popup
           data-slot="select-content"

--- a/web/src/contexts/ViewContext.tsx
+++ b/web/src/contexts/ViewContext.tsx
@@ -6,6 +6,9 @@ export type MemoTimeBasis = "create_time" | "update_time";
 export const MAX_COLUMNS_VALUES = [1, 2, 3, 0] as const;
 export type MemoMaxColumns = (typeof MAX_COLUMNS_VALUES)[number];
 
+export const CONTENT_WIDTH_VALUES = ["standard", "wide"] as const;
+export type MemoContentWidth = (typeof CONTENT_WIDTH_VALUES)[number];
+
 interface ViewState {
   orderByTimeAsc: boolean;
   timeBasis?: MemoTimeBasis;
@@ -13,6 +16,7 @@ interface ViewState {
   compactMode: boolean;
   linkPreview: boolean;
   maxColumns: MemoMaxColumns;
+  contentWidth: MemoContentWidth;
 }
 
 interface ViewContextValue {
@@ -21,18 +25,26 @@ interface ViewContextValue {
   compactMode: boolean;
   linkPreview: boolean;
   maxColumns: MemoMaxColumns;
+  contentWidth: MemoContentWidth;
   toggleSortOrder: () => void;
   setTimeBasis: (field: MemoTimeBasis) => void;
   setCompactMode: (value: boolean) => void;
   setLinkPreview: (value: boolean) => void;
   setMaxColumns: (value: MemoMaxColumns) => void;
+  setContentWidth: (value: MemoContentWidth) => void;
 }
 
 const ViewContext = createContext<ViewContextValue | null>(null);
 
 const LOCAL_STORAGE_KEY = "memos-view-setting";
 
-const DEFAULT_VIEW_STATE: ViewState = { orderByTimeAsc: false, compactMode: false, linkPreview: true, maxColumns: 1 };
+const DEFAULT_VIEW_STATE: ViewState = {
+  orderByTimeAsc: false,
+  compactMode: false,
+  linkPreview: true,
+  maxColumns: 1,
+  contentWidth: "standard",
+};
 
 export function ViewProvider({ children }: { children: ReactNode }) {
   const getInitialState = (): ViewState => {
@@ -45,12 +57,16 @@ export function ViewProvider({ children }: { children: ReactNode }) {
         const maxColumns = MAX_COLUMNS_VALUES.includes(data.maxColumns as MemoMaxColumns)
           ? (data.maxColumns as MemoMaxColumns)
           : DEFAULT_VIEW_STATE.maxColumns;
+        const contentWidth = CONTENT_WIDTH_VALUES.includes(data.contentWidth as MemoContentWidth)
+          ? (data.contentWidth as MemoContentWidth)
+          : DEFAULT_VIEW_STATE.contentWidth;
         return {
           orderByTimeAsc: Boolean(data.orderByTimeAsc ?? DEFAULT_VIEW_STATE.orderByTimeAsc),
           timeBasis,
           compactMode: Boolean(data.compactMode ?? DEFAULT_VIEW_STATE.compactMode),
           linkPreview: Boolean(data.linkPreview ?? DEFAULT_VIEW_STATE.linkPreview),
           maxColumns,
+          contentWidth,
         };
       }
     } catch (error) {
@@ -83,6 +99,7 @@ export function ViewProvider({ children }: { children: ReactNode }) {
   const setCompactMode = (value: boolean) => updateState({ compactMode: value });
   const setLinkPreview = (value: boolean) => updateState({ linkPreview: value });
   const setMaxColumns = (value: MemoMaxColumns) => updateState({ maxColumns: value });
+  const setContentWidth = (value: MemoContentWidth) => updateState({ contentWidth: value });
 
   return (
     <ViewContext.Provider
@@ -92,11 +109,13 @@ export function ViewProvider({ children }: { children: ReactNode }) {
         compactMode: viewState.compactMode,
         linkPreview: viewState.linkPreview,
         maxColumns: viewState.maxColumns,
+        contentWidth: viewState.contentWidth,
         toggleSortOrder,
         setTimeBasis,
         setCompactMode,
         setLinkPreview,
         setMaxColumns,
+        setContentWidth,
       }}
     >
       {children}

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -293,6 +293,9 @@
       "label": "Filters"
     },
     "compact-mode": "Compact mode",
+    "content-width": "Content width",
+    "content-width-standard": "Standard",
+    "content-width-wide": "Wide",
     "layout": "Layout",
     "layout-auto": "Auto",
     "layout-auto-description": "As many columns as fit the screen",

--- a/web/src/locales/zh-Hans.json
+++ b/web/src/locales/zh-Hans.json
@@ -246,6 +246,9 @@
       "label": "过滤器"
     },
     "compact-mode": "紧凑模式",
+    "content-width": "内容宽度",
+    "content-width-standard": "标准",
+    "content-width-wide": "宽屏",
     "layout": "布局",
     "layout-auto": "自动",
     "layout-auto-description": "根据屏幕宽度显示尽可能多的列",

--- a/web/tests/paged-memo-list.test.tsx
+++ b/web/tests/paged-memo-list.test.tsx
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import PagedMemoList from "@/components/PagedMemoList";
 import type { Memo } from "@/types/proto/api/v1/memo_service_pb";
 
-const view = vi.hoisted(() => ({ maxColumns: 1 as 0 | 1 | 2 | 3, compactMode: false }));
+const view = vi.hoisted(() => ({
+  maxColumns: 1 as 0 | 1 | 2 | 3,
+  compactMode: false,
+  contentWidth: "standard" as "standard" | "wide",
+}));
 const feed = vi.hoisted(() => ({
   memos: [] as unknown[],
   hasNextPage: false,
@@ -66,6 +70,7 @@ describe("<PagedMemoList>", () => {
   beforeEach(() => {
     view.maxColumns = 1;
     view.compactMode = false;
+    view.contentWidth = "standard";
     feed.memos = [];
     feed.hasNextPage = false;
     feed.fetchNextPage.mockClear();
@@ -127,6 +132,24 @@ describe("<PagedMemoList>", () => {
     } finally {
       widthSpy.mockRestore();
     }
+  });
+
+  describe("single-column width", () => {
+    it("uses the reading width by default", () => {
+      const { container } = renderList();
+
+      expect(container.querySelector(".max-w-2xl")).toBeInTheDocument();
+      expect(container.querySelector(".max-w-5xl")).not.toBeInTheDocument();
+    });
+
+    it("uses the wider width when selected", () => {
+      view.contentWidth = "wide";
+
+      const { container } = renderList();
+
+      expect(container.querySelector(".max-w-5xl")).toBeInTheDocument();
+      expect(container.querySelector(".max-w-2xl")).not.toBeInTheDocument();
+    });
   });
 
   describe("compact policy", () => {

--- a/web/tests/select-layering.test.tsx
+++ b/web/tests/select-layering.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+const options = [
+  { value: "standard", label: "Standard" },
+  { value: "wide", label: "Wide" },
+];
+
+describe("<Select>", () => {
+  it("places its portal positioner at the dropdown stacking tier", () => {
+    render(
+      <Select open value="standard" items={options}>
+        <SelectTrigger>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>,
+    );
+
+    expect(screen.getByText("Wide")).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="select-positioner"]')).toHaveClass("isolate", "z-dropdown");
+  });
+});

--- a/web/tests/view-context-columns.test.tsx
+++ b/web/tests/view-context-columns.test.tsx
@@ -9,7 +9,7 @@ const wrapper = ({ children }: { children: ReactNode }) => <ViewProvider>{childr
 
 const persisted = () => JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) ?? "{}");
 
-describe("ViewContext maxColumns setting", () => {
+describe("ViewContext display settings", () => {
   beforeEach(() => {
     localStorage.clear();
   });
@@ -42,5 +42,35 @@ describe("ViewContext maxColumns setting", () => {
     const { result } = renderHook(() => useView(), { wrapper });
 
     expect(result.current.maxColumns).toBe(1);
+  });
+
+  it("defaults to the standard content width", () => {
+    const { result } = renderHook(() => useView(), { wrapper });
+    expect(result.current.contentWidth).toBe("standard");
+  });
+
+  it("updates and persists the content width", () => {
+    const { result } = renderHook(() => useView(), { wrapper });
+
+    act(() => result.current.setContentWidth("wide"));
+
+    expect(result.current.contentWidth).toBe("wide");
+    expect(persisted().contentWidth).toBe("wide");
+  });
+
+  it("restores a persisted content width on init", () => {
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify({ contentWidth: "wide" }));
+
+    const { result } = renderHook(() => useView(), { wrapper });
+
+    expect(result.current.contentWidth).toBe("wide");
+  });
+
+  it("falls back to the standard content width for an invalid persisted value", () => {
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify({ contentWidth: "full" }));
+
+    const { result } = renderHook(() => useView(), { wrapper });
+
+    expect(result.current.contentWidth).toBe("standard");
   });
 });


### PR DESCRIPTION
## Summary

- add a Standard / Wide content-width option to the memo display settings
- persist the selection through the existing `memos-view-setting` preference
- widen single-column feeds and their composer from `max-w-2xl` to `max-w-5xl` when enabled
- preserve the current reading width by default and leave multi-column layouts unchanged
- keep nested Select portals above their parent popovers so every display-setting menu remains fully visible
- add English and Simplified Chinese labels

## Why

On large desktop viewports, the single-column memo feed remains constrained to a narrow reading width while substantial horizontal space is unused. Longer memos, tables, and code blocks wrap excessively even when the viewport has room.

This adds an opt-in wide layout without changing the default experience or requiring backend/schema changes.

## Validation

- `cd web && pnpm lint`
- `cd web && pnpm test` — 59 files, 250 tests passed
- `cd web && pnpm build`

Closes #6116
