### PR TITLE
fix(web): keep share token on shared-memo attachment thumbnails

### DIFF
--- a/web/src/utils/attachment.ts
+++ b/web/src/utils/attachment.ts
@@ -8,11 +8,34 @@ export const getAttachmentUrl = (attachment: Attachment) => {
   return `${window.location.origin}/file/${attachment.name}/${attachment.filename}`;
 };
 
+// Appends a flag param to share-mode links so anonymous viewers stay authorized; S3 presigned URLs are left untouched.
+const withShareTokenParam = (externalLink: string | undefined, key: string): string | undefined => {
+  if (!externalLink) {
+    return undefined;
+  }
+  const url = new URL(externalLink, window.location.origin);
+  if (!url.searchParams.has("share_token")) {
+    return undefined;
+  }
+  url.searchParams.set(key, "true");
+  return url.toString();
+};
+
 export const getAttachmentThumbnailUrl = (attachment: Attachment) => {
+  const shareUrl = withShareTokenParam(attachment.externalLink, "thumbnail");
+  if (shareUrl) {
+    return shareUrl;
+  }
+
   return `${window.location.origin}/file/${attachment.name}/${attachment.filename}?thumbnail=true`;
 };
 
 export const getAttachmentMotionClipUrl = (attachment: Attachment) => {
+  const shareUrl = withShareTokenParam(attachment.externalLink, "motion");
+  if (shareUrl) {
+    return shareUrl;
+  }
+
   return `${window.location.origin}/file/${attachment.name}/${attachment.filename}?motion=true`;
 };
 

--- a/web/tests/attachment-urls.test.ts
+++ b/web/tests/attachment-urls.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { Attachment } from "@/types/proto/api/v1/attachment_service_pb";
+import { getAttachmentMotionClipUrl, getAttachmentThumbnailUrl, getAttachmentUrl } from "@/utils/attachment";
+
+const origin = window.location.origin;
+
+const baseAttachment = {
+  name: "attachments/test-uid",
+  filename: "photo.png",
+  type: "image/png",
+} as Attachment;
+
+// Regression tests for #6128: share-mode thumbnails/motion clips must keep the share token on externalLink.
+describe("attachment URL builders in share mode", () => {
+  it("appends thumbnail=true to an externalLink that carries a share token", () => {
+    const attachment = {
+      ...baseAttachment,
+      externalLink: `${origin}/file/attachments/test-uid/photo.png?share_token=abc123`,
+    } as Attachment;
+
+    const url = new URL(getAttachmentThumbnailUrl(attachment));
+    expect(url.searchParams.get("thumbnail")).toBe("true");
+    expect(url.searchParams.get("share_token")).toBe("abc123");
+  });
+
+  it("appends motion=true to an externalLink that carries a share token", () => {
+    const attachment = {
+      ...baseAttachment,
+      externalLink: `${origin}/file/attachments/test-uid/photo.png?share_token=abc123`,
+    } as Attachment;
+
+    const url = new URL(getAttachmentMotionClipUrl(attachment));
+    expect(url.searchParams.get("motion")).toBe("true");
+    expect(url.searchParams.get("share_token")).toBe("abc123");
+  });
+
+  it("keeps the server thumbnail URL when externalLink has no share token (e.g. S3 presigned)", () => {
+    const attachment = {
+      ...baseAttachment,
+      externalLink: "https://s3.example.com/bucket/photo.png?X-Amz-Signature=xyz",
+    } as Attachment;
+
+    expect(getAttachmentThumbnailUrl(attachment)).toBe(`${origin}/file/attachments/test-uid/photo.png?thumbnail=true`);
+  });
+
+  it("keeps the server thumbnail URL when no externalLink is set", () => {
+    expect(getAttachmentThumbnailUrl(baseAttachment)).toBe(`${origin}/file/attachments/test-uid/photo.png?thumbnail=true`);
+  });
+
+  it("leaves getAttachmentUrl returning the externalLink verbatim", () => {
+    const attachment = {
+      ...baseAttachment,
+      externalLink: `${origin}/file/attachments/test-uid/photo.png?share_token=abc123`,
+    } as Attachment;
+
+    expect(getAttachmentUrl(attachment)).toBe(attachment.externalLink);
+  });
+});


### PR DESCRIPTION
### Summary

Fixes #6128. On share pages, inline image previews returned 401 for anonymous viewers while download links for the same files worked.

The share token is carried on `attachment.externalLink` (`withShareAttachmentLinks` in share mode), and `getAttachmentUrl` honors it, so downloads work. The thumbnail and motion-clip URL builders (`getAttachmentThumbnailUrl`, `getAttachmentMotionClipUrl`) ignored `externalLink` entirely and always built `?thumbnail=true` without the token, so anonymous viewers got 401s on every inline preview.

### Changes

- `web/src/utils/attachment.ts`: append `thumbnail=true` / `motion=true` to the share-mode `externalLink` (which already carries `share_token`) instead of building a token-less URL. S3 presigned URLs are left untouched, since appending params would break their signatures.
- `web/tests/attachment-urls.test.ts`: regression tests for token propagation in both builders, plus unchanged behavior for S3-style and token-less attachments.

### Testing

- `pnpm test`: 643 tests passing (5 new)
- `pnpm lint`: tsc + Biome clean
- Manual E2E on a fresh instance: private memo with PNG + PDF, shared, opened in an incognito window

**Before** (broken image, 401 on `?thumbnail=true`):
<img width="1294" height="297" alt="memos-before" src="https://github.com/user-attachments/assets/95d1d2aa-f424-4370-8c38-64815e0401c3" />

**After** (thumbnail renders, 200 on `?thumbnail=true&share_token=...`):
<img width="1107" height="297" alt="memos-after" src="https://github.com/user-attachments/assets/57fedd30-e991-4933-b558-93ac2c550950" />

Note: the test PNG is a 1x1 red pixel, so the visible image content above is tiny; what matters is that the element renders instead of showing a broken-image placeholder.

### Known limitation (pre-existing, out of scope)

On S3-backed instances, share-page thumbnails still 401 for anonymous viewers: presigned URLs can't carry the share token, and the server-side thumbnail path isn't reachable with one either. This PR does not regress that path.