### PR TITLE
feat/web: add memo detail shortcut button

### DIFF
--- a/web/src/components/MemoView/components/MemoHeader.tsx
+++ b/web/src/components/MemoView/components/MemoHeader.tsx
@@ -1,4 +1,4 @@
-import { BookmarkIcon } from "lucide-react";
+import { ArrowUpRightIcon, BookmarkIcon } from "lucide-react";
 import { useCallback, useState } from "react";
 import { Link } from "react-router-dom";
 import RelativeTime from "@/components/RelativeTime";
@@ -24,7 +24,14 @@ const MemoHeader: React.FC<MemoHeaderProps> = ({ showCreator, showVisibility, sh
   const [reactionSelectorOpen, setReactionSelectorOpen] = useState(false);
 
   const { memo, creator, currentUser, parentPage, isArchived, readonly, openEditor } = useMemoViewContext();
-  const { createTime, updateTime, displayTime: memoDisplayTime, isDisplayingUpdatedTime, relativeTimeFormat } = useMemoViewDerived();
+  const {
+    createTime,
+    updateTime,
+    displayTime: memoDisplayTime,
+    isDisplayingUpdatedTime,
+    isInMemoDetailPage,
+    relativeTimeFormat,
+  } = useMemoViewDerived();
   const { newMemoName } = useNewMemo();
 
   const navigateTo = useNavigateTo();
@@ -78,6 +85,14 @@ const MemoHeader: React.FC<MemoHeaderProps> = ({ showCreator, showVisibility, sh
           />
         )}
 
+        {!isInMemoDetailPage && (
+          <MemoDetailLinkButton
+            ariaLabel={`${t("attachment-library.actions.open")} ${t("common.memo")}`}
+            memoName={memo.name}
+            parentPage={parentPage}
+          />
+        )}
+
         {showVisibility && memo.visibility !== Visibility.PRIVATE && (
           <Tooltip>
             <TooltipTrigger>
@@ -109,6 +124,25 @@ const MemoHeader: React.FC<MemoHeaderProps> = ({ showCreator, showVisibility, sh
     </div>
   );
 };
+
+export const MemoDetailLinkButton: React.FC<{ ariaLabel: string; memoName: string; parentPage: string }> = ({
+  ariaLabel,
+  memoName,
+  parentPage,
+}) => (
+  <Link
+    aria-label={ariaLabel}
+    className={cn(
+      "h-6 w-6 flex justify-center items-center cursor-pointer transition-colors text-muted-foreground hover:text-foreground",
+      "sm:opacity-0 sm:group-hover:opacity-100 sm:focus-visible:opacity-100",
+    )}
+    state={{ from: parentPage }}
+    to={`/${memoName}`}
+    viewTransition
+  >
+    <ArrowUpRightIcon className="w-4 h-4" />
+  </Link>
+);
 
 interface CreatorDisplayProps {
   creator: User;

--- a/web/tests/memo-detail-link-button.test.tsx
+++ b/web/tests/memo-detail-link-button.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { MemoDetailLinkButton } from "@/components/MemoView/components/MemoHeader";
+
+const LocationState = () => {
+  const location = useLocation();
+  return <span data-testid="from">{location.state?.from}</span>;
+};
+
+describe("<MemoDetailLinkButton>", () => {
+  it("links to the memo detail page with parent page state", () => {
+    render(
+      <MemoryRouter>
+        <Routes>
+          <Route
+            path="/"
+            element={<MemoDetailLinkButton ariaLabel="Open Memo" memoName="memos/abc123" parentPage="/explore" />}
+          />
+          <Route path="/memos/abc123" element={<LocationState />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link", { name: "Open Memo" });
+    expect(link).toHaveAttribute("href", "/memos/abc123");
+
+    fireEvent.click(link);
+    expect(screen.getByTestId("from")).toHaveTextContent("/explore");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a small hover quick action for opening a memo detail page directly from the memo header.

This uses an `ArrowUpRight` icon link next to the existing inline actions, visible on mobile and on memo hover for larger screens. It is intended as a lightweight shortcut for users who frequently jump from the feed into a memo detail view.

This is related to #6055, which asks for quicker inline memo actions without going through the overflow menu.

## Changes

- Add `MemoDetailLinkButton` to `MemoHeader`
- Link the button to the memo detail route
- Add a focused test for the generated detail link

## Checks

- `./node_modules/.bin/vitest run tests/memo-detail-link-button.test.tsx`
- `pnpm lint`
- `pnpm release`
