### PR TITLE
feat/web: add memo detail shortcut button

### DIFF
--- a/web/src/components/MemoView/components/MemoHeader.tsx
+++ b/web/src/components/MemoView/components/MemoHeader.tsx
@@ -1,4 +1,4 @@
-import { BookmarkIcon } from "lucide-react";
+import { ArrowUpRightIcon, BookmarkIcon } from "lucide-react";
 import { useCallback, useState } from "react";
 import { Link } from "react-router-dom";
 import RelativeTime from "@/components/RelativeTime";
@@ -78,6 +78,8 @@ const MemoHeader: React.FC<MemoHeaderProps> = ({ showCreator, showVisibility, sh
           />
         )}
 
+        <MemoDetailLinkButton memoName={memo.name} />
+
         {showVisibility && memo.visibility !== Visibility.PRIVATE && (
           <Tooltip>
             <TooltipTrigger>
@@ -109,6 +111,17 @@ const MemoHeader: React.FC<MemoHeaderProps> = ({ showCreator, showVisibility, sh
     </div>
   );
 };
+
+export const MemoDetailLinkButton: React.FC<{ memoName: string }> = ({ memoName }) => (
+  <Link
+    aria-label="Open memo"
+    className="h-6 w-6 flex sm:hidden sm:group-hover:flex justify-center items-center cursor-pointer transition-colors text-muted-foreground hover:text-foreground"
+    to={`/${memoName}`}
+    viewTransition
+  >
+    <ArrowUpRightIcon className="w-4 h-4" />
+  </Link>
+);
 
 interface CreatorDisplayProps {
   creator: User;

--- a/web/tests/memo-detail-link-button.test.tsx
+++ b/web/tests/memo-detail-link-button.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { MemoDetailLinkButton } from "@/components/MemoView/components/MemoHeader";
+
+describe("<MemoDetailLinkButton>", () => {
+  it("links to the memo detail page", () => {
+    render(
+      <MemoryRouter>
+        <MemoDetailLinkButton memoName="memos/abc123" />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link", { name: "Open memo" });
+    expect(link).toHaveAttribute("href", "/memos/abc123");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a small hover quick action for opening a memo detail page directly from the memo header.

This uses an `ArrowUpRight` icon link next to the existing inline actions, visible on mobile and on memo hover for larger screens. It is intended as a lightweight shortcut for users who frequently jump from the feed into a memo detail view.

This is related to #6055, which asks for quicker inline memo actions without going through the overflow menu.

## Changes

- Add `MemoDetailLinkButton` to `MemoHeader`
- Link the button to the memo detail route
- Add a focused test for the generated detail link

## Checks

- `./node_modules/.bin/vitest run tests/memo-detail-link-button.test.tsx`
- `pnpm lint`
- `pnpm release`
