### PR TITLE
fix: hide note outline for blurred memos

### DIFF
--- a/web/src/components/AppSidebar/AppSidebar.tsx
+++ b/web/src/components/AppSidebar/AppSidebar.tsx
@@ -373,7 +373,6 @@ const MemoDetailSidebarContent = () => {
       memo={memoDetail.memo}
       forceReadonly={memoDetail.readonly}
       onShareImageOpen={memoDetail.onShareImageOpen}
-      blurred={memoDetail.blurred}
       showBlurredContent={memoDetail.showBlurredContent}
       className="pb-2"
     />

--- a/web/src/components/AppSidebar/AppSidebar.tsx
+++ b/web/src/components/AppSidebar/AppSidebar.tsx
@@ -373,6 +373,8 @@ const MemoDetailSidebarContent = () => {
       memo={memoDetail.memo}
       forceReadonly={memoDetail.readonly}
       onShareImageOpen={memoDetail.onShareImageOpen}
+      blurred={memoDetail.blurred}
+      showBlurredContent={memoDetail.showBlurredContent}
       className="pb-2"
     />
   );

--- a/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
+++ b/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
@@ -26,6 +26,8 @@ interface Props {
   className?: string;
   onShareImageOpen?: () => void;
   forceReadonly?: boolean;
+  blurred?: boolean;
+  showBlurredContent?: boolean;
 }
 
 const Section = ({ label, children }: { label: string; children: React.ReactNode }) => (
@@ -57,7 +59,14 @@ const BacklinkRow = ({ relation, snippet }: { relation: MemoRelation; snippet: s
   );
 };
 
-const MemoDetailSidebar = ({ memo, className, onShareImageOpen, forceReadonly = false }: Props) => {
+const MemoDetailSidebar = ({
+  memo,
+  className,
+  onShareImageOpen,
+  forceReadonly = false,
+  blurred = false,
+  showBlurredContent = false,
+}: Props) => {
   const t = useTranslate();
   const currentUser = useCurrentUser();
   const { profile } = useInstance();
@@ -68,7 +77,10 @@ const MemoDetailSidebar = ({ memo, className, onShareImageOpen, forceReadonly = 
   const canPin = !readonly && !memo.parent && memo.state === State.NORMAL;
   const canManageShares = !forceReadonly && !memo.parent && (memo.creator === currentUser?.name || isSuperUser(currentUser));
 
-  const headings = useMemo(() => extractHeadings(memo.content), [memo.content]);
+  const headings = useMemo(
+    () => (blurred && !showBlurredContent ? [] : extractHeadings(memo.content)),
+    [blurred, memo.content, showBlurredContent],
+  );
   const { referenced } = useMemo(() => getRelationBuckets(memo.relations, memo.name), [memo.relations, memo.name]);
   const backlinkMemoNames = useMemo(
     () =>

--- a/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
+++ b/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
@@ -60,13 +60,7 @@ const BacklinkRow = ({ relation, snippet }: { relation: MemoRelation; snippet: s
   );
 };
 
-const MemoDetailSidebar = ({
-  memo,
-  className,
-  onShareImageOpen,
-  forceReadonly = false,
-  showBlurredContent = false,
-}: Props) => {
+const MemoDetailSidebar = ({ memo, className, onShareImageOpen, forceReadonly = false, showBlurredContent = false }: Props) => {
   const t = useTranslate();
   const currentUser = useCurrentUser();
   const { isUserSettingsInitialized, userTagsSetting } = useAuth();

--- a/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
+++ b/web/src/components/MemoDetailSidebar/MemoDetailSidebar.tsx
@@ -8,10 +8,12 @@ import SidebarSectionHeader from "@/components/AppSidebar/SidebarSectionHeader";
 import { getRelationBuckets, getRelationMemo } from "@/components/MemoMetadata/Relation/relationHelpers";
 import { useResolvedRelationMemos } from "@/components/MemoMetadata/Relation/useResolvedRelationMemos";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { useAuth } from "@/contexts/AuthContext";
 import { useInstance } from "@/contexts/InstanceContext";
 import { useOverflowTitle } from "@/hooks";
 import useCurrentUser from "@/hooks/useCurrentUser";
 import { useUpdateMemo } from "@/hooks/useMemoQueries";
+import { findTagMetadata } from "@/lib/tag";
 import { cn } from "@/lib/utils";
 import { State } from "@/types/proto/api/v1/common_pb";
 import { Memo, type MemoRelation } from "@/types/proto/api/v1/memo_service_pb";
@@ -26,7 +28,6 @@ interface Props {
   className?: string;
   onShareImageOpen?: () => void;
   forceReadonly?: boolean;
-  blurred?: boolean;
   showBlurredContent?: boolean;
 }
 
@@ -64,11 +65,11 @@ const MemoDetailSidebar = ({
   className,
   onShareImageOpen,
   forceReadonly = false,
-  blurred = false,
   showBlurredContent = false,
 }: Props) => {
   const t = useTranslate();
   const currentUser = useCurrentUser();
+  const { isUserSettingsInitialized, userTagsSetting } = useAuth();
   const { profile } = useInstance();
   const { mutateAsync: updateMemo } = useUpdateMemo();
   const [sharePanelOpen, setSharePanelOpen] = useState(false);
@@ -77,10 +78,13 @@ const MemoDetailSidebar = ({
   const canPin = !readonly && !memo.parent && memo.state === State.NORMAL;
   const canManageShares = !forceReadonly && !memo.parent && (memo.creator === currentUser?.name || isSuperUser(currentUser));
 
-  const headings = useMemo(
-    () => (blurred && !showBlurredContent ? [] : extractHeadings(memo.content)),
-    [blurred, memo.content, showBlurredContent],
-  );
+  const blurred = memo.tags.some((tag) => userTagsSetting && findTagMetadata(tag, userTagsSetting)?.blurContent);
+  const headings = useMemo(() => {
+    if (!isUserSettingsInitialized || (blurred && !showBlurredContent)) {
+      return [];
+    }
+    return extractHeadings(memo.content);
+  }, [blurred, isUserSettingsInitialized, memo.content, showBlurredContent]);
   const { referenced } = useMemo(() => getRelationBuckets(memo.relations, memo.name), [memo.relations, memo.name]);
   const backlinkMemoNames = useMemo(
     () =>

--- a/web/src/components/MemoView/MemoView.tsx
+++ b/web/src/components/MemoView/MemoView.tsx
@@ -20,7 +20,17 @@ const MemoShareImageDialog = lazyWithReload(() => import("../MemoActionMenu/Memo
 const PreviewImageDialog = lazyWithReload(() => import("../PreviewImageDialog"));
 
 const MemoView: React.FC<MemoViewProps> = (props: MemoViewProps) => {
-  const { memo: memoData, className, parentPage: parentPageProp, compact, showCreator, showVisibility, showPinned } = props;
+  const {
+    memo: memoData,
+    className,
+    parentPage: parentPageProp,
+    compact,
+    showCreator,
+    showVisibility,
+    showPinned,
+    showBlurredContent: controlledShowBlurredContent,
+    onBlurVisibilityChange,
+  } = props;
   const cardRef = useRef<HTMLDivElement>(null);
   const [showEditor, setShowEditor] = useState(false);
   const [EditorComponent, setEditorComponent] = useState<ComponentType<MemoEditorProps>>();
@@ -34,9 +44,17 @@ const MemoView: React.FC<MemoViewProps> = (props: MemoViewProps) => {
   const parentPage = parentPageProp || "/";
 
   // Blur content when any tag has blur_content enabled in the current user's tag settings.
-  const [showBlurredContent, setShowBlurredContent] = useState(false);
+  const [localShowBlurredContent, setLocalShowBlurredContent] = useState(false);
+  const showBlurredContent = controlledShowBlurredContent ?? localShowBlurredContent;
   const blurred = memoData.tags?.some((tag) => userTagsSetting && findTagMetadata(tag, userTagsSetting)?.blurContent) ?? false;
-  const toggleBlurVisibility = useCallback(() => setShowBlurredContent((prev) => !prev), []);
+  const toggleBlurVisibility = useCallback(() => {
+    const nextShowBlurredContent = !showBlurredContent;
+    if (onBlurVisibilityChange) {
+      onBlurVisibilityChange(nextShowBlurredContent);
+    } else {
+      setLocalShowBlurredContent((prev) => !prev);
+    }
+  }, [onBlurVisibilityChange, showBlurredContent]);
 
   const { previewState, openPreview, setPreviewOpen } = useImagePreview();
 

--- a/web/src/components/MemoView/types.ts
+++ b/web/src/components/MemoView/types.ts
@@ -10,6 +10,8 @@ export interface MemoViewProps {
   parentPage?: string;
   shareImageDialogOpen?: boolean;
   onShareImageDialogOpenChange?: (open: boolean) => void;
+  showBlurredContent?: boolean;
+  onBlurVisibilityChange?: (show: boolean) => void;
 }
 
 export interface MemoHeaderProps {

--- a/web/src/contexts/AppSidebarContext.tsx
+++ b/web/src/contexts/AppSidebarContext.tsx
@@ -11,6 +11,8 @@ export interface MemoDetailSidebarDescriptor {
   from?: string;
   readonly?: boolean;
   onShareImageOpen?: () => void;
+  blurred?: boolean;
+  showBlurredContent?: boolean;
 }
 
 interface AppSidebarContextValue {

--- a/web/src/contexts/AppSidebarContext.tsx
+++ b/web/src/contexts/AppSidebarContext.tsx
@@ -11,7 +11,6 @@ export interface MemoDetailSidebarDescriptor {
   from?: string;
   readonly?: boolean;
   onShareImageOpen?: () => void;
-  blurred?: boolean;
   showBlurredContent?: boolean;
 }
 

--- a/web/src/pages/MemoDetail.tsx
+++ b/web/src/pages/MemoDetail.tsx
@@ -1,6 +1,6 @@
 import { Code, ConnectError } from "@connectrpc/connect";
 import { ArrowUpLeftFromCircleIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo as useReactMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo as useReactMemo, useRef, useState } from "react";
 import { Link, Navigate, useLocation, useParams } from "react-router-dom";
 import MemoCommentSection from "@/components/MemoCommentSection";
 import { MentionResolutionProvider } from "@/components/MemoContent/MentionResolutionContext";
@@ -12,7 +12,6 @@ import useMemoDetailError from "@/hooks/useMemoDetailError";
 import { useInfiniteMemoComments, useMemo } from "@/hooks/useMemoQueries";
 import { useSharedMemo, withShareAttachmentLinks } from "@/hooks/useMemoShareQueries";
 import { memoNamePrefix } from "@/lib/resource-names";
-import { findTagMetadata } from "@/lib/tag";
 import type { Attachment } from "@/types/proto/api/v1/attachment_service_pb";
 import type { Memo } from "@/types/proto/api/v1/memo_service_pb";
 
@@ -21,29 +20,27 @@ const MemoSidebarRegistration = ({
   from,
   readonly,
   onShareImageOpen,
-  blurred,
   showBlurredContent,
 }: {
   memo: Memo;
   from?: string;
   readonly: boolean;
   onShareImageOpen: () => void;
-  blurred: boolean;
   showBlurredContent: boolean;
 }) => {
   const { setMemoDetail } = useAppSidebar();
 
-  useEffect(() => {
-    setMemoDetail({ memo, from, readonly, onShareImageOpen, blurred, showBlurredContent });
-  }, [blurred, from, memo, onShareImageOpen, readonly, setMemoDetail, showBlurredContent]);
+  useLayoutEffect(() => {
+    setMemoDetail({ memo, from, readonly, onShareImageOpen, showBlurredContent });
+  }, [from, memo, onShareImageOpen, readonly, setMemoDetail, showBlurredContent]);
 
-  useEffect(() => () => setMemoDetail(undefined), [setMemoDetail]);
+  useLayoutEffect(() => () => setMemoDetail(undefined), [setMemoDetail]);
 
   return null;
 };
 
 const MemoDetail = () => {
-  const { isInitialized: authInitialized, userTagsSetting } = useAuth();
+  const { isInitialized: authInitialized } = useAuth();
   const { isInitialized: instanceInitialized } = useInstance();
   const [shareImageDialogOpen, setShareImageDialogOpen] = useState(false);
   const params = useParams();
@@ -58,6 +55,7 @@ const MemoDetail = () => {
 
   // Primary memo fetch — share token or direct name.
   const memoNameFromParams = params.uid ? `${memoNamePrefix}${params.uid}` : "";
+  const memoNavigationKey = isShareMode ? `share:${shareToken}` : memoNameFromParams;
   const {
     data: memoFromDirect,
     error: directError,
@@ -74,13 +72,13 @@ const MemoDetail = () => {
     if (!isShareMode) return memo;
     return { ...memo, attachments: withShareAttachmentLinks(memo.attachments as Attachment[], shareToken!) };
   }, [isShareMode, memo, shareToken]);
-  const blurred = displayMemo?.tags?.some((tag) => userTagsSetting && findTagMetadata(tag, userTagsSetting)?.blurContent) ?? false;
   const [revealedMemoName, setRevealedMemoName] = useState<string>();
   const showBlurredContent = Boolean(displayMemo && displayMemo.name === revealedMemoName);
   const handleBlurVisibilityChange = useCallback(
     (show: boolean) => setRevealedMemoName(show ? displayMemo?.name : undefined),
     [displayMemo?.name],
   );
+  useLayoutEffect(() => setRevealedMemoName(undefined), [memoNavigationKey]);
 
   useMemoDetailError({
     error: error as Error | null,
@@ -135,7 +133,6 @@ const MemoDetail = () => {
           from={parentPage}
           readonly={isShareMode}
           onShareImageOpen={handleShareImageOpen}
-          blurred={blurred}
           showBlurredContent={showBlurredContent}
         />
         <div className="w-full max-w-2xl px-4 sm:px-6">

--- a/web/src/pages/MemoDetail.tsx
+++ b/web/src/pages/MemoDetail.tsx
@@ -12,6 +12,7 @@ import useMemoDetailError from "@/hooks/useMemoDetailError";
 import { useInfiniteMemoComments, useMemo } from "@/hooks/useMemoQueries";
 import { useSharedMemo, withShareAttachmentLinks } from "@/hooks/useMemoShareQueries";
 import { memoNamePrefix } from "@/lib/resource-names";
+import { findTagMetadata } from "@/lib/tag";
 import type { Attachment } from "@/types/proto/api/v1/attachment_service_pb";
 import type { Memo } from "@/types/proto/api/v1/memo_service_pb";
 
@@ -20,17 +21,21 @@ const MemoSidebarRegistration = ({
   from,
   readonly,
   onShareImageOpen,
+  blurred,
+  showBlurredContent,
 }: {
   memo: Memo;
   from?: string;
   readonly: boolean;
   onShareImageOpen: () => void;
+  blurred: boolean;
+  showBlurredContent: boolean;
 }) => {
   const { setMemoDetail } = useAppSidebar();
 
   useEffect(() => {
-    setMemoDetail({ memo, from, readonly, onShareImageOpen });
-  }, [from, memo, onShareImageOpen, readonly, setMemoDetail]);
+    setMemoDetail({ memo, from, readonly, onShareImageOpen, blurred, showBlurredContent });
+  }, [blurred, from, memo, onShareImageOpen, readonly, setMemoDetail, showBlurredContent]);
 
   useEffect(() => () => setMemoDetail(undefined), [setMemoDetail]);
 
@@ -38,7 +43,7 @@ const MemoSidebarRegistration = ({
 };
 
 const MemoDetail = () => {
-  const { isInitialized: authInitialized } = useAuth();
+  const { isInitialized: authInitialized, userTagsSetting } = useAuth();
   const { isInitialized: instanceInitialized } = useInstance();
   const [shareImageDialogOpen, setShareImageDialogOpen] = useState(false);
   const params = useParams();
@@ -69,6 +74,13 @@ const MemoDetail = () => {
     if (!isShareMode) return memo;
     return { ...memo, attachments: withShareAttachmentLinks(memo.attachments as Attachment[], shareToken!) };
   }, [isShareMode, memo, shareToken]);
+  const blurred = displayMemo?.tags?.some((tag) => userTagsSetting && findTagMetadata(tag, userTagsSetting)?.blurContent) ?? false;
+  const [revealedMemoName, setRevealedMemoName] = useState<string>();
+  const showBlurredContent = Boolean(displayMemo && displayMemo.name === revealedMemoName);
+  const handleBlurVisibilityChange = useCallback(
+    (show: boolean) => setRevealedMemoName(show ? displayMemo?.name : undefined),
+    [displayMemo?.name],
+  );
 
   useMemoDetailError({
     error: error as Error | null,
@@ -118,7 +130,14 @@ const MemoDetail = () => {
   return (
     <section className="@container flex min-h-full w-full flex-col items-center pb-8 pt-3 md:pt-6">
       <MentionResolutionProvider contents={mentionResolutionContents} userNames={userResolutionNames}>
-        <MemoSidebarRegistration memo={displayMemo} from={parentPage} readonly={isShareMode} onShareImageOpen={handleShareImageOpen} />
+        <MemoSidebarRegistration
+          memo={displayMemo}
+          from={parentPage}
+          readonly={isShareMode}
+          onShareImageOpen={handleShareImageOpen}
+          blurred={blurred}
+          showBlurredContent={showBlurredContent}
+        />
         <div className="w-full max-w-2xl px-4 sm:px-6">
           <div className="w-full">
             {!isShareMode && parentMemo && (
@@ -143,6 +162,8 @@ const MemoDetail = () => {
               showCreator
               showVisibility
               showPinned
+              showBlurredContent={showBlurredContent}
+              onBlurVisibilityChange={handleBlurVisibilityChange}
               onShareImageDialogOpenChange={setShareImageDialogOpen}
             />
             {!isShareMode && (

--- a/web/tests/memo-detail-blur-navigation.test.tsx
+++ b/web/tests/memo-detail-blur-navigation.test.tsx
@@ -1,0 +1,110 @@
+import { create } from "@bufbuild/protobuf";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppSidebarProvider, useAppSidebar } from "@/contexts/AppSidebarContext";
+import MemoDetail from "@/pages/MemoDetail";
+import { State } from "@/types/proto/api/v1/common_pb";
+import { MemoSchema, Visibility } from "@/types/proto/api/v1/memo_service_pb";
+
+const memoQueryState = vi.hoisted(() => ({ memos: new Map<string, unknown>() }));
+
+vi.mock("@/components/MemoCommentSection", () => ({ default: () => null }));
+vi.mock("@/components/MemoContent/MentionResolutionContext", () => ({
+  MentionResolutionProvider: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("@/components/MemoView", () => ({
+  default: ({
+    showBlurredContent,
+    onBlurVisibilityChange,
+  }: {
+    showBlurredContent?: boolean;
+    onBlurVisibilityChange?: (show: boolean) => void;
+  }) => (
+    <button type="button" onClick={() => onBlurVisibilityChange?.(true)}>
+      {showBlurredContent ? "revealed" : "reveal"}
+    </button>
+  ),
+}));
+vi.mock("@/contexts/AuthContext", () => ({ useAuth: () => ({ isInitialized: true }) }));
+vi.mock("@/contexts/InstanceContext", () => ({ useInstance: () => ({ isInitialized: true }) }));
+vi.mock("@/hooks/useMemoDetailError", () => ({ default: () => undefined }));
+vi.mock("@/hooks/useMemoQueries", () => ({
+  useMemo: (name: string) => ({ data: memoQueryState.memos.get(name), error: null, isLoading: false }),
+  useInfiniteMemoComments: () => ({
+    data: [],
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  }),
+}));
+vi.mock("@/hooks/useMemoShareQueries", () => ({
+  useSharedMemo: () => ({ data: undefined, error: null, isLoading: false }),
+  withShareAttachmentLinks: (attachments: unknown[]) => attachments,
+}));
+
+const Navigation = () => {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button type="button" onClick={() => navigate("/memos/first")}>
+        first
+      </button>
+      <button type="button" onClick={() => navigate("/memos/second")}>
+        second
+      </button>
+    </>
+  );
+};
+
+const SidebarState = () => {
+  const { memoDetail } = useAppSidebar();
+  if (!memoDetail) return null;
+  return (
+    <div data-testid="sidebar-state">{`${memoDetail.memo.name}:${memoDetail.showBlurredContent ? "revealed" : "hidden"}`}</div>
+  );
+};
+
+describe("MemoDetail blur navigation", () => {
+  beforeEach(() => {
+    memoQueryState.memos.clear();
+    for (const uid of ["first", "second"]) {
+      memoQueryState.memos.set(
+        `memos/${uid}`,
+        create(MemoSchema, {
+          name: `memos/${uid}`,
+          creator: "users/alice",
+          state: State.NORMAL,
+          visibility: Visibility.PUBLIC,
+          content: `# ${uid}\n\n## Secret details`,
+          tags: ["secret"],
+        }),
+      );
+    }
+  });
+
+  it("starts blurred again after navigating away from a revealed memo and back", async () => {
+    render(
+      <MemoryRouter initialEntries={["/memos/first"]}>
+        <AppSidebarProvider>
+          <Navigation />
+          <SidebarState />
+          <Routes>
+            <Route path="/memos/:uid" element={<MemoDetail />} />
+          </Routes>
+        </AppSidebarProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByTestId("sidebar-state")).toHaveTextContent("memos/first:hidden");
+    fireEvent.click(screen.getByRole("button", { name: "reveal" }));
+    await waitFor(() => expect(screen.getByTestId("sidebar-state")).toHaveTextContent("memos/first:revealed"));
+
+    fireEvent.click(screen.getByRole("button", { name: "second" }));
+    await waitFor(() => expect(screen.getByTestId("sidebar-state")).toHaveTextContent("memos/second:hidden"));
+
+    fireEvent.click(screen.getByRole("button", { name: "first" }));
+    await waitFor(() => expect(screen.getByTestId("sidebar-state")).toHaveTextContent("memos/first:hidden"));
+  });
+});

--- a/web/tests/memo-detail-sidebar.test.tsx
+++ b/web/tests/memo-detail-sidebar.test.tsx
@@ -16,6 +16,10 @@ import {
 
 const copyToClipboard = vi.hoisted(() => vi.fn());
 const updateMemo = vi.hoisted(() => vi.fn());
+const authState = vi.hoisted(() => ({
+  isUserSettingsInitialized: true,
+  userTagsSetting: { tags: { secret: { blurContent: true } } },
+}));
 
 vi.mock("copy-to-clipboard", () => ({ default: copyToClipboard }));
 vi.mock("react-hot-toast", () => ({ default: { success: vi.fn() } }));
@@ -24,6 +28,7 @@ vi.mock("@/components/MemoDetailSidebar/MemoOutline", () => ({
 }));
 vi.mock("@/components/MemoDetailSidebar/MemoSharePanel", () => ({ default: () => <div data-testid="share-panel" /> }));
 vi.mock("@/components/MemoMetadata/Relation/useResolvedRelationMemos", () => ({ useResolvedRelationMemos: () => ({}) }));
+vi.mock("@/contexts/AuthContext", () => ({ useAuth: () => authState }));
 vi.mock("@/contexts/InstanceContext", () => ({ useInstance: () => ({ profile: { instanceUrl: "https://memos.example" } }) }));
 vi.mock("@/hooks/useCurrentUser", () => ({ default: () => ({ name: "users/alice" }) }));
 vi.mock("@/hooks/useMemoQueries", () => ({ useUpdateMemo: () => ({ mutateAsync: updateMemo }) }));
@@ -34,6 +39,8 @@ describe("MemoDetailSidebar", () => {
     copyToClipboard.mockReset();
     updateMemo.mockReset();
     updateMemo.mockResolvedValue(undefined);
+    authState.isUserSettingsInitialized = true;
+    authState.userTagsSetting = { tags: { secret: { blurContent: true } } };
   });
 
   it("renders concise actions, outline, and backlinks without repeating body metadata", async () => {
@@ -160,11 +167,12 @@ describe("MemoDetailSidebar", () => {
       state: State.NORMAL,
       visibility: Visibility.PUBLIC,
       content: "# Secret overview\n\n## Secret details",
+      tags: ["secret"],
     });
 
     const { rerender } = render(
       <MemoryRouter>
-        <MemoDetailSidebar memo={memo} blurred />
+        <MemoDetailSidebar memo={memo} />
       </MemoryRouter>,
     );
 
@@ -173,11 +181,32 @@ describe("MemoDetailSidebar", () => {
 
     rerender(
       <MemoryRouter>
-        <MemoDetailSidebar memo={memo} blurred showBlurredContent />
+        <MemoDetailSidebar memo={memo} showBlurredContent />
       </MemoryRouter>,
     );
 
     expect(screen.getByText("memo.outline")).toBeInTheDocument();
     expect(screen.getByTestId("outline")).toHaveTextContent("2");
+  });
+
+  it("does not expose headings while tag settings are loading", () => {
+    authState.isUserSettingsInitialized = false;
+    const memo = create(MemoSchema, {
+      name: "memos/loading-settings",
+      creator: "users/alice",
+      state: State.NORMAL,
+      visibility: Visibility.PUBLIC,
+      content: "# Private overview\n\n## Private details",
+      tags: ["secret"],
+    });
+
+    render(
+      <MemoryRouter>
+        <MemoDetailSidebar memo={memo} showBlurredContent />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("memo.outline")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("outline")).not.toBeInTheDocument();
   });
 });

--- a/web/tests/memo-detail-sidebar.test.tsx
+++ b/web/tests/memo-detail-sidebar.test.tsx
@@ -152,4 +152,32 @@ describe("MemoDetailSidebar", () => {
     expect(screen.getByText("memo.outline")).toBeInTheDocument();
     expect(screen.getByTestId("outline")).toHaveTextContent("2");
   });
+
+  it("hides the outline until blurred content is revealed", () => {
+    const memo = create(MemoSchema, {
+      name: "memos/blurred-outline",
+      creator: "users/alice",
+      state: State.NORMAL,
+      visibility: Visibility.PUBLIC,
+      content: "# Secret overview\n\n## Secret details",
+    });
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <MemoDetailSidebar memo={memo} blurred />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("memo.outline")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("outline")).not.toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <MemoDetailSidebar memo={memo} blurred showBlurredContent />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("memo.outline")).toBeInTheDocument();
+    expect(screen.getByTestId("outline")).toHaveTextContent("2");
+  });
 });


### PR DESCRIPTION
Fixes #6158

Hide the note outline while blurred content is hidden, and restore it after reveal.

Added regression coverage.