### PR TITLE
fix: align memo outline links with rendered headings

### DIFF
--- a/web/src/utils/markdown-manipulation.ts
+++ b/web/src/utils/markdown-manipulation.ts
@@ -137,11 +137,13 @@ export function extractHeadings(markdown: string): HeadingItem[] {
 }
 
 interface MdastNode {
+  type?: string;
   value?: string;
   children?: MdastNode[];
 }
 
 function getNodeText(node: MdastNode): string {
+  if (node.type === "html") return "";
   if (node.value) return node.value;
   if (node.children) return node.children.map(getNodeText).join("");
   return "";

--- a/web/tests/markdown-manipulation.test.ts
+++ b/web/tests/markdown-manipulation.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { extractHeadings } from "@/utils/markdown-manipulation";
+
+describe("extractHeadings", () => {
+  it("uses rendered text for headings containing inline HTML", () => {
+    const headings = extractHeadings(`# <ruby>連濁<rt>れんだく</rt></ruby>: "Why Hito-Bito isn't Hito-Hito"`);
+
+    expect(headings).toEqual([
+      {
+        text: `連濁れんだく: "Why Hito-Bito isn't Hito-Hito"`,
+        level: 1,
+        slug: "why-hito-bito-isnt-hito-hito",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes: For the ruby-markup heading reported in item 3 of #6154, the memo outline displays raw <ruby>/<rt> tags and generates a fragment that does not match the rendered heading ID, so outline navigation cannot reach the heading.
- Root cause: extractHeadings recursively treats mdast html marker nodes as visible text, while the rendered HAST heading excludes those markers before rehypeHeadingId computes its ID. The outline therefore derives both its label and slug from a different string than the renderer.

## Regression evidence

- Before: `npx --yes pnpm@11.0.1 test -- tests/markdown-manipulation.test.ts` exited `1`

- After: `npx --yes pnpm@11.0.1 test -- tests/markdown-manipulation.test.ts` exited `0`

## Verification

- `npx --yes pnpm@11.0.1 exec vitest run tests/markdown-manipulation.test.ts`
- `npx --yes pnpm@11.0.1 test`
- `npx --yes pnpm@11.0.1 lint`
- `npx --yes pnpm@11.0.1 build`

## Scope

- 2 files changed, +18 / -0 lines
