### PR TITLE
ci: attest build provenance for the release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write # for build provenance signing
+      attestations: write # to record the attestation
     steps:
       - name: Download binary artifacts
         uses: actions/download-artifact@v4
@@ -244,6 +246,11 @@ jobs:
         with:
           name: checksums
           path: artifacts
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-path: artifacts/*
 
       - name: Publish release assets
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Hi, and thanks for memos.

The release workflow is already in good shape — separate build, checksum and publish jobs, `sha256sum` over every binary, and least-privilege `permissions:` on each job individually. This is a small addition in the same spirit.

Right now the release assets carry a `checksums.txt` but no provenance. The checksums prove the binaries match what the `checksums` job saw; they cannot show that the binaries were produced by this workflow, from this repository, at that tag. For a self-hosted application, where people download `memos_..._linux_amd64` straight from the release page and run it on their own server, that origin question is the one they cannot currently answer.

This PR adds GitHub's build attestation to the `release` job, after the artifacts are downloaded and before `softprops/action-gh-release` uploads them:

```yaml
    permissions:
      contents: write
      id-token: write      # for build provenance signing
      attestations: write  # to record the attestation
...
      - name: Attest build provenance
        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
        with:
          subject-path: artifacts/*
```

`artifacts/*` is the same glob the upload step already uses, so it covers every binary and the checksums file without a second list to keep in sync. After a release:

```
gh attestation verify memos_<version>_linux_amd64 --repo usememos/memos
```

reports the workflow, commit and run that built it. The two permissions are added only to the `release` job, so the rest of the workflow is unchanged.

I deliberately left the container images alone in this PR. The `build-push` job builds per-platform and `merge-images` then combines them with `imagetools`, and attestations interact with manifest merging in ways I did not want to guess at from outside. If you would like the images covered too, I am happy to look at that separately — `provenance: mode=max` on the per-platform builds is usually the route, but it deserves its own review.

No SLSA level is claimed here; the attestation is what it is.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and its job structure myself.
