### PR TITLE
feat: support memo-scoped Markdown attachment images

### DIFF
--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -442,8 +442,7 @@ func (s *service) ExtractAll(content []byte) (*ExtractedData, error) {
 				data.ManagedAttachmentReferences = append(data.ManagedAttachmentReferences, ManagedAttachmentReference{UID: uid})
 			}
 		}
-		if rawHTML, ok := n.(*gast.RawHTML); ok {
-			raw := string(rawHTML.Segments.Value(content))
+		if raw, ok := extractRawHTML(n, content); ok {
 			if strings.Contains(raw, "/file/attachments/") {
 				// Managed attachment URLs are deliberately supported only through
 				// Markdown image nodes. Raw HTML would require a second, security-
@@ -493,6 +492,21 @@ func (s *service) ExtractAll(content []byte) (*ExtractedData, error) {
 	data.InvalidManagedAttachmentReferences = uniquePreserveCase(data.InvalidManagedAttachmentReferences)
 
 	return data, nil
+}
+
+func extractRawHTML(node gast.Node, source []byte) (string, bool) {
+	switch node := node.(type) {
+	case *gast.RawHTML:
+		return string(node.Segments.Value(source)), true
+	case *gast.HTMLBlock:
+		raw := append([]byte(nil), node.Lines().Value(source)...)
+		if node.HasClosure() {
+			raw = append(raw, node.ClosureLine.Value(source)...)
+		}
+		return string(raw), true
+	default:
+		return "", false
+	}
 }
 
 // ParseManagedAttachmentImageURL parses a same-origin relative managed image URL.

--- a/internal/markdown/markdown.go
+++ b/internal/markdown/markdown.go
@@ -3,6 +3,7 @@ package markdown
 import (
 	"bytes"
 	"cmp"
+	"net/url"
 	"slices"
 	"strings"
 
@@ -13,17 +14,26 @@ import (
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/text"
 
+	"github.com/usememos/memos/internal/base"
 	mast "github.com/usememos/memos/internal/markdown/ast"
 	"github.com/usememos/memos/internal/markdown/extensions"
 	"github.com/usememos/memos/internal/markdown/renderer"
 	storepb "github.com/usememos/memos/proto/gen/store"
 )
 
+// ManagedAttachmentReference is an attachment URL embedded using Markdown image syntax.
+type ManagedAttachmentReference struct {
+	UID string
+}
+
 // ExtractedData contains all metadata extracted from markdown in a single pass.
 type ExtractedData struct {
-	Tags     []string
-	Mentions []string
-	Property *storepb.MemoPayload_Property
+	Tags                               []string
+	Mentions                           []string
+	ImageDestinations                  []string
+	ManagedAttachmentReferences        []ManagedAttachmentReference
+	InvalidManagedAttachmentReferences []string
+	Property                           *storepb.MemoPayload_Property
 }
 
 // Service handles markdown metadata extraction.
@@ -402,9 +412,11 @@ func (s *service) ExtractAll(content []byte) (*ExtractedData, error) {
 	}
 
 	data := &ExtractedData{
-		Tags:     []string{},
-		Mentions: []string{},
-		Property: &storepb.MemoPayload_Property{},
+		Tags:                        []string{},
+		Mentions:                    []string{},
+		ImageDestinations:           []string{},
+		ManagedAttachmentReferences: []ManagedAttachmentReference{},
+		Property:                    &storepb.MemoPayload_Property{},
 	}
 
 	firstBlockChecked := false
@@ -419,6 +431,25 @@ func (s *service) ExtractAll(content []byte) (*ExtractedData, error) {
 		}
 		if mentionNode, ok := n.(*mast.MentionNode); ok {
 			data.Mentions = append(data.Mentions, string(mentionNode.Username))
+		}
+		if imageNode, ok := n.(*gast.Image); ok {
+			destination := string(imageNode.Destination)
+			data.ImageDestinations = append(data.ImageDestinations, destination)
+			uid, managed, valid := ParseManagedAttachmentImageURL(destination)
+			if managed && !valid {
+				data.InvalidManagedAttachmentReferences = append(data.InvalidManagedAttachmentReferences, string(imageNode.Destination))
+			} else if managed {
+				data.ManagedAttachmentReferences = append(data.ManagedAttachmentReferences, ManagedAttachmentReference{UID: uid})
+			}
+		}
+		if rawHTML, ok := n.(*gast.RawHTML); ok {
+			raw := string(rawHTML.Segments.Value(content))
+			if strings.Contains(raw, "/file/attachments/") {
+				// Managed attachment URLs are deliberately supported only through
+				// Markdown image nodes. Raw HTML would require a second, security-
+				// sensitive HTML parser to enforce equivalent URL rules.
+				data.InvalidManagedAttachmentReferences = append(data.InvalidManagedAttachmentReferences, raw)
+			}
 		}
 
 		// Check if the first block-level child of the document is an H1 heading.
@@ -458,8 +489,48 @@ func (s *service) ExtractAll(content []byte) (*ExtractedData, error) {
 	// Deduplicate tags while preserving original case
 	data.Tags = uniquePreserveCase(data.Tags)
 	data.Mentions = uniquePreserveCase(data.Mentions)
+	data.ManagedAttachmentReferences = uniqueManagedAttachmentReferences(data.ManagedAttachmentReferences)
+	data.InvalidManagedAttachmentReferences = uniquePreserveCase(data.InvalidManagedAttachmentReferences)
 
 	return data, nil
+}
+
+// ParseManagedAttachmentImageURL parses a same-origin relative managed image URL.
+// Absolute URL origin matching is intentionally left to callers that know the
+// configured instance URL.
+func ParseManagedAttachmentImageURL(raw string) (uid string, managed, valid bool) {
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.IsAbs() || parsed.Host != "" {
+		return "", false, false
+	}
+	if !strings.HasPrefix(parsed.Path, "/file/attachments/") {
+		return "", false, false
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" || parsed.RawPath != "" || strings.Contains(parsed.EscapedPath(), "%") {
+		return "", true, false
+	}
+
+	parts := strings.Split(strings.TrimPrefix(parsed.Path, "/file/attachments/"), "/")
+	if (len(parts) != 1 && len(parts) != 2) || !base.UIDMatcher.MatchString(parts[0]) {
+		return "", true, false
+	}
+	if len(parts) == 2 && parts[1] == "" {
+		return "", true, false
+	}
+	return parts[0], true, true
+}
+
+func uniqueManagedAttachmentReferences(references []ManagedAttachmentReference) []ManagedAttachmentReference {
+	seen := make(map[string]struct{}, len(references))
+	result := make([]ManagedAttachmentReference, 0, len(references))
+	for _, reference := range references {
+		if _, ok := seen[reference.UID]; ok {
+			continue
+		}
+		seen[reference.UID] = struct{}{}
+		result = append(result, reference)
+	}
+	return result
 }
 
 // RenameTag renames all occurrences of oldTag to newTag in content.

--- a/internal/markdown/markdown_test.go
+++ b/internal/markdown/markdown_test.go
@@ -361,6 +361,36 @@ func TestExtractAllMentions(t *testing.T) {
 	assert.Empty(t, data.Mentions)
 }
 
+func TestExtractAllManagedAttachmentImages(t *testing.T) {
+	svc := NewService()
+	data, err := svc.ExtractAll([]byte(strings.Join([]string{
+		"![canonical](/file/attachments/image-one)",
+		"![legacy](/file/attachments/image-two/photo.png)",
+		"![duplicate](/file/attachments/image-one)",
+		"![reference][managed-image]",
+		"",
+		"[managed-image]: /file/attachments/image-three",
+		"![external](https://example.com/file/attachments/external)",
+		"`![code](/file/attachments/code-image)`",
+	}, "\n")))
+	require.NoError(t, err)
+	require.Equal(t, []ManagedAttachmentReference{{UID: "image-one"}, {UID: "image-two"}, {UID: "image-three"}}, data.ManagedAttachmentReferences)
+	require.Empty(t, data.InvalidManagedAttachmentReferences)
+}
+
+func TestExtractAllRejectsMalformedManagedAttachmentImages(t *testing.T) {
+	svc := NewService()
+	data, err := svc.ExtractAll([]byte(strings.Join([]string{
+		"![query](/file/attachments/image-one?share_token=secret)",
+		"![encoded](/file/attachments/%69mage-two)",
+		"![extra](/file/attachments/image-three/file/extra)",
+		`<img src="/file/attachments/raw-html">`,
+	}, "\n")))
+	require.NoError(t, err)
+	require.Empty(t, data.ManagedAttachmentReferences)
+	require.Len(t, data.InvalidManagedAttachmentReferences, 4)
+}
+
 func TestExtractAllMentionSyntaxAndContexts(t *testing.T) {
 	svc := NewService(WithTagExtension(), WithMentionExtension())
 	tests := []struct {

--- a/internal/markdown/markdown_test.go
+++ b/internal/markdown/markdown_test.go
@@ -391,6 +391,66 @@ func TestExtractAllRejectsMalformedManagedAttachmentImages(t *testing.T) {
 	require.Len(t, data.InvalidManagedAttachmentReferences, 4)
 }
 
+func TestExtractAllRejectsManagedAttachmentReferencesInRawHTML(t *testing.T) {
+	svc := NewService()
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "inline HTML",
+			content: `before <img src="/file/attachments/inline-image"> after`,
+		},
+		{
+			name: "HTML block",
+			content: strings.Join([]string{
+				"<div>",
+				`  <img src="/file/attachments/block-image">`,
+				"</div>",
+			}, "\n"),
+		},
+		{
+			name: "self-closing HTML block",
+			content: strings.Join([]string{
+				`<img`,
+				`  src="/file/attachments/multiline-image"`,
+				`/>`,
+			}, "\n"),
+		},
+		{
+			name: "HTML block closure line",
+			content: strings.Join([]string{
+				"<pre>",
+				"content",
+				`</pre><img src="/file/attachments/closure-image">`,
+			}, "\n"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := svc.ExtractAll([]byte(test.content))
+			require.NoError(t, err)
+			require.Empty(t, data.ManagedAttachmentReferences)
+			require.Len(t, data.InvalidManagedAttachmentReferences, 1)
+		})
+	}
+}
+
+func TestExtractAllIgnoresManagedAttachmentReferencesInCode(t *testing.T) {
+	svc := NewService()
+	data, err := svc.ExtractAll([]byte(strings.Join([]string{
+		"`<img src=\"/file/attachments/inline-code\">`",
+		"",
+		"```html",
+		`<img src="/file/attachments/fenced-code">`,
+		"```",
+	}, "\n")))
+	require.NoError(t, err)
+	require.Empty(t, data.ManagedAttachmentReferences)
+	require.Empty(t, data.InvalidManagedAttachmentReferences)
+}
+
 func TestExtractAllMentionSyntaxAndContexts(t *testing.T) {
 	svc := NewService(WithTagExtension(), WithMentionExtension())
 	tests := []struct {

--- a/server/access/memo.go
+++ b/server/access/memo.go
@@ -1,0 +1,131 @@
+// Package access defines transport-independent resource authorization policies
+// shared by the server's API and HTTP adapters.
+package access
+
+import "github.com/usememos/memos/store"
+
+// MemoReadDenial describes why a memo read was rejected.
+type MemoReadDenial int
+
+const (
+	// MemoReadDenialNone means the read is allowed.
+	MemoReadDenialNone MemoReadDenial = iota
+	// MemoReadDenialNotFound hides missing, archived, and invalid memo state.
+	MemoReadDenialNotFound
+	// MemoReadDenialUnauthenticated means the resource requires a signed-in user.
+	MemoReadDenialUnauthenticated
+	// MemoReadDenialPermission means the signed-in user cannot read the resource.
+	MemoReadDenialPermission
+)
+
+// MemoReadClass describes whether the resource is anonymously readable.
+type MemoReadClass int
+
+const (
+	// MemoReadClassPrivate is for owner, authenticated, or share-token reads.
+	MemoReadClassPrivate MemoReadClass = iota
+	// MemoReadClassPublic is for resources currently readable without credentials.
+	MemoReadClassPublic
+)
+
+// MemoReadDecision is the outcome of evaluating memo read access.
+type MemoReadDecision struct {
+	Denial MemoReadDenial
+	Class  MemoReadClass
+}
+
+// Allowed reports whether the read is permitted.
+func (d MemoReadDecision) Allowed() bool {
+	return d.Denial == MemoReadDenialNone
+}
+
+// CheckMemoRead evaluates access to memo. If parent is non-nil, both the comment
+// memo and its parent must be readable. A share grants access only to the exact,
+// non-comment memo identified by sharedMemoID.
+func CheckMemoRead(memo, parent *store.Memo, viewer *store.User, allowAnonymous bool, sharedMemoID *int32) MemoReadDecision {
+	if memo == nil {
+		return MemoReadDecision{Denial: MemoReadDenialNotFound}
+	}
+
+	if parent == nil {
+		shareApplies := sharedMemoID != nil && memo.ParentUID == nil && memo.ID == *sharedMemoID
+		return checkMemo(memo, viewer, allowAnonymous, shareApplies)
+	}
+
+	// A token for a parent never grants access to its comments, and legacy
+	// comment shares never bypass the parent policy. A comment's visibility is
+	// derived from its parent so stale denormalized visibility values cannot
+	// leak or hide comments after the parent visibility changes.
+	commentState := checkCommentState(memo, viewer)
+	if !commentState.Allowed() {
+		return commentState
+	}
+	parentDecision := checkMemo(parent, viewer, allowAnonymous, false)
+	if !parentDecision.Allowed() {
+		return parentDecision
+	}
+	if commentState.Class == MemoReadClassPrivate {
+		return MemoReadDecision{Class: MemoReadClassPrivate}
+	}
+	return parentDecision
+}
+
+func checkCommentState(memo *store.Memo, viewer *store.User) MemoReadDecision {
+	if memo == nil {
+		return MemoReadDecision{Denial: MemoReadDenialNotFound}
+	}
+	if memo.RowStatus == store.Archived {
+		if viewer != nil && viewer.ID == memo.CreatorID {
+			return MemoReadDecision{Class: MemoReadClassPrivate}
+		}
+		return MemoReadDecision{Denial: MemoReadDenialNotFound}
+	}
+	if memo.RowStatus != store.Normal {
+		return MemoReadDecision{Denial: MemoReadDenialNotFound}
+	}
+	return MemoReadDecision{Class: MemoReadClassPublic}
+}
+
+func checkMemo(memo *store.Memo, viewer *store.User, allowAnonymous, shareApplies bool) MemoReadDecision {
+	if memo == nil {
+		return MemoReadDecision{Denial: MemoReadDenialNotFound}
+	}
+	if memo.RowStatus == store.Archived {
+		if viewer != nil && viewer.ID == memo.CreatorID {
+			return MemoReadDecision{Class: MemoReadClassPrivate}
+		}
+		return MemoReadDecision{Denial: MemoReadDenialNotFound}
+	}
+	if memo.RowStatus != store.Normal {
+		return MemoReadDecision{Denial: MemoReadDenialNotFound}
+	}
+	if shareApplies {
+		return MemoReadDecision{Class: MemoReadClassPrivate}
+	}
+
+	switch memo.Visibility {
+	case store.Public:
+		if allowAnonymous {
+			return MemoReadDecision{Class: MemoReadClassPublic}
+		}
+		if viewer != nil {
+			return MemoReadDecision{Class: MemoReadClassPrivate}
+		}
+		return MemoReadDecision{Denial: MemoReadDenialUnauthenticated}
+	case store.Protected:
+		if viewer != nil {
+			return MemoReadDecision{Class: MemoReadClassPrivate}
+		}
+		return MemoReadDecision{Denial: MemoReadDenialUnauthenticated}
+	case store.Private:
+		if viewer == nil {
+			return MemoReadDecision{Denial: MemoReadDenialUnauthenticated}
+		}
+		if viewer.ID != memo.CreatorID {
+			return MemoReadDecision{Denial: MemoReadDenialPermission}
+		}
+		return MemoReadDecision{Class: MemoReadClassPrivate}
+	default:
+		return MemoReadDecision{Denial: MemoReadDenialNotFound}
+	}
+}

--- a/server/access/memo_test.go
+++ b/server/access/memo_test.go
@@ -1,0 +1,55 @@
+package access
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/usememos/memos/store"
+)
+
+func TestCheckMemoRead(t *testing.T) {
+	owner := &store.User{ID: 1}
+	other := &store.User{ID: 2, Role: store.RoleAdmin}
+	public := &store.Memo{ID: 1, CreatorID: owner.ID, RowStatus: store.Normal, Visibility: store.Public}
+	private := &store.Memo{ID: 2, CreatorID: owner.ID, RowStatus: store.Normal, Visibility: store.Private}
+
+	require.Equal(t, MemoReadDecision{Class: MemoReadClassPublic}, CheckMemoRead(public, nil, nil, true, nil))
+	require.Equal(t, MemoReadDenialUnauthenticated, CheckMemoRead(public, nil, nil, false, nil).Denial)
+	require.Equal(t, MemoReadDecision{Class: MemoReadClassPrivate}, CheckMemoRead(private, nil, owner, true, nil))
+	require.Equal(t, MemoReadDenialPermission, CheckMemoRead(private, nil, other, true, nil).Denial)
+
+	shareID := private.ID
+	require.Equal(t, MemoReadDecision{Class: MemoReadClassPrivate}, CheckMemoRead(private, nil, nil, false, &shareID))
+}
+
+func TestCheckMemoReadCommentRequiresParentAndRejectsShares(t *testing.T) {
+	owner := &store.User{ID: 1}
+	parentUID := "parent"
+	comment := &store.Memo{ID: 2, CreatorID: owner.ID, RowStatus: store.Normal, Visibility: store.Public, ParentUID: &parentUID}
+	parent := &store.Memo{ID: 1, CreatorID: owner.ID, RowStatus: store.Normal, Visibility: store.Private}
+
+	require.Equal(t, MemoReadDenialUnauthenticated, CheckMemoRead(comment, parent, nil, true, nil).Denial)
+
+	commentShareID := comment.ID
+	require.Equal(t, MemoReadDenialUnauthenticated, CheckMemoRead(comment, parent, nil, true, &commentShareID).Denial)
+	parentShareID := parent.ID
+	require.Equal(t, MemoReadDenialUnauthenticated, CheckMemoRead(comment, parent, nil, true, &parentShareID).Denial)
+	require.True(t, CheckMemoRead(comment, parent, owner, true, nil).Allowed())
+
+	// Parent visibility is authoritative even if the denormalized comment value
+	// has not been synchronized yet.
+	comment.Visibility = store.Private
+	parent.Visibility = store.Public
+	require.Equal(t, MemoReadDecision{Class: MemoReadClassPublic}, CheckMemoRead(comment, parent, nil, true, nil))
+}
+
+func TestCheckMemoReadArchivedAndUnknownStateFailClosed(t *testing.T) {
+	owner := &store.User{ID: 1}
+	archived := &store.Memo{ID: 1, CreatorID: owner.ID, RowStatus: store.Archived, Visibility: store.Public}
+	require.Equal(t, MemoReadDenialNotFound, CheckMemoRead(archived, nil, nil, true, nil).Denial)
+	require.Equal(t, MemoReadDecision{Class: MemoReadClassPrivate}, CheckMemoRead(archived, nil, owner, true, nil))
+
+	unknown := &store.Memo{ID: 2, CreatorID: owner.ID, RowStatus: store.RowStatus("UNKNOWN"), Visibility: store.Public}
+	require.Equal(t, MemoReadDenialNotFound, CheckMemoRead(unknown, nil, owner, true, nil).Denial)
+}

--- a/server/router/api/v1/acl_config.go
+++ b/server/router/api/v1/acl_config.go
@@ -33,8 +33,12 @@ var PublicMethods = map[string]struct{}{
 	"/memos.api.v1.MemoService/GetMemo":              {},
 	"/memos.api.v1.MemoService/ListMemos":            {},
 	"/memos.api.v1.MemoService/ListMemoComments":     {},
+	"/memos.api.v1.MemoService/ListMemoAttachments":  {},
 	"/memos.api.v1.MemoService/GetLinkMetadata":      {},
 	"/memos.api.v1.MemoService/BatchGetLinkMetadata": {},
+
+	// Attachment metadata follows the visibility of its linked memo.
+	"/memos.api.v1.AttachmentService/GetAttachment": {},
 
 	// Memo sharing - share-token endpoints require no authentication
 	"/memos.api.v1.MemoService/GetSharedMemo": {},

--- a/server/router/api/v1/acl_config_test.go
+++ b/server/router/api/v1/acl_config_test.go
@@ -28,8 +28,12 @@ func TestPublicMethodsArePublic(t *testing.T) {
 		// Memo Service
 		"/memos.api.v1.MemoService/GetMemo",
 		"/memos.api.v1.MemoService/ListMemos",
+		"/memos.api.v1.MemoService/ListMemoComments",
+		"/memos.api.v1.MemoService/ListMemoAttachments",
 		"/memos.api.v1.MemoService/GetLinkMetadata",
 		"/memos.api.v1.MemoService/BatchGetLinkMetadata",
+		// Attachment Service metadata follows linked memo visibility.
+		"/memos.api.v1.AttachmentService/GetAttachment",
 	}
 
 	for _, method := range publicMethods {
@@ -126,6 +130,8 @@ func TestAuthBootstrapClassification(t *testing.T) {
 		"/memos.api.v1.MemoService/ListMemos",
 		"/memos.api.v1.MemoService/GetMemo",
 		"/memos.api.v1.MemoService/ListMemoComments",
+		"/memos.api.v1.MemoService/ListMemoAttachments",
+		"/memos.api.v1.AttachmentService/GetAttachment",
 		"/memos.api.v1.UserService/GetUser",
 		"/memos.api.v1.UserService/ListAllUserStats",
 	}

--- a/server/router/api/v1/attachment_service.go
+++ b/server/router/api/v1/attachment_service.go
@@ -446,7 +446,7 @@ func (s *APIV1Service) validateAttachmentDeletions(ctx context.Context, attachme
 	}
 
 	for creatorID := range creatorIDs {
-		creatorAttachments, err := s.Store.ListAttachments(ctx, &store.FindAttachment{CreatorID: &creatorID})
+		creatorAttachments, err := s.Store.ListAttachments(ctx, &store.FindAttachment{CreatorID: &creatorID, SkipDefaultLimit: true})
 		if err != nil {
 			return status.Errorf(codes.Internal, "failed to list motion media group: %v", err)
 		}
@@ -507,14 +507,14 @@ func (s *APIV1Service) detachAttachmentsForDeletion(ctx context.Context, attachm
 		for _, attachment := range memoAttachments {
 			removedIDs = append(removedIDs, attachment.ID)
 		}
-		if err := s.Store.ApplyMemoAttachmentMutation(ctx, &store.MemoAttachmentMutation{
+		if err := s.Store.ApplyMemoMutation(ctx, &store.MemoMutation{
 			MemoID:               memo.ID,
 			MemoCreatorID:        memo.CreatorID,
 			ExpectedMemoContent:  memo.Content,
 			RemovedAttachmentIDs: removedIDs,
 		}); err != nil {
-			if errors.Is(err, store.ErrMemoAttachmentConflict) {
-				return status.Errorf(codes.FailedPrecondition, "memo attachment state changed: %v", err)
+			if errors.Is(err, store.ErrMemoMutationConflict) {
+				return status.Errorf(codes.FailedPrecondition, "memo state changed: %v", err)
 			}
 			return status.Errorf(codes.Internal, "failed to detach attachments: %v", err)
 		}

--- a/server/router/api/v1/attachment_service.go
+++ b/server/router/api/v1/attachment_service.go
@@ -142,6 +142,9 @@ func (s *APIV1Service) CreateAttachment(ctx context.Context, request *v1pb.Creat
 		if !canModifyMemo(user, memo) {
 			return nil, status.Errorf(codes.PermissionDenied, "permission denied")
 		}
+		if memo.CreatorID != user.ID {
+			return nil, status.Errorf(codes.PermissionDenied, "attachments linked at creation must be owned by the memo creator")
+		}
 		create.MemoID = &memo.ID
 	}
 
@@ -331,6 +334,12 @@ func (s *APIV1Service) DeleteAttachment(ctx context.Context, request *v1pb.Delet
 	if attachment == nil {
 		return nil, status.Errorf(codes.NotFound, "attachment not found")
 	}
+	if err := s.validateAttachmentDeletions(ctx, []*store.Attachment{attachment}); err != nil {
+		return nil, err
+	}
+	if err := s.detachAttachmentsForDeletion(ctx, []*store.Attachment{attachment}); err != nil {
+		return nil, err
+	}
 	// Delete the attachment from the database.
 	if err := s.Store.DeleteAttachment(ctx, &store.DeleteAttachment{
 		ID: attachment.ID,
@@ -382,12 +391,135 @@ func (s *APIV1Service) BatchDeleteAttachments(ctx context.Context, request *v1pb
 		}
 		attachments = append(attachments, attachment)
 	}
-
-	if err := s.Store.DeleteAttachments(ctx, attachments); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to delete attachments: %v", err)
+	if err := s.validateAttachmentDeletions(ctx, attachments); err != nil {
+		return nil, err
+	}
+	if err := s.detachAttachmentsForDeletion(ctx, attachments); err != nil {
+		return nil, err
+	}
+	for _, attachment := range attachments {
+		if err := s.Store.DeleteAttachment(ctx, &store.DeleteAttachment{ID: attachment.ID}); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to delete attachment: %v", err)
+		}
 	}
 
 	return &emptypb.Empty{}, nil
+}
+
+func (s *APIV1Service) validateAttachmentDeletions(ctx context.Context, attachments []*store.Attachment) error {
+	deletingUIDs := make(map[string]struct{}, len(attachments))
+	creatorIDs := make(map[int32]struct{})
+	for _, attachment := range attachments {
+		deletingUIDs[attachment.UID] = struct{}{}
+		if motion := getAttachmentMotionMedia(attachment); motion != nil && motion.GroupId != "" {
+			creatorIDs[attachment.CreatorID] = struct{}{}
+		}
+	}
+
+	memos := make(map[int32]*store.Memo)
+	for _, attachment := range attachments {
+		if attachment.MemoID == nil {
+			continue
+		}
+		memo := memos[*attachment.MemoID]
+		if memo == nil {
+			var err error
+			memo, err = s.Store.GetMemo(ctx, &store.FindMemo{ID: attachment.MemoID})
+			if err != nil {
+				return status.Errorf(codes.Internal, "failed to get attachment memo: %v", err)
+			}
+			if memo == nil {
+				return status.Errorf(codes.FailedPrecondition, "attachment memo no longer exists")
+			}
+			memos[memo.ID] = memo
+		}
+
+		references, err := s.extractManagedAttachmentReferences(memo.Content)
+		if err != nil {
+			return status.Errorf(codes.FailedPrecondition, "memo contains an invalid managed attachment reference: %v", err)
+		}
+		for _, reference := range references {
+			if _, ok := deletingUIDs[reference.UID]; ok {
+				return status.Errorf(codes.FailedPrecondition, "attachment %s is referenced by memo content", reference.UID)
+			}
+		}
+	}
+
+	for creatorID := range creatorIDs {
+		creatorAttachments, err := s.Store.ListAttachments(ctx, &store.FindAttachment{CreatorID: &creatorID})
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to list motion media group: %v", err)
+		}
+		groups := make(map[string][]*store.Attachment)
+		for _, attachment := range creatorAttachments {
+			motion := getAttachmentMotionMedia(attachment)
+			if motion != nil && motion.GroupId != "" {
+				groups[motion.GroupId] = append(groups[motion.GroupId], attachment)
+			}
+		}
+		for _, attachment := range attachments {
+			if attachment.CreatorID != creatorID {
+				continue
+			}
+			motion := getAttachmentMotionMedia(attachment)
+			if motion == nil || motion.GroupId == "" || len(groups[motion.GroupId]) < 2 {
+				continue
+			}
+			for _, groupAttachment := range groups[motion.GroupId] {
+				if _, ok := deletingUIDs[groupAttachment.UID]; !ok {
+					return status.Errorf(codes.FailedPrecondition, "motion media group %s must be deleted together", motion.GroupId)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *APIV1Service) detachAttachmentsForDeletion(ctx context.Context, attachments []*store.Attachment) error {
+	deletingUIDs := make(map[string]struct{}, len(attachments))
+	attachmentsByMemoID := make(map[int32][]*store.Attachment)
+	for _, attachment := range attachments {
+		deletingUIDs[attachment.UID] = struct{}{}
+		if attachment.MemoID != nil {
+			attachmentsByMemoID[*attachment.MemoID] = append(attachmentsByMemoID[*attachment.MemoID], attachment)
+		}
+	}
+
+	for memoID, memoAttachments := range attachmentsByMemoID {
+		memo, err := s.Store.GetMemo(ctx, &store.FindMemo{ID: &memoID})
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to recheck attachment memo: %v", err)
+		}
+		if memo == nil {
+			return status.Errorf(codes.FailedPrecondition, "attachment memo no longer exists")
+		}
+		references, err := s.extractManagedAttachmentReferences(memo.Content)
+		if err != nil {
+			return status.Errorf(codes.FailedPrecondition, "memo contains an invalid managed attachment reference: %v", err)
+		}
+		for _, reference := range references {
+			if _, ok := deletingUIDs[reference.UID]; ok {
+				return status.Errorf(codes.FailedPrecondition, "attachment %s is referenced by memo content", reference.UID)
+			}
+		}
+		removedIDs := make([]int32, 0, len(memoAttachments))
+		for _, attachment := range memoAttachments {
+			removedIDs = append(removedIDs, attachment.ID)
+		}
+		if err := s.Store.ApplyMemoAttachmentMutation(ctx, &store.MemoAttachmentMutation{
+			MemoID:               memo.ID,
+			MemoCreatorID:        memo.CreatorID,
+			ExpectedMemoContent:  memo.Content,
+			RemovedAttachmentIDs: removedIDs,
+		}); err != nil {
+			if errors.Is(err, store.ErrMemoAttachmentConflict) {
+				return status.Errorf(codes.FailedPrecondition, "memo attachment state changed: %v", err)
+			}
+			return status.Errorf(codes.Internal, "failed to detach attachments: %v", err)
+		}
+	}
+	return nil
 }
 
 func (s *APIV1Service) validateAttachmentFilter(ctx context.Context, filterStr string) error {
@@ -410,10 +542,12 @@ func (s *APIV1Service) validateAttachmentFilter(ctx context.Context, filterStr s
 // For unlinked attachments (no memo), only the creator can access.
 // For linked attachments, access follows the memo's visibility rules.
 func (s *APIV1Service) checkAttachmentAccess(ctx context.Context, attachment *store.Attachment) error {
-	user, _ := s.fetchCurrentUser(ctx)
-
 	// For unlinked attachments, only the creator can access.
 	if attachment.MemoID == nil {
+		user, err := s.fetchCurrentUser(ctx)
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to get current user")
+		}
 		if user == nil {
 			return status.Errorf(codes.Unauthenticated, "user not authenticated")
 		}
@@ -432,14 +566,5 @@ func (s *APIV1Service) checkAttachmentAccess(ctx context.Context, attachment *st
 		return status.Errorf(codes.NotFound, "memo not found")
 	}
 
-	if memo.Visibility == store.Public {
-		return nil
-	}
-	if user == nil {
-		return status.Errorf(codes.Unauthenticated, "user not authenticated")
-	}
-	if memo.Visibility == store.Private && memo.CreatorID != user.ID && !isSuperUser(user) {
-		return status.Errorf(codes.PermissionDenied, "permission denied")
-	}
-	return nil
+	return s.checkMemoAndParentReadAccess(ctx, memo)
 }

--- a/server/router/api/v1/attachment_service_storage.go
+++ b/server/router/api/v1/attachment_service_storage.go
@@ -36,7 +36,10 @@ func convertAttachmentFromStore(attachment *store.Attachment) *v1pb.Attachment {
 		memoName := fmt.Sprintf("%s%s", MemoNamePrefix, *attachment.MemoUID)
 		attachmentMessage.Memo = &memoName
 	}
-	if attachment.StorageType == storepb.AttachmentStorageType_EXTERNAL || attachment.StorageType == storepb.AttachmentStorageType_S3 {
+	// Managed storage is always addressed through the authenticated file route.
+	// In particular, never expose an expiring S3 presigned URL as attachment API
+	// metadata because it can outlive a memo visibility change.
+	if attachment.StorageType == storepb.AttachmentStorageType_EXTERNAL {
 		attachmentMessage.ExternalLink = attachment.Reference
 	}
 

--- a/server/router/api/v1/attachment_service_storage_test.go
+++ b/server/router/api/v1/attachment_service_storage_test.go
@@ -1,0 +1,30 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/usememos/memos/proto/gen/store"
+	"github.com/usememos/memos/store"
+)
+
+func TestConvertAttachmentFromStoreHidesManagedStorageReference(t *testing.T) {
+	s3Attachment := &store.Attachment{
+		UID:         "s3-image",
+		Filename:    "image.png",
+		Type:        "image/png",
+		StorageType: storepb.AttachmentStorageType_S3,
+		Reference:   "https://s3.example.com/presigned-secret",
+	}
+	require.Empty(t, convertAttachmentFromStore(s3Attachment).ExternalLink)
+
+	externalAttachment := &store.Attachment{
+		UID:         "external-image",
+		Filename:    "image.png",
+		Type:        "image/png",
+		StorageType: storepb.AttachmentStorageType_EXTERNAL,
+		Reference:   "https://cdn.example.com/image.png",
+	}
+	require.Equal(t, externalAttachment.Reference, convertAttachmentFromStore(externalAttachment).ExternalLink)
+}

--- a/server/router/api/v1/memo_attachment_service.go
+++ b/server/router/api/v1/memo_attachment_service.go
@@ -2,14 +2,19 @@ package v1
 
 import (
 	"context"
+	stderrors "errors"
+	"net/url"
 	"slices"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
+	"github.com/usememos/memos/internal/markdown"
 	v1pb "github.com/usememos/memos/proto/gen/api/v1"
+	storepb "github.com/usememos/memos/proto/gen/store"
 	"github.com/usememos/memos/store"
 )
 
@@ -35,10 +40,16 @@ func (s *APIV1Service) SetMemoAttachments(ctx context.Context, request *v1pb.Set
 	if !canModifyMemo(user, memo) {
 		return nil, status.Errorf(codes.PermissionDenied, "permission denied")
 	}
-	if err := s.setMemoAttachmentsInternal(ctx, user, memo, request.Attachments); err != nil {
+	prepared, err := s.prepareMemoAttachments(ctx, user, memo, request.Attachments)
+	if err != nil {
 		return nil, err
 	}
-	if err := s.touchMemoUpdatedTimestamp(ctx, memo.ID); err != nil {
+	requiredAttachmentIDs, err := s.resolveMemoAttachmentReferences(memo.Content, prepared.normalized)
+	if err != nil {
+		return nil, err
+	}
+	updatedTs := time.Now().Unix()
+	if err := s.applyMemoAttachments(ctx, memo, prepared, &store.UpdateMemo{ID: memo.ID, UpdatedTs: &updatedTs}, requiredAttachmentIDs); err != nil {
 		return nil, err
 	}
 	updatedMemo, parentMemo, memoMessage, err := s.buildUpdatedMemoState(ctx, memo.ID)
@@ -50,17 +61,28 @@ func (s *APIV1Service) SetMemoAttachments(ctx context.Context, request *v1pb.Set
 	return &emptypb.Empty{}, nil
 }
 
-func (s *APIV1Service) setMemoAttachmentsInternal(ctx context.Context, user *store.User, memo *store.Memo, requestAttachments []*v1pb.Attachment) error {
+type preparedMemoAttachments struct {
+	current    []*store.Attachment
+	normalized []*store.Attachment
+	removed    []*store.Attachment
+}
+
+func (s *APIV1Service) prepareMemoAttachments(
+	ctx context.Context,
+	user *store.User,
+	memo *store.Memo,
+	requestAttachments []*v1pb.Attachment,
+) (*preparedMemoAttachments, error) {
 	currentAttachments, err := s.Store.ListAttachments(ctx, &store.FindAttachment{
 		MemoID: &memo.ID,
 	})
 	if err != nil {
-		return status.Errorf(codes.Internal, "failed to list attachments")
+		return nil, status.Errorf(codes.Internal, "failed to list attachments")
 	}
 
-	normalizedAttachments, err := s.normalizeMemoAttachmentRequest(ctx, user, currentAttachments, requestAttachments)
+	normalizedAttachments, err := s.normalizeMemoAttachmentRequest(ctx, memo, currentAttachments, requestAttachments)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	requestedIDs := make(map[int32]bool, len(normalizedAttachments))
@@ -68,31 +90,89 @@ func (s *APIV1Service) setMemoAttachmentsInternal(ctx context.Context, user *sto
 		requestedIDs[attachment.ID] = true
 	}
 
-	// Delete attachments that are not in the request.
+	removedAttachments := make([]*store.Attachment, 0)
 	for _, attachment := range currentAttachments {
 		if !requestedIDs[attachment.ID] {
+			if attachment.CreatorID != memo.CreatorID {
+				return nil, status.Errorf(codes.FailedPrecondition, "cannot remove another user's attachment from this memo")
+			}
 			if attachment.CreatorID != user.ID && !isSuperUser(user) {
-				return status.Errorf(codes.PermissionDenied, "cannot remove another user's attachment")
+				return nil, status.Errorf(codes.PermissionDenied, "cannot remove another user's attachment")
 			}
-			if err = s.Store.DeleteAttachment(ctx, &store.DeleteAttachment{
-				ID:     int32(attachment.ID),
-				MemoID: &memo.ID,
-			}); err != nil {
-				return status.Errorf(codes.Internal, "failed to delete attachment")
-			}
+			removedAttachments = append(removedAttachments, attachment)
 		}
 	}
 
+	return &preparedMemoAttachments{
+		current:    currentAttachments,
+		normalized: normalizedAttachments,
+		removed:    removedAttachments,
+	}, nil
+}
+
+func (s *APIV1Service) applyMemoAttachments(
+	ctx context.Context,
+	memo *store.Memo,
+	prepared *preparedMemoAttachments,
+	memoUpdate *store.UpdateMemo,
+	requiredAttachmentIDs []int32,
+) error {
+	if prepared == nil {
+		prepared = &preparedMemoAttachments{}
+	}
+	currentIDs := make(map[int32]struct{}, len(prepared.current))
+	for _, attachment := range prepared.current {
+		currentIDs[attachment.ID] = struct{}{}
+	}
+
+	normalizedAttachments := slices.Clone(prepared.normalized)
 	slices.Reverse(normalizedAttachments)
-	// Update attachments' memo_id in the request.
+	bindings := make([]*store.MemoAttachmentBinding, 0, len(normalizedAttachments))
 	for index, attachment := range normalizedAttachments {
 		updatedTs := time.Now().Unix() + int64(index)
-		if err := s.Store.UpdateAttachment(ctx, &store.UpdateAttachment{
-			ID:        attachment.ID,
-			MemoID:    &memo.ID,
-			UpdatedTs: &updatedTs,
-		}); err != nil {
-			return status.Errorf(codes.Internal, "failed to update attachment: %v", err)
+		_, wasBoundToMemo := currentIDs[attachment.ID]
+		bindings = append(bindings, &store.MemoAttachmentBinding{
+			ID:             attachment.ID,
+			UID:            attachment.UID,
+			UpdatedTs:      updatedTs,
+			WasBoundToMemo: wasBoundToMemo,
+		})
+	}
+	slices.SortFunc(bindings, func(a, b *store.MemoAttachmentBinding) int {
+		if a.ID < b.ID {
+			return -1
+		}
+		if a.ID > b.ID {
+			return 1
+		}
+		return 0
+	})
+	removedAttachmentIDs := make([]int32, 0, len(prepared.removed))
+	for _, attachment := range prepared.removed {
+		removedAttachmentIDs = append(removedAttachmentIDs, attachment.ID)
+	}
+	mutation := &store.MemoAttachmentMutation{
+		MemoID:                memo.ID,
+		MemoCreatorID:         memo.CreatorID,
+		ExpectedMemoContent:   memo.Content,
+		MemoUpdate:            memoUpdate,
+		Bindings:              bindings,
+		RemovedAttachmentIDs:  removedAttachmentIDs,
+		RequiredAttachmentIDs: requiredAttachmentIDs,
+	}
+	if err := s.Store.ApplyMemoAttachmentMutation(ctx, mutation); err != nil {
+		if stderrors.Is(err, store.ErrMemoAttachmentConflict) {
+			return status.Errorf(codes.FailedPrecondition, "memo attachment state changed: %v", err)
+		}
+		return status.Errorf(codes.Internal, "failed to apply memo attachment mutation: %v", err)
+	}
+
+	// Rows are detached in the transaction above. Delete storage one at a time so
+	// local cleanup remains storage-first; on failure the unlinked row remains and
+	// the owner can safely retry deletion.
+	for _, attachment := range prepared.removed {
+		if err := s.Store.DeleteAttachment(ctx, &store.DeleteAttachment{ID: attachment.ID}); err != nil {
+			return status.Errorf(codes.Internal, "failed to delete attachment: %v", err)
 		}
 	}
 
@@ -101,12 +181,20 @@ func (s *APIV1Service) setMemoAttachmentsInternal(ctx context.Context, user *sto
 
 func (s *APIV1Service) normalizeMemoAttachmentRequest(
 	ctx context.Context,
-	user *store.User,
+	memo *store.Memo,
 	currentAttachments []*store.Attachment,
 	requestAttachments []*v1pb.Attachment,
 ) ([]*store.Attachment, error) {
+	currentByID := make(map[int32]struct{}, len(currentAttachments))
+	for _, attachment := range currentAttachments {
+		currentByID[attachment.ID] = struct{}{}
+	}
+
 	requestedAttachments := make([]*store.Attachment, 0, len(requestAttachments))
 	for _, requestAttachment := range requestAttachments {
+		if requestAttachment == nil {
+			return nil, status.Errorf(codes.InvalidArgument, "attachment is required")
+		}
 		attachmentUID, err := ExtractAttachmentUIDFromName(requestAttachment.Name)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid attachment name: %v", err)
@@ -118,8 +206,15 @@ func (s *APIV1Service) normalizeMemoAttachmentRequest(
 		if attachment == nil {
 			return nil, status.Errorf(codes.NotFound, "attachment not found: %s", attachmentUID)
 		}
-		if attachment.CreatorID != user.ID && !isSuperUser(user) {
-			return nil, status.Errorf(codes.PermissionDenied, "cannot attach another user's attachment")
+		_, alreadyInTarget := currentByID[attachment.ID]
+		if attachment.CreatorID != memo.CreatorID && !alreadyInTarget {
+			// Hide another user's unlinked or foreign-memo attachment from the
+			// caller. Admin status grants memo maintenance privileges, not the
+			// right to transfer attachment ownership into a different account.
+			return nil, status.Errorf(codes.NotFound, "attachment not found: %s", attachmentUID)
+		}
+		if attachment.MemoID != nil && !alreadyInTarget {
+			return nil, status.Errorf(codes.FailedPrecondition, "attachment %s is already bound to another memo", attachmentUID)
 		}
 		requestedAttachments = append(requestedAttachments, attachment)
 	}
@@ -184,6 +279,96 @@ func (s *APIV1Service) normalizeMemoAttachmentRequest(
 	return normalized, nil
 }
 
+func (s *APIV1Service) resolveMemoAttachmentReferences(content string, attachments []*store.Attachment) ([]int32, error) {
+	references, err := s.extractManagedAttachmentReferences(content)
+	if err != nil {
+		return nil, err
+	}
+
+	attachmentsByUID := make(map[string]*store.Attachment, len(attachments))
+	for _, attachment := range attachments {
+		attachmentsByUID[attachment.UID] = attachment
+	}
+	requiredAttachmentIDs := make([]int32, 0, len(references))
+	for _, reference := range references {
+		attachment := attachmentsByUID[reference.UID]
+		if attachment == nil {
+			return nil, status.Errorf(codes.FailedPrecondition, "managed image attachment %s must be bound to the memo", reference.UID)
+		}
+		if !strings.HasPrefix(strings.ToLower(attachment.Type), "image/") {
+			return nil, status.Errorf(codes.InvalidArgument, "managed image attachment %s must have an image MIME type", reference.UID)
+		}
+		if attachment.StorageType == storepb.AttachmentStorageType_EXTERNAL {
+			return nil, status.Errorf(codes.InvalidArgument, "external attachment %s cannot be used as a managed memo image", reference.UID)
+		}
+		requiredAttachmentIDs = append(requiredAttachmentIDs, attachment.ID)
+	}
+	return requiredAttachmentIDs, nil
+}
+
+func (s *APIV1Service) extractManagedAttachmentReferences(content string) ([]markdown.ManagedAttachmentReference, error) {
+	data, err := s.MarkdownService.ExtractAll([]byte(content))
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid markdown content: %v", err)
+	}
+	if len(data.InvalidManagedAttachmentReferences) > 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid managed attachment image URL: %s", data.InvalidManagedAttachmentReferences[0])
+	}
+	references := slices.Clone(data.ManagedAttachmentReferences)
+	instanceURLString := ""
+	if s.Profile != nil {
+		instanceURLString = strings.TrimSpace(s.Profile.InstanceURL)
+	}
+	var instanceURL *url.URL
+	if instanceURLString != "" {
+		instanceURL, err = url.Parse(instanceURLString)
+		if err != nil || !instanceURL.IsAbs() || instanceURL.Host == "" {
+			return nil, status.Errorf(codes.Internal, "invalid configured instance URL")
+		}
+	}
+	for _, destination := range data.ImageDestinations {
+		parsed, err := url.Parse(destination)
+		if err != nil || (!parsed.IsAbs() && parsed.Host == "") || !strings.HasPrefix(parsed.Path, "/file/attachments/") {
+			continue
+		}
+		if parsed.Scheme == "" && parsed.Host != "" {
+			if instanceURL == nil || strings.EqualFold(parsed.Host, instanceURL.Host) {
+				return nil, status.Errorf(codes.InvalidArgument, "protocol-relative managed attachment image URLs are not allowed: %s", destination)
+			}
+			continue
+		}
+		if instanceURL == nil {
+			return nil, status.Errorf(codes.InvalidArgument, "absolute managed attachment image URLs require a configured instance URL")
+		}
+		if !strings.EqualFold(parsed.Scheme, instanceURL.Scheme) || !strings.EqualFold(parsed.Host, instanceURL.Host) {
+			continue
+		}
+		relative := parsed.EscapedPath()
+		if parsed.RawQuery != "" {
+			relative += "?" + parsed.RawQuery
+		}
+		if parsed.Fragment != "" {
+			relative += "#" + parsed.Fragment
+		}
+		uid, managed, valid := markdown.ParseManagedAttachmentImageURL(relative)
+		if !managed || !valid {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid managed attachment image URL: %s", destination)
+		}
+		references = append(references, markdown.ManagedAttachmentReference{UID: uid})
+	}
+
+	seenReferences := make(map[string]struct{}, len(references))
+	uniqueReferences := make([]markdown.ManagedAttachmentReference, 0, len(references))
+	for _, reference := range references {
+		if _, ok := seenReferences[reference.UID]; ok {
+			continue
+		}
+		seenReferences[reference.UID] = struct{}{}
+		uniqueReferences = append(uniqueReferences, reference)
+	}
+	return uniqueReferences, nil
+}
+
 func allGroupMembersRequested(group []*store.Attachment, requestedNames map[string]bool) bool {
 	if len(group) == 0 {
 		return false
@@ -210,18 +395,8 @@ func (s *APIV1Service) ListMemoAttachments(ctx context.Context, request *v1pb.Li
 		return nil, status.Errorf(codes.NotFound, "memo not found")
 	}
 
-	// Check memo visibility.
-	if memo.Visibility != store.Public {
-		user, err := s.fetchCurrentUser(ctx)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to get user: %v", err)
-		}
-		if user == nil {
-			return nil, status.Errorf(codes.Unauthenticated, "user not authenticated")
-		}
-		if memo.Visibility == store.Private && memo.CreatorID != user.ID && !isSuperUser(user) {
-			return nil, status.Errorf(codes.PermissionDenied, "permission denied")
-		}
+	if err := s.checkMemoAndParentReadAccess(ctx, memo); err != nil {
+		return nil, err
 	}
 
 	attachments, err := s.Store.ListAttachments(ctx, &store.FindAttachment{

--- a/server/router/api/v1/memo_attachment_service.go
+++ b/server/router/api/v1/memo_attachment_service.go
@@ -49,7 +49,7 @@ func (s *APIV1Service) SetMemoAttachments(ctx context.Context, request *v1pb.Set
 		return nil, err
 	}
 	updatedTs := time.Now().Unix()
-	if err := s.applyMemoAttachments(ctx, memo, prepared, &store.UpdateMemo{ID: memo.ID, UpdatedTs: &updatedTs}, requiredAttachmentIDs); err != nil {
+	if err := s.applyMemoMutation(ctx, memo, prepared, &store.UpdateMemo{ID: memo.ID, UpdatedTs: &updatedTs}, requiredAttachmentIDs, nil); err != nil {
 		return nil, err
 	}
 	updatedMemo, parentMemo, memoMessage, err := s.buildUpdatedMemoState(ctx, memo.ID)
@@ -110,12 +110,13 @@ func (s *APIV1Service) prepareMemoAttachments(
 	}, nil
 }
 
-func (s *APIV1Service) applyMemoAttachments(
+func (s *APIV1Service) applyMemoMutation(
 	ctx context.Context,
 	memo *store.Memo,
 	prepared *preparedMemoAttachments,
 	memoUpdate *store.UpdateMemo,
 	requiredAttachmentIDs []int32,
+	referenceRelations *[]*store.MemoRelation,
 ) error {
 	if prepared == nil {
 		prepared = &preparedMemoAttachments{}
@@ -151,20 +152,35 @@ func (s *APIV1Service) applyMemoAttachments(
 	for _, attachment := range prepared.removed {
 		removedAttachmentIDs = append(removedAttachmentIDs, attachment.ID)
 	}
-	mutation := &store.MemoAttachmentMutation{
-		MemoID:                memo.ID,
-		MemoCreatorID:         memo.CreatorID,
-		ExpectedMemoContent:   memo.Content,
-		MemoUpdate:            memoUpdate,
-		Bindings:              bindings,
-		RemovedAttachmentIDs:  removedAttachmentIDs,
-		RequiredAttachmentIDs: requiredAttachmentIDs,
-	}
-	if err := s.Store.ApplyMemoAttachmentMutation(ctx, mutation); err != nil {
-		if stderrors.Is(err, store.ErrMemoAttachmentConflict) {
-			return status.Errorf(codes.FailedPrecondition, "memo attachment state changed: %v", err)
+	if referenceRelations != nil {
+		relations := make([]*store.MemoRelation, 0, len(*referenceRelations))
+		for _, relation := range *referenceRelations {
+			relations = append(relations, &store.MemoRelation{
+				MemoID:        memo.ID,
+				RelatedMemoID: relation.RelatedMemoID,
+				Type:          relation.Type,
+			})
 		}
-		return status.Errorf(codes.Internal, "failed to apply memo attachment mutation: %v", err)
+		referenceRelations = &relations
+	}
+	mutation := &store.MemoMutation{
+		MemoID:                    memo.ID,
+		MemoCreatorID:             memo.CreatorID,
+		ExpectedMemoContent:       memo.Content,
+		MemoUpdate:                memoUpdate,
+		Bindings:                  bindings,
+		RemovedAttachmentIDs:      removedAttachmentIDs,
+		RequiredAttachmentIDs:     requiredAttachmentIDs,
+		ReplaceReferenceRelations: referenceRelations != nil,
+	}
+	if referenceRelations != nil {
+		mutation.ReferenceRelations = *referenceRelations
+	}
+	if err := s.Store.ApplyMemoMutation(ctx, mutation); err != nil {
+		if stderrors.Is(err, store.ErrMemoMutationConflict) {
+			return status.Errorf(codes.FailedPrecondition, "memo state changed: %v", err)
+		}
+		return status.Errorf(codes.Internal, "failed to apply memo mutation: %v", err)
 	}
 
 	// Rows are detached in the transaction above. Delete storage one at a time so
@@ -332,7 +348,7 @@ func (s *APIV1Service) extractManagedAttachmentReferences(content string) ([]mar
 			continue
 		}
 		if parsed.Scheme == "" && parsed.Host != "" {
-			if instanceURL == nil || strings.EqualFold(parsed.Host, instanceURL.Host) {
+			if instanceURL == nil || sameURLAuthority(parsed, instanceURL) {
 				return nil, status.Errorf(codes.InvalidArgument, "protocol-relative managed attachment image URLs are not allowed: %s", destination)
 			}
 			continue
@@ -340,7 +356,7 @@ func (s *APIV1Service) extractManagedAttachmentReferences(content string) ([]mar
 		if instanceURL == nil {
 			return nil, status.Errorf(codes.InvalidArgument, "absolute managed attachment image URLs require a configured instance URL")
 		}
-		if !strings.EqualFold(parsed.Scheme, instanceURL.Scheme) || !strings.EqualFold(parsed.Host, instanceURL.Host) {
+		if !sameURLOrigin(parsed, instanceURL) {
 			continue
 		}
 		relative := parsed.EscapedPath()
@@ -367,6 +383,32 @@ func (s *APIV1Service) extractManagedAttachmentReferences(content string) ([]mar
 		uniqueReferences = append(uniqueReferences, reference)
 	}
 	return uniqueReferences, nil
+}
+
+func sameURLAuthority(candidate, instance *url.URL) bool {
+	withScheme := *candidate
+	withScheme.Scheme = instance.Scheme
+	return sameURLOrigin(&withScheme, instance)
+}
+
+func sameURLOrigin(a, b *url.URL) bool {
+	return strings.EqualFold(a.Scheme, b.Scheme) &&
+		strings.EqualFold(a.Hostname(), b.Hostname()) &&
+		effectiveURLPort(a) == effectiveURLPort(b)
+}
+
+func effectiveURLPort(u *url.URL) string {
+	if port := u.Port(); port != "" {
+		return port
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	default:
+		return ""
+	}
 }
 
 func allGroupMembersRequested(group []*store.Attachment, requestedNames map[string]bool) bool {

--- a/server/router/api/v1/memo_relation_service.go
+++ b/server/router/api/v1/memo_relation_service.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
@@ -35,10 +36,12 @@ func (s *APIV1Service) SetMemoRelations(ctx context.Context, request *v1pb.SetMe
 	if memo.CreatorID != user.ID && !isSuperUser(user) {
 		return nil, status.Errorf(codes.PermissionDenied, "permission denied")
 	}
-	if err := s.setMemoRelationsInternal(ctx, memo, request.Relations); err != nil {
+	relations, err := s.prepareMemoRelations(ctx, memo, request.Relations)
+	if err != nil {
 		return nil, err
 	}
-	if err := s.touchMemoUpdatedTimestamp(ctx, memo.ID); err != nil {
+	updatedTs := time.Now().Unix()
+	if err := s.applyMemoMutation(ctx, memo, nil, &store.UpdateMemo{ID: memo.ID, UpdatedTs: &updatedTs}, nil, &relations); err != nil {
 		return nil, err
 	}
 	updatedMemo, parentMemo, memoMessage, err := s.buildUpdatedMemoState(ctx, memo.ID)
@@ -50,17 +53,13 @@ func (s *APIV1Service) SetMemoRelations(ctx context.Context, request *v1pb.SetMe
 	return &emptypb.Empty{}, nil
 }
 
-func (s *APIV1Service) setMemoRelationsInternal(ctx context.Context, memo *store.Memo, relations []*v1pb.MemoRelation) error {
-	referenceType := store.MemoRelationReference
-	// Delete all reference relations first.
-	if err := s.Store.DeleteMemoRelation(ctx, &store.DeleteMemoRelation{
-		MemoID: &memo.ID,
-		Type:   &referenceType,
-	}); err != nil {
-		return status.Errorf(codes.Internal, "failed to delete memo relation")
-	}
-
+func (s *APIV1Service) prepareMemoRelations(ctx context.Context, memo *store.Memo, relations []*v1pb.MemoRelation) ([]*store.MemoRelation, error) {
+	prepared := make([]*store.MemoRelation, 0, len(relations))
+	seenRelatedMemoIDs := make(map[int32]struct{}, len(relations))
 	for _, relation := range relations {
+		if relation == nil || relation.RelatedMemo == nil {
+			return nil, status.Errorf(codes.InvalidArgument, "related memo is required")
+		}
 		// Ignore reflexive relations.
 		if buildMemoName(memo.UID) == relation.RelatedMemo.Name {
 			continue
@@ -72,22 +71,26 @@ func (s *APIV1Service) setMemoRelationsInternal(ctx context.Context, memo *store
 		}
 		relatedMemoUID, err := ExtractMemoUIDFromName(relation.RelatedMemo.Name)
 		if err != nil {
-			return status.Errorf(codes.InvalidArgument, "invalid related memo name: %v", err)
+			return nil, status.Errorf(codes.InvalidArgument, "invalid related memo name: %v", err)
 		}
 		relatedMemo, err := s.Store.GetMemo(ctx, &store.FindMemo{UID: &relatedMemoUID})
 		if err != nil {
-			return status.Errorf(codes.Internal, "failed to get related memo")
+			return nil, status.Errorf(codes.Internal, "failed to get related memo")
 		}
-		if _, err := s.Store.UpsertMemoRelation(ctx, &store.MemoRelation{
+		if relatedMemo == nil {
+			return nil, status.Errorf(codes.NotFound, "related memo not found")
+		}
+		if _, ok := seenRelatedMemoIDs[relatedMemo.ID]; ok {
+			continue
+		}
+		seenRelatedMemoIDs[relatedMemo.ID] = struct{}{}
+		prepared = append(prepared, &store.MemoRelation{
 			MemoID:        memo.ID,
 			RelatedMemoID: relatedMemo.ID,
 			Type:          convertMemoRelationTypeToStore(relation.Type),
-		}); err != nil {
-			return status.Errorf(codes.Internal, "failed to upsert memo relation")
-		}
+		})
 	}
-
-	return nil
+	return prepared, nil
 }
 
 func (s *APIV1Service) ListMemoRelations(ctx context.Context, request *v1pb.ListMemoRelationsRequest) (*v1pb.ListMemoRelationsResponse, error) {

--- a/server/router/api/v1/memo_service.go
+++ b/server/router/api/v1/memo_service.go
@@ -136,6 +136,10 @@ func (s *APIV1Service) CreateMemo(ctx context.Context, request *v1pb.CreateMemoR
 	if err != nil {
 		return nil, err
 	}
+	preparedRelations, err := s.prepareMemoRelations(ctx, create, request.Memo.Relations)
+	if err != nil {
+		return nil, err
+	}
 
 	memo, err := s.Store.CreateMemo(ctx, create)
 	if err != nil {
@@ -150,9 +154,13 @@ func (s *APIV1Service) CreateMemo(ctx context.Context, request *v1pb.CreateMemoR
 	}
 
 	attachments := []*store.Attachment{}
-	if len(preparedAttachments.normalized) > 0 {
-		if err := s.applyMemoAttachments(ctx, memo, preparedAttachments, nil, requiredAttachmentIDs); err != nil {
-			return nil, errors.Wrap(err, "failed to set memo attachments")
+	if len(preparedAttachments.normalized) > 0 || len(preparedRelations) > 0 {
+		var relations *[]*store.MemoRelation
+		if len(preparedRelations) > 0 {
+			relations = &preparedRelations
+		}
+		if err := s.applyMemoMutation(ctx, memo, preparedAttachments, nil, requiredAttachmentIDs, relations); err != nil {
+			return nil, err
 		}
 		a, err := s.Store.ListAttachments(ctx, &store.FindAttachment{
 			MemoID: &memo.ID,
@@ -161,11 +169,6 @@ func (s *APIV1Service) CreateMemo(ctx context.Context, request *v1pb.CreateMemoR
 			return nil, errors.Wrap(err, "failed to get memo attachments")
 		}
 		attachments = a
-	}
-	if len(request.Memo.Relations) > 0 {
-		if err := s.setMemoRelationsInternal(ctx, memo, request.Memo.Relations); err != nil {
-			return nil, errors.Wrap(err, "failed to set memo relations")
-		}
 	}
 
 	relations, err := s.loadMemoRelations(ctx, memo)
@@ -529,7 +532,14 @@ func (s *APIV1Service) UpdateMemo(ctx context.Context, request *v1pb.UpdateMemoR
 	if attachmentsUpdated {
 		preparedAttachments, err = s.prepareMemoAttachments(ctx, user, memo, request.Memo.Attachments)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to prepare memo attachments")
+			return nil, err
+		}
+	}
+	var preparedRelations []*store.MemoRelation
+	if relationsUpdated {
+		preparedRelations, err = s.prepareMemoRelations(ctx, memo, request.Memo.Relations)
+		if err != nil {
+			return nil, err
 		}
 	}
 	var requiredAttachmentIDs []int32
@@ -549,17 +559,16 @@ func (s *APIV1Service) UpdateMemo(ctx context.Context, request *v1pb.UpdateMemoR
 		}
 	}
 
-	if contentUpdated || attachmentsUpdated {
-		if err := s.applyMemoAttachments(ctx, memo, preparedAttachments, update, requiredAttachmentIDs); err != nil {
-			return nil, errors.Wrap(err, "failed to update memo and attachments")
+	if contentUpdated || attachmentsUpdated || relationsUpdated {
+		var relations *[]*store.MemoRelation
+		if relationsUpdated {
+			relations = &preparedRelations
+		}
+		if err := s.applyMemoMutation(ctx, memo, preparedAttachments, update, requiredAttachmentIDs, relations); err != nil {
+			return nil, err
 		}
 	} else if err = s.Store.UpdateMemo(ctx, update); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update memo")
-	}
-	if relationsUpdated {
-		if err := s.setMemoRelationsInternal(ctx, memo, request.Memo.Relations); err != nil {
-			return nil, errors.Wrap(err, "failed to set memo relations")
-		}
 	}
 
 	memo, err = s.Store.GetMemo(ctx, &store.FindMemo{

--- a/server/router/api/v1/memo_service.go
+++ b/server/router/api/v1/memo_service.go
@@ -11,10 +11,13 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/usememos/memos/internal/httpgetter"
 	v1pb "github.com/usememos/memos/proto/gen/api/v1"
+	storepb "github.com/usememos/memos/proto/gen/store"
+	"github.com/usememos/memos/server/access"
 	"github.com/usememos/memos/server/runner/memopayload"
 	"github.com/usememos/memos/store"
 )
@@ -37,34 +40,44 @@ func isSSESuppressed(ctx context.Context) bool {
 }
 
 func (s *APIV1Service) checkMemoReadAccess(ctx context.Context, memo *store.Memo) error {
-	if memo == nil {
-		return status.Errorf(codes.NotFound, "memo not found")
-	}
+	return s.checkMemoReadAccessWithParent(ctx, memo, nil)
+}
 
-	// Archived memos are only visible to their creator.
-	if memo.RowStatus == store.Archived {
-		user, err := s.fetchCurrentUser(ctx)
+func (s *APIV1Service) checkMemoAndParentReadAccess(ctx context.Context, memo *store.Memo) error {
+	var parent *store.Memo
+	if memo != nil && memo.ParentUID != nil {
+		var err error
+		parent, err = s.Store.GetMemo(ctx, &store.FindMemo{UID: memo.ParentUID})
 		if err != nil {
-			return status.Errorf(codes.Internal, "failed to get user")
+			return status.Errorf(codes.Internal, "failed to get parent memo")
 		}
-		if user == nil || memo.CreatorID != user.ID {
+		if parent == nil {
 			return status.Errorf(codes.NotFound, "memo not found")
 		}
 	}
+	return s.checkMemoReadAccessWithParent(ctx, memo, parent)
+}
 
-	if memo.Visibility != store.Public {
-		user, err := s.fetchCurrentUser(ctx)
-		if err != nil {
-			return status.Errorf(codes.Internal, "failed to get user")
-		}
-		if user == nil {
-			return status.Errorf(codes.Unauthenticated, "user not authenticated")
-		}
-		if memo.Visibility == store.Private && memo.CreatorID != user.ID {
-			return status.Errorf(codes.PermissionDenied, "permission denied")
-		}
+func (s *APIV1Service) checkMemoReadAccessWithParent(ctx context.Context, memo, parent *store.Memo) error {
+	user, err := s.fetchCurrentUser(ctx)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to get user")
 	}
-	return nil
+	allowAnonymous := s.Profile != nil && s.Profile.AllowAnonymous()
+	return memoAccessDecisionError(access.CheckMemoRead(memo, parent, user, allowAnonymous, nil))
+}
+
+func memoAccessDecisionError(decision access.MemoReadDecision) error {
+	switch decision.Denial {
+	case access.MemoReadDenialNone:
+		return nil
+	case access.MemoReadDenialNotFound:
+		return status.Errorf(codes.NotFound, "memo not found")
+	case access.MemoReadDenialUnauthenticated:
+		return status.Errorf(codes.Unauthenticated, "user not authenticated")
+	default:
+		return status.Errorf(codes.PermissionDenied, "permission denied")
+	}
 }
 
 func (s *APIV1Service) CreateMemo(ctx context.Context, request *v1pb.CreateMemoRequest) (*v1pb.Memo, error) {
@@ -74,6 +87,9 @@ func (s *APIV1Service) CreateMemo(ctx context.Context, request *v1pb.CreateMemoR
 	}
 	if user == nil {
 		return nil, status.Errorf(codes.Unauthenticated, "user not authenticated")
+	}
+	if request.Memo == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "memo is required")
 	}
 
 	memoUID, err := ValidateAndGenerateUID(request.MemoId)
@@ -112,6 +128,15 @@ func (s *APIV1Service) CreateMemo(ctx context.Context, request *v1pb.CreateMemoR
 		create.Payload.Location = convertLocationToStore(request.Memo.Location)
 	}
 
+	preparedAttachments, err := s.prepareMemoAttachments(ctx, user, create, request.Memo.Attachments)
+	if err != nil {
+		return nil, err
+	}
+	requiredAttachmentIDs, err := s.resolveMemoAttachmentReferences(create.Content, preparedAttachments.normalized)
+	if err != nil {
+		return nil, err
+	}
+
 	memo, err := s.Store.CreateMemo(ctx, create)
 	if err != nil {
 		// Check for unique constraint violation (AIP-133 compliance)
@@ -125,12 +150,10 @@ func (s *APIV1Service) CreateMemo(ctx context.Context, request *v1pb.CreateMemoR
 	}
 
 	attachments := []*store.Attachment{}
-
-	if len(request.Memo.Attachments) > 0 {
-		if err := s.setMemoAttachmentsInternal(ctx, user, memo, request.Memo.Attachments); err != nil {
+	if len(preparedAttachments.normalized) > 0 {
+		if err := s.applyMemoAttachments(ctx, memo, preparedAttachments, nil, requiredAttachmentIDs); err != nil {
 			return nil, errors.Wrap(err, "failed to set memo attachments")
 		}
-
 		a, err := s.Store.ListAttachments(ctx, &store.FindAttachment{
 			MemoID: &memo.ID,
 		})
@@ -353,20 +376,8 @@ func (s *APIV1Service) GetMemo(ctx context.Context, request *v1pb.GetMemoRequest
 		return nil, status.Errorf(codes.NotFound, "memo not found")
 	}
 
-	if err := s.checkMemoReadAccess(ctx, memo); err != nil {
+	if err := s.checkMemoAndParentReadAccess(ctx, memo); err != nil {
 		return nil, err
-	}
-	if memo.ParentUID != nil {
-		parentMemo, err := s.Store.GetMemo(ctx, &store.FindMemo{UID: memo.ParentUID})
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to get parent memo")
-		}
-		if parentMemo == nil {
-			return nil, status.Errorf(codes.NotFound, "memo not found")
-		}
-		if err := s.checkMemoReadAccess(ctx, parentMemo); err != nil {
-			return nil, err
-		}
 	}
 
 	reactions, err := s.Store.ListReactions(ctx, &store.FindReaction{
@@ -394,11 +405,24 @@ func (s *APIV1Service) GetMemo(ctx context.Context, request *v1pb.GetMemoRequest
 		}
 		return nil, errors.Wrap(err, "failed to convert memo")
 	}
+	if memo.ParentUID != nil {
+		parent, err := s.Store.GetMemo(ctx, &store.FindMemo{UID: memo.ParentUID})
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to get parent memo")
+		}
+		if parent == nil {
+			return nil, status.Errorf(codes.NotFound, "memo not found")
+		}
+		memoMessage.Visibility = convertVisibilityFromStore(parent.Visibility)
+	}
 	return memoMessage, nil
 }
 
 // UpdateMemo updates an existing memo.
 func (s *APIV1Service) UpdateMemo(ctx context.Context, request *v1pb.UpdateMemoRequest) (*v1pb.Memo, error) {
+	if request.Memo == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "memo is required")
+	}
 	memoUID, err := ExtractMemoUIDFromName(request.Memo.Name)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid memo name: %v", err)
@@ -430,12 +454,19 @@ func (s *APIV1Service) UpdateMemo(ctx context.Context, request *v1pb.UpdateMemoR
 	update := &store.UpdateMemo{
 		ID: memo.ID,
 	}
-	var previousContent string
+	previousContent := memo.Content
 	contentUpdated := false
+	attachmentsUpdated := false
+	relationsUpdated := false
+	nextMemo := *memo
+	if memo.Payload != nil {
+		nextMemo.Payload = &storepb.MemoPayload{}
+		proto.Merge(nextMemo.Payload, memo.Payload)
+	}
+
 	for _, path := range request.UpdateMask.Paths {
 		if path == "content" {
 			contentUpdated = true
-			previousContent = memo.Content
 			contentLengthLimit, err := s.getContentLengthLimit(ctx)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to get content length limit")
@@ -443,12 +474,12 @@ func (s *APIV1Service) UpdateMemo(ctx context.Context, request *v1pb.UpdateMemoR
 			if len(request.Memo.Content) > contentLengthLimit {
 				return nil, status.Errorf(codes.InvalidArgument, "content too long (max %d characters)", contentLengthLimit)
 			}
-			memo.Content = request.Memo.Content
-			if err := memopayload.RebuildMemoPayload(ctx, memo, s.MarkdownService); err != nil {
+			nextMemo.Content = request.Memo.Content
+			if err := memopayload.RebuildMemoPayload(ctx, &nextMemo, s.MarkdownService); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to rebuild memo payload: %v", err)
 			}
-			update.Content = &memo.Content
-			update.Payload = memo.Payload
+			update.Content = &nextMemo.Content
+			update.Payload = nextMemo.Payload
 		} else if path == "visibility" {
 			visibility := convertVisibilityToStore(request.Memo.Visibility)
 			if memo.ParentUID != nil {
@@ -468,6 +499,9 @@ func (s *APIV1Service) UpdateMemo(ctx context.Context, request *v1pb.UpdateMemoR
 			rowStatus := convertStateToStore(request.Memo.State)
 			update.RowStatus = &rowStatus
 		} else if path == "create_time" {
+			if request.Memo.CreateTime == nil || !request.Memo.CreateTime.IsValid() {
+				return nil, status.Errorf(codes.InvalidArgument, "create_time is invalid")
+			}
 			createdTs := request.Memo.CreateTime.AsTime().Unix()
 			update.CreatedTs = &createdTs
 		} else if path == "update_time" {
@@ -479,22 +513,53 @@ func (s *APIV1Service) UpdateMemo(ctx context.Context, request *v1pb.UpdateMemoR
 		} else if path == "display_time" {
 			return nil, status.Errorf(codes.InvalidArgument, "display_time is not supported")
 		} else if path == "location" {
-			payload := memo.Payload
-			payload.Location = convertLocationToStore(request.Memo.Location)
-			update.Payload = payload
+			if nextMemo.Payload == nil {
+				nextMemo.Payload = &storepb.MemoPayload{}
+			}
+			nextMemo.Payload.Location = convertLocationToStore(request.Memo.Location)
+			update.Payload = nextMemo.Payload
 		} else if path == "attachments" {
-			if err := s.setMemoAttachmentsInternal(ctx, user, memo, request.Memo.Attachments); err != nil {
-				return nil, errors.Wrap(err, "failed to set memo attachments")
-			}
+			attachmentsUpdated = true
 		} else if path == "relations" {
-			if err := s.setMemoRelationsInternal(ctx, memo, request.Memo.Relations); err != nil {
-				return nil, errors.Wrap(err, "failed to set memo relations")
-			}
+			relationsUpdated = true
 		}
 	}
 
-	if err = s.Store.UpdateMemo(ctx, update); err != nil {
+	var preparedAttachments *preparedMemoAttachments
+	if attachmentsUpdated {
+		preparedAttachments, err = s.prepareMemoAttachments(ctx, user, memo, request.Memo.Attachments)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to prepare memo attachments")
+		}
+	}
+	var requiredAttachmentIDs []int32
+	if contentUpdated || attachmentsUpdated {
+		var finalAttachments []*store.Attachment
+		if preparedAttachments != nil {
+			finalAttachments = preparedAttachments.normalized
+		} else {
+			finalAttachments, err = s.Store.ListAttachments(ctx, &store.FindAttachment{MemoID: &memo.ID})
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to list attachments")
+			}
+		}
+		requiredAttachmentIDs, err = s.resolveMemoAttachmentReferences(nextMemo.Content, finalAttachments)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if contentUpdated || attachmentsUpdated {
+		if err := s.applyMemoAttachments(ctx, memo, preparedAttachments, update, requiredAttachmentIDs); err != nil {
+			return nil, errors.Wrap(err, "failed to update memo and attachments")
+		}
+	} else if err = s.Store.UpdateMemo(ctx, update); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update memo")
+	}
+	if relationsUpdated {
+		if err := s.setMemoRelationsInternal(ctx, memo, request.Memo.Relations); err != nil {
+			return nil, errors.Wrap(err, "failed to set memo relations")
+		}
 	}
 
 	memo, err = s.Store.GetMemo(ctx, &store.FindMemo{

--- a/server/router/api/v1/memo_service_comments.go
+++ b/server/router/api/v1/memo_service_comments.go
@@ -38,8 +38,11 @@ func (s *APIV1Service) CreateMemoComment(ctx context.Context, request *v1pb.Crea
 	if user == nil {
 		return nil, status.Errorf(codes.Unauthenticated, "user not authenticated")
 	}
-	if relatedMemo.Visibility == store.Private && relatedMemo.CreatorID != user.ID && !isSuperUser(user) {
-		return nil, status.Errorf(codes.PermissionDenied, "permission denied")
+	if relatedMemo.RowStatus != store.Normal {
+		return nil, status.Errorf(codes.FailedPrecondition, "cannot comment on an archived memo")
+	}
+	if err := s.checkMemoAndParentReadAccess(ctx, relatedMemo); err != nil {
+		return nil, err
 	}
 	if request.Comment == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "comment is required")
@@ -149,16 +152,6 @@ func (s *APIV1Service) ListMemoComments(ctx context.Context, request *v1pb.ListM
 		return nil, err
 	}
 
-	currentUser, err := s.fetchCurrentUser(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get user")
-	}
-	var memoFilter string
-	if currentUser == nil {
-		memoFilter = `visibility == "PUBLIC"`
-	} else {
-		memoFilter = fmt.Sprintf(`creator_id == %d || visibility in ["PUBLIC", "PROTECTED"]`, currentUser.ID)
-	}
 	memoRelationComment := store.MemoRelationComment
 	var limit, offset int
 	if request.PageToken != "" {
@@ -172,12 +165,13 @@ func (s *APIV1Service) ListMemoComments(ctx context.Context, request *v1pb.ListM
 		limit = normalizePageSize(request.PageSize)
 	}
 	limitPlusOne := limit + 1
+	normal := store.Normal
 	memoRelations, err := s.Store.ListMemoRelations(ctx, &store.FindMemoRelation{
-		RelatedMemoID: &memo.ID,
-		Type:          &memoRelationComment,
-		MemoFilter:    &memoFilter,
-		Limit:         &limitPlusOne,
-		Offset:        &offset,
+		RelatedMemoID:       &memo.ID,
+		Type:                &memoRelationComment,
+		SourceMemoRowStatus: &normal,
+		Limit:               &limitPlusOne,
+		Offset:              &offset,
 	})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to list memo relations")
@@ -204,7 +198,7 @@ func (s *APIV1Service) ListMemoComments(ctx context.Context, request *v1pb.ListM
 	for _, m := range memoRelations {
 		memoRelationIDs = append(memoRelationIDs, m.MemoID)
 	}
-	memos, err := s.Store.ListMemos(ctx, &store.FindMemo{IDList: memoRelationIDs})
+	memos, err := s.Store.ListMemos(ctx, &store.FindMemo{IDList: memoRelationIDs, RowStatus: &normal})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to list memos")
 	}
@@ -274,6 +268,7 @@ func (s *APIV1Service) ListMemoComments(ctx context.Context, request *v1pb.ListM
 			}
 			return nil, errors.Wrap(err, "failed to convert memo")
 		}
+		memoMessage.Visibility = convertVisibilityFromStore(memo.Visibility)
 		memosResponse = append(memosResponse, memoMessage)
 	}
 

--- a/server/router/api/v1/memo_service_comments.go
+++ b/server/router/api/v1/memo_service_comments.go
@@ -38,11 +38,11 @@ func (s *APIV1Service) CreateMemoComment(ctx context.Context, request *v1pb.Crea
 	if user == nil {
 		return nil, status.Errorf(codes.Unauthenticated, "user not authenticated")
 	}
-	if relatedMemo.RowStatus != store.Normal {
-		return nil, status.Errorf(codes.FailedPrecondition, "cannot comment on an archived memo")
-	}
 	if err := s.checkMemoAndParentReadAccess(ctx, relatedMemo); err != nil {
 		return nil, err
+	}
+	if relatedMemo.RowStatus != store.Normal {
+		return nil, status.Errorf(codes.FailedPrecondition, "cannot comment on an archived memo")
 	}
 	if request.Comment == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "comment is required")

--- a/server/router/api/v1/memo_share_service.go
+++ b/server/router/api/v1/memo_share_service.go
@@ -40,6 +40,12 @@ func (s *APIV1Service) CreateMemoShare(ctx context.Context, request *v1pb.Create
 	if memo == nil {
 		return nil, status.Errorf(codes.NotFound, "memo not found")
 	}
+	if memo.ParentUID != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "comments cannot be shared independently")
+	}
+	if memo.RowStatus != store.Normal {
+		return nil, status.Errorf(codes.FailedPrecondition, "only active memos can be shared")
+	}
 	if memo.CreatorID != user.ID && !isSuperUser(user) {
 		return nil, status.Errorf(codes.PermissionDenied, "permission denied")
 	}
@@ -161,7 +167,7 @@ func (s *APIV1Service) GetSharedMemo(ctx context.Context, request *v1pb.GetShare
 		return nil, status.Errorf(codes.Internal, "failed to get memo")
 	}
 	// Treat archived or missing memos the same as an invalid token — no information leakage.
-	if memo == nil || memo.RowStatus == store.Archived {
+	if memo == nil || memo.RowStatus != store.Normal || memo.ParentUID != nil {
 		return nil, status.Errorf(codes.NotFound, "not found")
 	}
 

--- a/server/router/api/v1/memo_update_helpers.go
+++ b/server/router/api/v1/memo_update_helpers.go
@@ -58,6 +58,9 @@ func (s *APIV1Service) buildUpdatedMemoState(ctx context.Context, memoID int32) 
 	var parentMemo *store.Memo
 	if memo.ParentUID != nil {
 		parentMemo, _ = s.Store.GetMemo(ctx, &store.FindMemo{UID: memo.ParentUID})
+		if parentMemo != nil {
+			memoMessage.Visibility = convertVisibilityFromStore(parentMemo.Visibility)
+		}
 	}
 
 	return memo, parentMemo, memoMessage, nil
@@ -68,11 +71,15 @@ func (s *APIV1Service) dispatchMemoUpdatedSideEffects(ctx context.Context, memo 
 		slog.Warn("Failed to dispatch memo updated webhook", slog.Any("err", err))
 	}
 
+	visibility := memo.Visibility
+	if parentMemo != nil {
+		visibility = parentMemo.Visibility
+	}
 	s.SSEHub.Broadcast(&SSEEvent{
 		Type:       SSEEventMemoUpdated,
 		Name:       memoMessage.Name,
 		Parent:     memoMessage.GetParent(),
-		Visibility: memo.Visibility,
+		Visibility: visibility,
 		CreatorID:  resolveSSECreatorID(memo, parentMemo),
 	})
 }

--- a/server/router/api/v1/memo_update_helpers.go
+++ b/server/router/api/v1/memo_update_helpers.go
@@ -3,26 +3,12 @@ package v1
 import (
 	"context"
 	"log/slog"
-	"time"
 
 	"github.com/pkg/errors"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	v1pb "github.com/usememos/memos/proto/gen/api/v1"
 	"github.com/usememos/memos/store"
 )
-
-func (s *APIV1Service) touchMemoUpdatedTimestamp(ctx context.Context, memoID int32) error {
-	updatedTs := time.Now().Unix()
-	if err := s.Store.UpdateMemo(ctx, &store.UpdateMemo{
-		ID:        memoID,
-		UpdatedTs: &updatedTs,
-	}); err != nil {
-		return status.Errorf(codes.Internal, "failed to update memo timestamp")
-	}
-	return nil
-}
 
 func (s *APIV1Service) buildUpdatedMemoState(ctx context.Context, memoID int32) (*store.Memo, *store.Memo, *v1pb.Memo, error) {
 	memo, err := s.Store.GetMemo(ctx, &store.FindMemo{ID: &memoID})
@@ -57,10 +43,14 @@ func (s *APIV1Service) buildUpdatedMemoState(ctx context.Context, memoID int32) 
 
 	var parentMemo *store.Memo
 	if memo.ParentUID != nil {
-		parentMemo, _ = s.Store.GetMemo(ctx, &store.FindMemo{UID: memo.ParentUID})
-		if parentMemo != nil {
-			memoMessage.Visibility = convertVisibilityFromStore(parentMemo.Visibility)
+		parentMemo, err = s.Store.GetMemo(ctx, &store.FindMemo{UID: memo.ParentUID})
+		if err != nil {
+			return nil, nil, nil, errors.Wrap(err, "failed to get parent memo")
 		}
+		if parentMemo == nil {
+			return nil, nil, nil, errors.New("parent memo not found")
+		}
+		memoMessage.Visibility = convertVisibilityFromStore(parentMemo.Visibility)
 	}
 
 	return memo, parentMemo, memoMessage, nil

--- a/server/router/api/v1/test/attachment_service_test.go
+++ b/server/router/api/v1/test/attachment_service_test.go
@@ -2,9 +2,13 @@ package test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/usememos/memos/internal/testutil"
 	v1pb "github.com/usememos/memos/proto/gen/api/v1"
@@ -138,6 +142,46 @@ func TestCreateAttachment(t *testing.T) {
 	})
 }
 
+func TestAttachmentMetadataFollowsMemoVisibility(t *testing.T) {
+	ctx := context.Background()
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+	owner, err := ts.CreateRegularUser(ctx, "metadata-owner")
+	require.NoError(t, err)
+	ownerCtx := ts.CreateUserContext(ctx, owner.ID)
+	attachment, err := ts.Service.CreateAttachment(ownerCtx, &v1pb.CreateAttachmentRequest{Attachment: &v1pb.Attachment{
+		Filename: "metadata.png",
+		Type:     "image/png",
+		Content:  []byte("metadata image"),
+	}})
+	require.NoError(t, err)
+	memo, err := ts.Service.CreateMemo(ownerCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{
+		Content:     "public metadata",
+		Visibility:  v1pb.Visibility_PUBLIC,
+		Attachments: []*v1pb.Attachment{{Name: attachment.Name}},
+	}})
+	require.NoError(t, err)
+
+	_, err = ts.Service.GetAttachment(ctx, &v1pb.GetAttachmentRequest{Name: attachment.Name})
+	require.NoError(t, err)
+	listed, err := ts.Service.ListMemoAttachments(ctx, &v1pb.ListMemoAttachmentsRequest{Name: memo.Name})
+	require.NoError(t, err)
+	require.Len(t, listed.Attachments, 1)
+
+	protected := store.Protected
+	memoID := memoIDFromName(ctx, t, ts, memo.Name)
+	require.NoError(t, ts.Store.UpdateMemo(ctx, &store.UpdateMemo{ID: memoID, Visibility: &protected}))
+	_, err = ts.Service.GetAttachment(ctx, &v1pb.GetAttachmentRequest{Name: attachment.Name})
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+	_, err = ts.Service.ListMemoAttachments(ctx, &v1pb.ListMemoAttachmentsRequest{Name: memo.Name})
+	require.Equal(t, codes.Unauthenticated, status.Code(err))
+
+	archived := store.Archived
+	require.NoError(t, ts.Store.UpdateMemo(ctx, &store.UpdateMemo{ID: memoID, RowStatus: &archived}))
+	_, err = ts.Service.GetAttachment(ctx, &v1pb.GetAttachmentRequest{Name: attachment.Name})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
 func TestCreateAttachmentMemoPermission(t *testing.T) {
 	ctx := context.Background()
 
@@ -173,7 +217,7 @@ func TestCreateAttachmentMemoPermission(t *testing.T) {
 		require.Equal(t, memoIDFromName(ctx, t, ts, memo.Name), *stored.MemoID)
 	})
 
-	t.Run("admin can create attachment directly linked to memo", func(t *testing.T) {
+	t.Run("admin cannot create an admin-owned attachment linked to another user's memo", func(t *testing.T) {
 		ts := NewTestService(t)
 		defer ts.Cleanup()
 
@@ -191,7 +235,7 @@ func TestCreateAttachmentMemoPermission(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		attachment, err := ts.Service.CreateAttachment(adminCtx, &v1pb.CreateAttachmentRequest{
+		_, err = ts.Service.CreateAttachment(adminCtx, &v1pb.CreateAttachmentRequest{
 			Attachment: &v1pb.Attachment{
 				Filename: "admin.txt",
 				Type:     "text/plain",
@@ -199,13 +243,10 @@ func TestCreateAttachmentMemoPermission(t *testing.T) {
 				Memo:     &memo.Name,
 			},
 		})
+		require.Equal(t, codes.PermissionDenied, status.Code(err))
+		attachments, err := ts.Store.ListAttachments(ctx, &store.FindAttachment{CreatorID: &admin.ID})
 		require.NoError(t, err)
-		attachmentUID, err := apiv1.ExtractAttachmentUIDFromName(attachment.Name)
-		require.NoError(t, err)
-		stored, err := ts.Store.GetAttachment(ctx, &store.FindAttachment{UID: &attachmentUID})
-		require.NoError(t, err)
-		require.NotNil(t, stored.MemoID)
-		require.Equal(t, memoIDFromName(ctx, t, ts, memo.Name), *stored.MemoID)
+		require.Empty(t, attachments)
 	})
 
 	t.Run("non-owner cannot create attachment directly linked to memo", func(t *testing.T) {
@@ -368,4 +409,106 @@ func TestBatchDeleteAttachments(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "permission denied")
 	})
+}
+
+func TestBatchDeleteAttachmentsStorageFailureIsRetriable(t *testing.T) {
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+	ctx := context.Background()
+	user, err := ts.CreateRegularUser(ctx, "delete_retry_user")
+	require.NoError(t, err)
+	userCtx := ts.CreateUserContext(ctx, user.ID)
+
+	attachments := make([]*v1pb.Attachment, 0, 2)
+	for _, filename := range []string{"retry-one.png", "retry-two.png"} {
+		attachment, err := ts.Service.CreateAttachment(userCtx, &v1pb.CreateAttachmentRequest{Attachment: &v1pb.Attachment{
+			Filename: filename,
+			Type:     "image/png",
+			Content:  []byte(filename),
+		}})
+		require.NoError(t, err)
+		attachments = append(attachments, attachment)
+	}
+	memo, err := ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{
+		Content:     "batch deletion retry",
+		Attachments: []*v1pb.Attachment{{Name: attachments[0].Name}, {Name: attachments[1].Name}},
+	}})
+	require.NoError(t, err)
+
+	localPaths := make([]string, 0, len(attachments))
+	for index, attachment := range attachments {
+		uid, err := apiv1.ExtractAttachmentUIDFromName(attachment.Name)
+		require.NoError(t, err)
+		stored, err := ts.Store.GetAttachment(ctx, &store.FindAttachment{UID: &uid})
+		require.NoError(t, err)
+		reference := filepath.Join("batch-delete-retry", attachment.Filename)
+		path := filepath.Join(ts.Profile.Data, reference)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+		require.NoError(t, os.WriteFile(path, []byte(attachment.Filename), 0o600))
+		_, err = ts.Store.GetDriver().GetDB().ExecContext(ctx,
+			"UPDATE attachment SET storage_type = ?, reference = ? WHERE id = ?",
+			"LOCAL", reference, stored.ID,
+		)
+		require.NoError(t, err, "attachment %d", index)
+		localPaths = append(localPaths, path)
+	}
+
+	names := []string{attachments[0].Name, attachments[1].Name}
+	_, err = ts.Service.BatchDeleteAttachments(store.WithDeleteAttachmentStorageFailpoint(userCtx), &v1pb.BatchDeleteAttachmentsRequest{Names: names})
+	require.Equal(t, codes.Internal, status.Code(err))
+	for _, attachment := range attachments {
+		uid, err := apiv1.ExtractAttachmentUIDFromName(attachment.Name)
+		require.NoError(t, err)
+		stored, err := ts.Store.GetAttachment(ctx, &store.FindAttachment{UID: &uid})
+		require.NoError(t, err)
+		require.NotNil(t, stored)
+		require.Nil(t, stored.MemoID)
+	}
+	listed, err := ts.Service.ListMemoAttachments(userCtx, &v1pb.ListMemoAttachmentsRequest{Name: memo.Name})
+	require.NoError(t, err)
+	require.Empty(t, listed.Attachments)
+
+	_, err = ts.Service.BatchDeleteAttachments(userCtx, &v1pb.BatchDeleteAttachmentsRequest{Names: names})
+	require.NoError(t, err)
+	for _, path := range localPaths {
+		_, err := os.Stat(path)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	}
+}
+
+func TestDeleteMotionMediaGroupRequiresWholeGroup(t *testing.T) {
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+	ctx := context.Background()
+	user, err := ts.CreateRegularUser(ctx, "delete-motion-group")
+	require.NoError(t, err)
+	userCtx := ts.CreateUserContext(ctx, user.ID)
+
+	still, err := ts.Service.CreateAttachment(userCtx, &v1pb.CreateAttachmentRequest{Attachment: &v1pb.Attachment{
+		Filename: "live.jpg",
+		Type:     "image/jpeg",
+		Content:  []byte("still"),
+		MotionMedia: &v1pb.MotionMedia{
+			Family:  v1pb.MotionMediaFamily_APPLE_LIVE_PHOTO,
+			Role:    v1pb.MotionMediaRole_STILL,
+			GroupId: "delete-live-group",
+		},
+	}})
+	require.NoError(t, err)
+	video, err := ts.Service.CreateAttachment(userCtx, &v1pb.CreateAttachmentRequest{Attachment: &v1pb.Attachment{
+		Filename: "live.mov",
+		Type:     "video/quicktime",
+		Content:  []byte("video"),
+		MotionMedia: &v1pb.MotionMedia{
+			Family:  v1pb.MotionMediaFamily_APPLE_LIVE_PHOTO,
+			Role:    v1pb.MotionMediaRole_VIDEO,
+			GroupId: "delete-live-group",
+		},
+	}})
+	require.NoError(t, err)
+
+	_, err = ts.Service.DeleteAttachment(userCtx, &v1pb.DeleteAttachmentRequest{Name: still.Name})
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	_, err = ts.Service.BatchDeleteAttachments(userCtx, &v1pb.BatchDeleteAttachmentsRequest{Names: []string{still.Name, video.Name}})
+	require.NoError(t, err)
 }

--- a/server/router/api/v1/test/attachment_service_test.go
+++ b/server/router/api/v1/test/attachment_service_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/lithammer/shortuuid/v4"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -511,4 +512,51 @@ func TestDeleteMotionMediaGroupRequiresWholeGroup(t *testing.T) {
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
 	_, err = ts.Service.BatchDeleteAttachments(userCtx, &v1pb.BatchDeleteAttachmentsRequest{Names: []string{still.Name, video.Name}})
 	require.NoError(t, err)
+}
+
+func TestDeleteMotionMediaGroupChecksBeyondDefaultAttachmentPage(t *testing.T) {
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+	ctx := context.Background()
+	user, err := ts.CreateRegularUser(ctx, "delete-motion-group-many")
+	require.NoError(t, err)
+	userCtx := ts.CreateUserContext(ctx, user.ID)
+
+	still, err := ts.Store.CreateAttachment(ctx, &store.Attachment{
+		UID:       shortuuid.New(),
+		CreatorID: user.ID,
+		Filename:  "old-live.jpg",
+		Type:      "image/jpeg",
+		Payload: &storepb.AttachmentPayload{MotionMedia: &storepb.MotionMedia{
+			Family:  storepb.MotionMediaFamily_APPLE_LIVE_PHOTO,
+			Role:    storepb.MotionMediaRole_STILL,
+			GroupId: "delete-old-live-group",
+		}},
+	})
+	require.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		attachment, err := ts.Store.CreateAttachment(ctx, &store.Attachment{
+			UID: shortuuid.New(), CreatorID: user.ID, Filename: "filler.txt", Type: "text/plain",
+		})
+		require.NoError(t, err)
+		updatedTs := still.UpdatedTs + int64(i) + 1
+		require.NoError(t, ts.Store.UpdateAttachment(ctx, &store.UpdateAttachment{ID: attachment.ID, UpdatedTs: &updatedTs}))
+	}
+	video, err := ts.Store.CreateAttachment(ctx, &store.Attachment{
+		UID:       shortuuid.New(),
+		CreatorID: user.ID,
+		Filename:  "new-live.mov",
+		Type:      "video/quicktime",
+		Payload: &storepb.AttachmentPayload{MotionMedia: &storepb.MotionMedia{
+			Family:  storepb.MotionMediaFamily_APPLE_LIVE_PHOTO,
+			Role:    storepb.MotionMediaRole_VIDEO,
+			GroupId: "delete-old-live-group",
+		}},
+	})
+	require.NoError(t, err)
+	updatedTs := still.UpdatedTs + 1000
+	require.NoError(t, ts.Store.UpdateAttachment(ctx, &store.UpdateAttachment{ID: video.ID, UpdatedTs: &updatedTs}))
+
+	_, err = ts.Service.DeleteAttachment(userCtx, &v1pb.DeleteAttachmentRequest{Name: "attachments/" + video.UID})
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
 }

--- a/server/router/api/v1/test/memo_attachment_markdown_test.go
+++ b/server/router/api/v1/test/memo_attachment_markdown_test.go
@@ -1,0 +1,351 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	v1pb "github.com/usememos/memos/proto/gen/api/v1"
+	api "github.com/usememos/memos/server/router/api/v1"
+	"github.com/usememos/memos/store"
+)
+
+func TestMemoManagedAttachmentImages(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("create accepts canonical and legacy managed image URLs", func(t *testing.T) {
+		ts := NewTestService(t)
+		defer ts.Cleanup()
+		user, err := ts.CreateRegularUser(ctx, "managed-create")
+		require.NoError(t, err)
+		userCtx := ts.CreateUserContext(ctx, user.ID)
+		first := createTestImageAttachment(userCtx, t, ts, "first.png")
+		second := createTestImageAttachment(userCtx, t, ts, "second.png")
+		firstUID := strings.TrimPrefix(first.Name, "attachments/")
+		secondUID := strings.TrimPrefix(second.Name, "attachments/")
+
+		memo, err := ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{
+			Content: fmt.Sprintf("![first](/file/attachments/%s)\n![second](/file/attachments/%s/second.png)", firstUID, secondUID),
+			Attachments: []*v1pb.Attachment{
+				{Name: first.Name},
+				{Name: second.Name},
+			},
+			Visibility: v1pb.Visibility_PRIVATE,
+		}})
+		require.NoError(t, err)
+		require.Len(t, memo.Attachments, 2)
+	})
+
+	t.Run("create validates references before creating the memo", func(t *testing.T) {
+		ts := NewTestService(t)
+		defer ts.Cleanup()
+		user, err := ts.CreateRegularUser(ctx, "managed-missing")
+		require.NoError(t, err)
+		userCtx := ts.CreateUserContext(ctx, user.ID)
+
+		_, err = ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{
+			MemoId: "managed-missing-memo",
+			Memo: &v1pb.Memo{
+				Content:    "![missing](http://localhost:8080/file/attachments/missing-image)",
+				Visibility: v1pb.Visibility_PRIVATE,
+			},
+		})
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+		uid := "managed-missing-memo"
+		stored, getErr := ts.Store.GetMemo(ctx, &store.FindMemo{UID: &uid})
+		require.NoError(t, getErr)
+		require.Nil(t, stored)
+	})
+
+	t.Run("managed image must have an image MIME type", func(t *testing.T) {
+		ts := NewTestService(t)
+		defer ts.Cleanup()
+		user, err := ts.CreateRegularUser(ctx, "managed-mime")
+		require.NoError(t, err)
+		userCtx := ts.CreateUserContext(ctx, user.ID)
+		textAttachment, err := ts.Service.CreateAttachment(userCtx, &v1pb.CreateAttachmentRequest{Attachment: &v1pb.Attachment{
+			Filename: "not-image.txt",
+			Type:     "text/plain",
+			Content:  []byte("not an image"),
+		}})
+		require.NoError(t, err)
+		uid := strings.TrimPrefix(textAttachment.Name, "attachments/")
+
+		_, err = ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{
+			Content:     fmt.Sprintf("![wrong type](/file/attachments/%s)", uid),
+			Attachments: []*v1pb.Attachment{{Name: textAttachment.Name}},
+		}})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("malformed managed URLs are rejected", func(t *testing.T) {
+		ts := NewTestService(t)
+		defer ts.Cleanup()
+		user, err := ts.CreateRegularUser(ctx, "managed-malformed")
+		require.NoError(t, err)
+		userCtx := ts.CreateUserContext(ctx, user.ID)
+		image := createTestImageAttachment(userCtx, t, ts, "query.png")
+		uid := strings.TrimPrefix(image.Name, "attachments/")
+
+		_, err = ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{
+			Content:     fmt.Sprintf("![query](/file/attachments/%s?share_token=secret)", uid),
+			Attachments: []*v1pb.Attachment{{Name: image.Name}},
+		}})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("protocol-relative managed URLs are rejected", func(t *testing.T) {
+		ts := NewTestService(t)
+		defer ts.Cleanup()
+		user, err := ts.CreateRegularUser(ctx, "managed-network-path")
+		require.NoError(t, err)
+		userCtx := ts.CreateUserContext(ctx, user.ID)
+		image := createTestImageAttachment(userCtx, t, ts, "network-path.png")
+		uid := strings.TrimPrefix(image.Name, "attachments/")
+
+		_, err = ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{
+			Content:     fmt.Sprintf("![network path](//localhost:8080/file/attachments/%s)", uid),
+			Attachments: []*v1pb.Attachment{{Name: image.Name}},
+		}})
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("cross-origin protocol-relative image URLs remain external", func(t *testing.T) {
+		ts := NewTestService(t)
+		defer ts.Cleanup()
+		user, err := ts.CreateRegularUser(ctx, "external-network-path")
+		require.NoError(t, err)
+		userCtx := ts.CreateUserContext(ctx, user.ID)
+
+		memo, err := ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{
+			Content: "![external](//cdn.example.com/file/attachments/external-image)",
+		}})
+		require.NoError(t, err)
+		require.Empty(t, memo.Attachments)
+	})
+
+	t.Run("same-origin absolute managed URL is verified and accepted", func(t *testing.T) {
+		ts := NewTestService(t)
+		defer ts.Cleanup()
+		user, err := ts.CreateRegularUser(ctx, "managed-absolute")
+		require.NoError(t, err)
+		userCtx := ts.CreateUserContext(ctx, user.ID)
+		image := createTestImageAttachment(userCtx, t, ts, "absolute.png")
+		uid := strings.TrimPrefix(image.Name, "attachments/")
+
+		memo, err := ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{
+			Content:     fmt.Sprintf("![absolute](http://localhost:8080/file/attachments/%s)", uid),
+			Attachments: []*v1pb.Attachment{{Name: image.Name}},
+		}})
+		require.NoError(t, err)
+		require.Len(t, memo.Attachments, 1)
+	})
+
+	t.Run("set attachments cannot remove an image referenced by content", func(t *testing.T) {
+		ts := NewTestService(t)
+		defer ts.Cleanup()
+		user, err := ts.CreateRegularUser(ctx, "managed-set")
+		require.NoError(t, err)
+		userCtx := ts.CreateUserContext(ctx, user.ID)
+		image := createTestImageAttachment(userCtx, t, ts, "kept.png")
+		uid := strings.TrimPrefix(image.Name, "attachments/")
+		memo, err := ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{
+			Content:     fmt.Sprintf("![kept](/file/attachments/%s)", uid),
+			Attachments: []*v1pb.Attachment{{Name: image.Name}},
+		}})
+		require.NoError(t, err)
+
+		_, err = ts.Service.SetMemoAttachments(userCtx, &v1pb.SetMemoAttachmentsRequest{Name: memo.Name})
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+		attachments, listErr := ts.Service.ListMemoAttachments(userCtx, &v1pb.ListMemoAttachmentsRequest{Name: memo.Name})
+		require.NoError(t, listErr)
+		require.Len(t, attachments.Attachments, 1)
+	})
+
+	t.Run("content and attachments are validated as one final update state", func(t *testing.T) {
+		ts := NewTestService(t)
+		defer ts.Cleanup()
+		user, err := ts.CreateRegularUser(ctx, "managed-update")
+		require.NoError(t, err)
+		userCtx := ts.CreateUserContext(ctx, user.ID)
+		image := createTestImageAttachment(userCtx, t, ts, "removed.png")
+		uid := strings.TrimPrefix(image.Name, "attachments/")
+		memo, err := ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{
+			Content:     fmt.Sprintf("![removed](/file/attachments/%s)", uid),
+			Attachments: []*v1pb.Attachment{{Name: image.Name}},
+		}})
+		require.NoError(t, err)
+
+		updated, err := ts.Service.UpdateMemo(userCtx, &v1pb.UpdateMemoRequest{
+			Memo:       &v1pb.Memo{Name: memo.Name, Content: "image removed", Attachments: []*v1pb.Attachment{}},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"attachments", "content"}},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "image removed", updated.Content)
+		require.Empty(t, updated.Attachments)
+		stored, getErr := ts.Store.GetAttachment(ctx, &store.FindAttachment{UID: &uid})
+		require.NoError(t, getErr)
+		require.Nil(t, stored)
+	})
+
+	t.Run("local deletion failure leaves a detached row that can be retried", func(t *testing.T) {
+		ts := NewTestService(t)
+		defer ts.Cleanup()
+		user, err := ts.CreateRegularUser(ctx, "managed-delete-retry")
+		require.NoError(t, err)
+		userCtx := ts.CreateUserContext(ctx, user.ID)
+		image := createTestImageAttachment(userCtx, t, ts, "retry.png")
+		uid := strings.TrimPrefix(image.Name, "attachments/")
+		memo, err := ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{
+			Content:     "attachment will be removed",
+			Attachments: []*v1pb.Attachment{{Name: image.Name}},
+		}})
+		require.NoError(t, err)
+		storedImage, err := ts.Store.GetAttachment(ctx, &store.FindAttachment{UID: &uid})
+		require.NoError(t, err)
+		localReference := "retry-delete.png"
+		localPath := filepath.Join(ts.Profile.Data, localReference)
+		require.NoError(t, os.WriteFile(localPath, []byte("local image"), 0o600))
+		_, err = ts.Store.GetDriver().GetDB().ExecContext(ctx,
+			"UPDATE attachment SET storage_type = ?, reference = ? WHERE id = ?",
+			"LOCAL", localReference, storedImage.ID,
+		)
+		require.NoError(t, err)
+
+		_, err = ts.Service.UpdateMemo(store.WithDeleteAttachmentStorageFailpoint(userCtx), &v1pb.UpdateMemoRequest{
+			Memo:       &v1pb.Memo{Name: memo.Name, Content: "attachment removed", Attachments: []*v1pb.Attachment{}},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"content", "attachments"}},
+		})
+		require.Equal(t, codes.Internal, status.Code(err))
+		storedMemo, getErr := ts.Service.GetMemo(userCtx, &v1pb.GetMemoRequest{Name: memo.Name})
+		require.NoError(t, getErr)
+		require.Equal(t, "attachment removed", storedMemo.Content)
+		storedImage, getErr = ts.Store.GetAttachment(ctx, &store.FindAttachment{UID: &uid})
+		require.NoError(t, getErr)
+		require.NotNil(t, storedImage)
+		require.Nil(t, storedImage.MemoID)
+
+		_, err = ts.Service.DeleteAttachment(userCtx, &v1pb.DeleteAttachmentRequest{Name: image.Name})
+		require.NoError(t, err)
+		_, statErr := os.Stat(localPath)
+		require.ErrorIs(t, statErr, os.ErrNotExist)
+	})
+
+	t.Run("failed content validation does not mutate the memo", func(t *testing.T) {
+		ts := NewTestService(t)
+		defer ts.Cleanup()
+		user, err := ts.CreateRegularUser(ctx, "managed-update-failure")
+		require.NoError(t, err)
+		userCtx := ts.CreateUserContext(ctx, user.ID)
+		memo, err := ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{Content: "original"}})
+		require.NoError(t, err)
+
+		_, err = ts.Service.UpdateMemo(userCtx, &v1pb.UpdateMemoRequest{
+			Memo:       &v1pb.Memo{Name: memo.Name, Content: "![missing](/file/attachments/missing-update-image)"},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"content"}},
+		})
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+		stored, getErr := ts.Service.GetMemo(userCtx, &v1pb.GetMemoRequest{Name: memo.Name})
+		require.NoError(t, getErr)
+		require.Equal(t, "original", stored.Content)
+	})
+
+	t.Run("delete APIs reject referenced attachments", func(t *testing.T) {
+		ts := NewTestService(t)
+		defer ts.Cleanup()
+		user, err := ts.CreateRegularUser(ctx, "managed-delete")
+		require.NoError(t, err)
+		userCtx := ts.CreateUserContext(ctx, user.ID)
+		image := createTestImageAttachment(userCtx, t, ts, "referenced.png")
+		uid := strings.TrimPrefix(image.Name, "attachments/")
+		_, err = ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{
+			Content:     fmt.Sprintf("![referenced](/file/attachments/%s)", uid),
+			Attachments: []*v1pb.Attachment{{Name: image.Name}},
+		}})
+		require.NoError(t, err)
+
+		_, err = ts.Service.DeleteAttachment(userCtx, &v1pb.DeleteAttachmentRequest{Name: image.Name})
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+		_, err = ts.Service.BatchDeleteAttachments(userCtx, &v1pb.BatchDeleteAttachmentsRequest{Names: []string{image.Name}})
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+		stored, getErr := ts.Store.GetAttachment(ctx, &store.FindAttachment{UID: &uid})
+		require.NoError(t, getErr)
+		require.NotNil(t, stored)
+	})
+}
+
+func TestMemoAttachmentBindingDoesNotReparent(t *testing.T) {
+	ctx := context.Background()
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+	user, err := ts.CreateRegularUser(ctx, "no-reparent")
+	require.NoError(t, err)
+	userCtx := ts.CreateUserContext(ctx, user.ID)
+	image := createTestImageAttachment(userCtx, t, ts, "bound.png")
+	first, err := ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{Attachments: []*v1pb.Attachment{{Name: image.Name}}}})
+	require.NoError(t, err)
+	second, err := ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{Content: "second"}})
+	require.NoError(t, err)
+
+	_, err = ts.Service.SetMemoAttachments(userCtx, &v1pb.SetMemoAttachmentsRequest{
+		Name:        second.Name,
+		Attachments: []*v1pb.Attachment{{Name: image.Name}},
+	})
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+	uid, err := api.ExtractAttachmentUIDFromName(image.Name)
+	require.NoError(t, err)
+	stored, err := ts.Store.GetAttachment(ctx, &store.FindAttachment{UID: &uid})
+	require.NoError(t, err)
+	require.NotNil(t, stored.MemoID)
+	require.Equal(t, memoIDFromName(ctx, t, ts, first.Name), *stored.MemoID)
+}
+
+func TestCreateMemoDoesNotBindAnotherUsersAttachmentOrCreatePartialMemo(t *testing.T) {
+	ctx := context.Background()
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+	owner, err := ts.CreateRegularUser(ctx, "foreign-attachment-owner")
+	require.NoError(t, err)
+	other, err := ts.CreateRegularUser(ctx, "foreign-attachment-caller")
+	require.NoError(t, err)
+	ownerCtx := ts.CreateUserContext(ctx, owner.ID)
+	otherCtx := ts.CreateUserContext(ctx, other.ID)
+	image := createTestImageAttachment(ownerCtx, t, ts, "foreign.png")
+
+	_, err = ts.Service.CreateMemo(otherCtx, &v1pb.CreateMemoRequest{
+		MemoId: "no-partial-foreign-memo",
+		Memo: &v1pb.Memo{
+			Content:     "foreign attachment",
+			Attachments: []*v1pb.Attachment{{Name: image.Name}},
+		},
+	})
+	require.Equal(t, codes.NotFound, status.Code(err))
+	uid := "no-partial-foreign-memo"
+	memo, getErr := ts.Store.GetMemo(ctx, &store.FindMemo{UID: &uid})
+	require.NoError(t, getErr)
+	require.Nil(t, memo)
+	attachmentUID := strings.TrimPrefix(image.Name, "attachments/")
+	attachment, getErr := ts.Store.GetAttachment(ctx, &store.FindAttachment{UID: &attachmentUID})
+	require.NoError(t, getErr)
+	require.NotNil(t, attachment)
+	require.Nil(t, attachment.MemoID)
+}
+
+func createTestImageAttachment(ctx context.Context, t *testing.T, ts *TestService, filename string) *v1pb.Attachment {
+	t.Helper()
+	attachment, err := ts.Service.CreateAttachment(ctx, &v1pb.CreateAttachmentRequest{Attachment: &v1pb.Attachment{
+		Filename: filename,
+		Type:     "image/png",
+		Content:  []byte("test image"),
+	}})
+	require.NoError(t, err)
+	return attachment
+}

--- a/server/router/api/v1/test/memo_attachment_markdown_test.go
+++ b/server/router/api/v1/test/memo_attachment_markdown_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/lithammer/shortuuid/v4"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -135,18 +136,57 @@ func TestMemoManagedAttachmentImages(t *testing.T) {
 	t.Run("same-origin absolute managed URL is verified and accepted", func(t *testing.T) {
 		ts := NewTestService(t)
 		defer ts.Cleanup()
+		ts.Profile.InstanceURL = "http://localhost"
 		user, err := ts.CreateRegularUser(ctx, "managed-absolute")
 		require.NoError(t, err)
 		userCtx := ts.CreateUserContext(ctx, user.ID)
 		image := createTestImageAttachment(userCtx, t, ts, "absolute.png")
 		uid := strings.TrimPrefix(image.Name, "attachments/")
 
+		content := fmt.Sprintf("![absolute](http://localhost:80/file/attachments/%s)", uid)
+		_, err = ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{Content: content}})
+		require.Equal(t, codes.FailedPrecondition, status.Code(err))
+
 		memo, err := ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{
-			Content:     fmt.Sprintf("![absolute](http://localhost:8080/file/attachments/%s)", uid),
+			Content:     content,
 			Attachments: []*v1pb.Attachment{{Name: image.Name}},
 		}})
 		require.NoError(t, err)
 		require.Len(t, memo.Attachments, 1)
+	})
+
+	t.Run("content validation sees attachments beyond the default page", func(t *testing.T) {
+		ts := NewTestService(t)
+		defer ts.Cleanup()
+		user, err := ts.CreateRegularUser(ctx, "managed-many-attachments")
+		require.NoError(t, err)
+		userCtx := ts.CreateUserContext(ctx, user.ID)
+		memo, err := ts.Service.CreateMemo(userCtx, &v1pb.CreateMemoRequest{Memo: &v1pb.Memo{Content: "many attachments"}})
+		require.NoError(t, err)
+		memoID := memoIDFromName(ctx, t, ts, memo.Name)
+
+		referenced, err := ts.Store.CreateAttachment(ctx, &store.Attachment{
+			UID: shortuuid.New(), CreatorID: user.ID, Filename: "referenced.png", Type: "image/png", MemoID: &memoID,
+		})
+		require.NoError(t, err)
+		for i := 0; i < 100; i++ {
+			attachment, err := ts.Store.CreateAttachment(ctx, &store.Attachment{
+				UID: shortuuid.New(), CreatorID: user.ID, Filename: fmt.Sprintf("extra-%03d.png", i), Type: "image/png", MemoID: &memoID,
+			})
+			require.NoError(t, err)
+			updatedTs := referenced.UpdatedTs + int64(i) + 1
+			require.NoError(t, ts.Store.UpdateAttachment(ctx, &store.UpdateAttachment{ID: attachment.ID, UpdatedTs: &updatedTs}))
+		}
+
+		updated, err := ts.Service.UpdateMemo(userCtx, &v1pb.UpdateMemoRequest{
+			Memo: &v1pb.Memo{
+				Name:    memo.Name,
+				Content: fmt.Sprintf("![oldest](/file/attachments/%s)", referenced.UID),
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"content"}},
+		})
+		require.NoError(t, err)
+		require.Len(t, updated.Attachments, 101)
 	})
 
 	t.Run("set attachments cannot remove an image referenced by content", func(t *testing.T) {
@@ -211,6 +251,7 @@ func TestMemoManagedAttachmentImages(t *testing.T) {
 		require.NoError(t, err)
 		storedImage, err := ts.Store.GetAttachment(ctx, &store.FindAttachment{UID: &uid})
 		require.NoError(t, err)
+		require.NotNil(t, storedImage)
 		localReference := "retry-delete.png"
 		localPath := filepath.Join(ts.Profile.Data, localReference)
 		require.NoError(t, os.WriteFile(localPath, []byte("local image"), 0o600))
@@ -304,6 +345,7 @@ func TestMemoAttachmentBindingDoesNotReparent(t *testing.T) {
 	require.NoError(t, err)
 	stored, err := ts.Store.GetAttachment(ctx, &store.FindAttachment{UID: &uid})
 	require.NoError(t, err)
+	require.NotNil(t, stored)
 	require.NotNil(t, stored.MemoID)
 	require.Equal(t, memoIDFromName(ctx, t, ts, first.Name), *stored.MemoID)
 }

--- a/server/router/api/v1/test/memo_attachment_service_test.go
+++ b/server/router/api/v1/test/memo_attachment_service_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	apiv1 "github.com/usememos/memos/proto/gen/api/v1"
 	"github.com/usememos/memos/store"
@@ -273,7 +275,7 @@ func TestSetMemoAttachments(t *testing.T) {
 			},
 		})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "cannot attach another user's attachment")
+		require.Equal(t, codes.NotFound, status.Code(err))
 
 		victimAttachments, err := ts.Service.ListMemoAttachments(victimCtx, &apiv1.ListMemoAttachmentsRequest{Name: victimMemo.Name})
 		require.NoError(t, err)

--- a/server/router/api/v1/test/memo_relation_service_test.go
+++ b/server/router/api/v1/test/memo_relation_service_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	apiv1 "github.com/usememos/memos/proto/gen/api/v1"
 )
@@ -166,4 +169,45 @@ func TestSetMemoRelations(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not found")
 	})
+}
+
+func TestUpdateMemoValidatesAllRelationsBeforeMutation(t *testing.T) {
+	ctx := context.Background()
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+	user, err := ts.CreateRegularUser(ctx, "atomic-relation-update")
+	require.NoError(t, err)
+	userCtx := ts.CreateUserContext(ctx, user.ID)
+
+	target, err := ts.Service.CreateMemo(userCtx, &apiv1.CreateMemoRequest{Memo: &apiv1.Memo{Content: "target"}})
+	require.NoError(t, err)
+	replacement, err := ts.Service.CreateMemo(userCtx, &apiv1.CreateMemoRequest{Memo: &apiv1.Memo{Content: "replacement"}})
+	require.NoError(t, err)
+	source, err := ts.Service.CreateMemo(userCtx, &apiv1.CreateMemoRequest{Memo: &apiv1.Memo{
+		Content: "original",
+		Relations: []*apiv1.MemoRelation{{
+			RelatedMemo: &apiv1.MemoRelation_Memo{Name: target.Name},
+			Type:        apiv1.MemoRelation_REFERENCE,
+		}},
+	}})
+	require.NoError(t, err)
+
+	_, err = ts.Service.UpdateMemo(userCtx, &apiv1.UpdateMemoRequest{
+		Memo: &apiv1.Memo{
+			Name:    source.Name,
+			Content: "must roll back",
+			Relations: []*apiv1.MemoRelation{
+				{RelatedMemo: &apiv1.MemoRelation_Memo{Name: replacement.Name}, Type: apiv1.MemoRelation_REFERENCE},
+				{RelatedMemo: &apiv1.MemoRelation_Memo{Name: "invalid-name"}, Type: apiv1.MemoRelation_REFERENCE},
+			},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"content", "relations"}},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+
+	stored, err := ts.Service.GetMemo(userCtx, &apiv1.GetMemoRequest{Name: source.Name})
+	require.NoError(t, err)
+	require.Equal(t, "original", stored.Content)
+	require.Len(t, stored.Relations, 1)
+	require.Equal(t, target.Name, stored.Relations[0].RelatedMemo.Name)
 }

--- a/server/router/api/v1/test/memo_service_test.go
+++ b/server/router/api/v1/test/memo_service_test.go
@@ -667,6 +667,41 @@ func TestCreateMemoCommentInheritsParentVisibility(t *testing.T) {
 	require.Equal(t, codes.Unauthenticated, status.Code(err))
 }
 
+func TestCreateMemoCommentDoesNotRevealArchivedPrivateMemo(t *testing.T) {
+	ctx := context.Background()
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+
+	owner, err := ts.CreateRegularUser(ctx, "archived-comment-owner")
+	require.NoError(t, err)
+	ownerCtx := ts.CreateUserContext(ctx, owner.ID)
+	other, err := ts.CreateRegularUser(ctx, "archived-comment-other")
+	require.NoError(t, err)
+	otherCtx := ts.CreateUserContext(ctx, other.ID)
+	parent, err := ts.Service.CreateMemo(ownerCtx, &apiv1.CreateMemoRequest{Memo: &apiv1.Memo{
+		Content:    "archived private parent",
+		Visibility: apiv1.Visibility_PRIVATE,
+	}})
+	require.NoError(t, err)
+	_, err = ts.Service.UpdateMemo(ownerCtx, &apiv1.UpdateMemoRequest{
+		Memo:       &apiv1.Memo{Name: parent.Name, State: apiv1.State_ARCHIVED},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"state"}},
+	})
+	require.NoError(t, err)
+
+	_, err = ts.Service.CreateMemoComment(otherCtx, &apiv1.CreateMemoCommentRequest{
+		Name:    parent.Name,
+		Comment: &apiv1.Memo{Content: "should not reveal parent state"},
+	})
+	require.Equal(t, codes.NotFound, status.Code(err))
+
+	_, err = ts.Service.CreateMemoComment(ownerCtx, &apiv1.CreateMemoCommentRequest{
+		Name:    parent.Name,
+		Comment: &apiv1.Memo{Content: "owner still cannot comment"},
+	})
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
+}
+
 func TestGetMemoCommentRequiresParentReadAccess(t *testing.T) {
 	ctx := context.Background()
 

--- a/server/router/api/v1/test/memo_service_test.go
+++ b/server/router/api/v1/test/memo_service_test.go
@@ -584,6 +584,47 @@ func TestListMemoCommentsPaginates(t *testing.T) {
 	require.Empty(t, secondPage.NextPageToken)
 }
 
+func TestListMemoCommentsFiltersArchivedBeforePagination(t *testing.T) {
+	ctx := context.Background()
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+
+	owner, err := ts.CreateRegularUser(ctx, "comment-archive-page-owner")
+	require.NoError(t, err)
+	ownerCtx := ts.CreateUserContext(ctx, owner.ID)
+	memo, err := ts.Service.CreateMemo(ownerCtx, &apiv1.CreateMemoRequest{Memo: &apiv1.Memo{
+		Content:    "memo with archived comments",
+		Visibility: apiv1.Visibility_PUBLIC,
+	}})
+	require.NoError(t, err)
+
+	comments := make([]*apiv1.Memo, 0, 5)
+	for i := 0; i < 5; i++ {
+		comment, err := ts.Service.CreateMemoComment(ownerCtx, &apiv1.CreateMemoCommentRequest{
+			Name:    memo.Name,
+			Comment: &apiv1.Memo{Content: fmt.Sprintf("comment %d", i)},
+		})
+		require.NoError(t, err)
+		comments = append(comments, comment)
+	}
+	for _, comment := range comments[3:] {
+		_, err := ts.Service.UpdateMemo(ownerCtx, &apiv1.UpdateMemoRequest{
+			Memo:       &apiv1.Memo{Name: comment.Name, State: apiv1.State_ARCHIVED},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"state"}},
+		})
+		require.NoError(t, err)
+	}
+
+	firstPage, err := ts.Service.ListMemoComments(ownerCtx, &apiv1.ListMemoCommentsRequest{Name: memo.Name, PageSize: 2})
+	require.NoError(t, err)
+	require.Len(t, firstPage.Memos, 2)
+	require.NotEmpty(t, firstPage.NextPageToken)
+	secondPage, err := ts.Service.ListMemoComments(ownerCtx, &apiv1.ListMemoCommentsRequest{Name: memo.Name, PageToken: firstPage.NextPageToken})
+	require.NoError(t, err)
+	require.Len(t, secondPage.Memos, 1)
+	require.Empty(t, secondPage.NextPageToken)
+}
+
 func TestCreateMemoCommentInheritsParentVisibility(t *testing.T) {
 	ctx := context.Background()
 
@@ -689,6 +730,41 @@ func TestGetMemoCommentRequiresParentReadAccess(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, comments.Memos, 1)
 	require.Equal(t, commentName, comments.Memos[0].Name)
+}
+
+func TestMemoCommentUsesCurrentParentVisibility(t *testing.T) {
+	ctx := context.Background()
+	ts := NewTestService(t)
+	defer ts.Cleanup()
+
+	owner, err := ts.CreateRegularUser(ctx, "dynamic-comment-owner")
+	require.NoError(t, err)
+	ownerCtx := ts.CreateUserContext(ctx, owner.ID)
+	parent, err := ts.Service.CreateMemo(ownerCtx, &apiv1.CreateMemoRequest{Memo: &apiv1.Memo{
+		Content:    "initially private",
+		Visibility: apiv1.Visibility_PRIVATE,
+	}})
+	require.NoError(t, err)
+	comment, err := ts.Service.CreateMemoComment(ownerCtx, &apiv1.CreateMemoCommentRequest{
+		Name:    parent.Name,
+		Comment: &apiv1.Memo{Content: "inherits private"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, apiv1.Visibility_PRIVATE, comment.Visibility)
+
+	_, err = ts.Service.UpdateMemo(ownerCtx, &apiv1.UpdateMemoRequest{
+		Memo:       &apiv1.Memo{Name: parent.Name, Visibility: apiv1.Visibility_PUBLIC},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"visibility"}},
+	})
+	require.NoError(t, err)
+
+	visibleComment, err := ts.Service.GetMemo(ctx, &apiv1.GetMemoRequest{Name: comment.Name})
+	require.NoError(t, err)
+	require.Equal(t, comment.Name, visibleComment.Name)
+	comments, err := ts.Service.ListMemoComments(ctx, &apiv1.ListMemoCommentsRequest{Name: parent.Name})
+	require.NoError(t, err)
+	require.Len(t, comments.Memos, 1)
+	require.Equal(t, comment.Name, comments.Memos[0].Name)
 }
 
 // TestCreateMemoWithCustomTimestamps tests that custom timestamps can be set when creating memos and comments.

--- a/server/router/api/v1/test/memo_share_service_test.go
+++ b/server/router/api/v1/test/memo_share_service_test.go
@@ -110,7 +110,7 @@ func TestGetSharedMemo_IncludesReactions(t *testing.T) {
 	require.Equal(t, memo.Name, sharedMemo.Reactions[0].ContentId)
 }
 
-func TestGetSharedMemo_ExcludesParentAndRelations(t *testing.T) {
+func TestCreateMemoShare_RejectsComment(t *testing.T) {
 	ctx := context.Background()
 
 	ts := NewTestService(t)
@@ -143,19 +143,21 @@ func TestGetSharedMemo_ExcludesParentAndRelations(t *testing.T) {
 	require.NotEmpty(t, regularMemo.GetParent())
 	require.NotEmpty(t, regularMemo.Relations)
 
-	share, err := ts.Service.CreateMemoShare(userCtx, &apiv1.CreateMemoShareRequest{
+	_, err = ts.Service.CreateMemoShare(userCtx, &apiv1.CreateMemoShareRequest{
 		Parent:    comment.Name,
 		MemoShare: &apiv1.MemoShare{},
 	})
-	require.NoError(t, err)
+	require.Equal(t, codes.FailedPrecondition, status.Code(err))
 
-	shareToken := share.Name[strings.LastIndex(share.Name, "/")+1:]
-	sharedMemo, err := ts.Service.GetSharedMemo(ctx, &apiv1.GetSharedMemoRequest{
-		ShareToken: shareToken,
+	// Legacy rows created before this rule must not remain a bypass.
+	legacyShare, err := ts.Store.CreateMemoShare(ctx, &store.MemoShare{
+		UID:       "legacy-comment-share",
+		MemoID:    parseMemoIDFromNameForTest(t, ts, comment.Name),
+		CreatorID: user.ID,
 	})
 	require.NoError(t, err)
-	require.Empty(t, sharedMemo.GetParent())
-	require.Empty(t, sharedMemo.Relations)
+	_, err = ts.Service.GetSharedMemo(ctx, &apiv1.GetSharedMemoRequest{ShareToken: legacyShare.UID})
+	require.Equal(t, codes.NotFound, status.Code(err))
 }
 
 func TestGetSharedMemo_SkipsReactionsWithMissingCreators(t *testing.T) {

--- a/server/router/fileserver/fileserver.go
+++ b/server/router/fileserver/fileserver.go
@@ -23,6 +23,7 @@ import (
 	"github.com/usememos/memos/internal/profile"
 	"github.com/usememos/memos/internal/storage/s3"
 	storepb "github.com/usememos/memos/proto/gen/store"
+	"github.com/usememos/memos/server/access"
 	"github.com/usememos/memos/server/auth"
 	"github.com/usememos/memos/store"
 )
@@ -47,6 +48,9 @@ const (
 
 	// cacheMaxAge is the max-age value for Cache-Control headers (1 hour).
 	cacheMaxAge = "public, max-age=3600"
+
+	publicAttachmentCacheControl  = "public, no-cache"
+	privateAttachmentCacheControl = "private, no-store"
 )
 
 // xssUnsafeTypes contains MIME types that could execute scripts if served directly.
@@ -120,6 +124,7 @@ func NewFileServerService(profile *profile.Profile, store *store.Store, secret s
 // RegisterRoutes registers HTTP file serving routes.
 func (s *FileServerService) RegisterRoutes(echoServer *echo.Echo) {
 	fileGroup := echoServer.Group("/file")
+	fileGroup.GET("/attachments/:uid", s.serveAttachmentFile)
 	fileGroup.GET("/attachments/:uid/:filename", s.serveAttachmentFile)
 	fileGroup.GET("/users/:identifier/avatar", s.serveUserAvatar)
 }
@@ -131,6 +136,7 @@ func (s *FileServerService) RegisterRoutes(echoServer *echo.Echo) {
 // serveAttachmentFile serves attachment binary content using native HTTP.
 func (s *FileServerService) serveAttachmentFile(c *echo.Context) error {
 	ctx := c.Request().Context()
+	c.Response().Header().Set(echo.HeaderCacheControl, privateAttachmentCacheControl)
 	uid := c.Param("uid")
 	wantThumbnail := c.QueryParam("thumbnail") == "true"
 	wantMotion := c.QueryParam("motion") == "true"
@@ -146,8 +152,12 @@ func (s *FileServerService) serveAttachmentFile(c *echo.Context) error {
 		return echo.NewHTTPError(http.StatusNotFound, "attachment not found")
 	}
 
-	if err := s.checkAttachmentPermission(ctx, c, attachment); err != nil {
+	readClass, err := s.checkAttachmentPermission(ctx, c, attachment)
+	if err != nil {
 		return err
+	}
+	if readClass == access.MemoReadClassPublic {
+		c.Response().Header().Set(echo.HeaderCacheControl, publicAttachmentCacheControl)
 	}
 
 	if wantMotion {
@@ -647,60 +657,75 @@ func (s *FileServerService) getMotionPath(attachment *store.Attachment) (string,
 // =============================================================================
 
 // checkAttachmentPermission verifies the user has permission to access the attachment.
-func (s *FileServerService) checkAttachmentPermission(ctx context.Context, c *echo.Context, attachment *store.Attachment) error {
+func (s *FileServerService) checkAttachmentPermission(ctx context.Context, c *echo.Context, attachment *store.Attachment) (access.MemoReadClass, error) {
 	// For unlinked attachments, only the creator can access.
 	if attachment.MemoID == nil {
 		user, err := s.getCurrentUser(ctx, c)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, "failed to get current user").Wrap(err)
+			return access.MemoReadClassPrivate, echo.NewHTTPError(http.StatusInternalServerError, "failed to get current user").Wrap(err)
 		}
 		if user == nil {
-			return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized access")
+			return access.MemoReadClassPrivate, echo.NewHTTPError(http.StatusUnauthorized, "unauthorized access")
 		}
 		if user.ID != attachment.CreatorID && user.Role != store.RoleAdmin {
-			return echo.NewHTTPError(http.StatusForbidden, "forbidden access")
+			return access.MemoReadClassPrivate, echo.NewHTTPError(http.StatusForbidden, "forbidden access")
 		}
-		return nil
+		return access.MemoReadClassPrivate, nil
 	}
 
 	memo, err := s.Store.GetMemo(ctx, &store.FindMemo{ID: attachment.MemoID})
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to find memo").Wrap(err)
+		return access.MemoReadClassPrivate, echo.NewHTTPError(http.StatusInternalServerError, "failed to find memo").Wrap(err)
 	}
 	if memo == nil {
-		return echo.NewHTTPError(http.StatusNotFound, "memo not found")
+		return access.MemoReadClassPrivate, echo.NewHTTPError(http.StatusNotFound, "memo not found")
 	}
 
-	// Public-visibility attachments are served to anonymous visitors only when the
-	// instance allows anonymous access. On a private instance (no InstanceURL), the
-	// request must still resolve to an authenticated user or a valid share token below.
-	if memo.Visibility == store.Public && s.Profile.AllowAnonymous() {
-		return nil
+	var parent *store.Memo
+	if memo.ParentUID != nil {
+		parent, err = s.Store.GetMemo(ctx, &store.FindMemo{UID: memo.ParentUID})
+		if err != nil {
+			return access.MemoReadClassPrivate, echo.NewHTTPError(http.StatusInternalServerError, "failed to find parent memo").Wrap(err)
+		}
+		if parent == nil {
+			return access.MemoReadClassPrivate, echo.NewHTTPError(http.StatusNotFound, "memo not found")
+		}
 	}
 
-	// Check share token fallback: allow access if request carries a valid, non-expired share token
-	// that was issued for this specific memo. This covers attachment requests made from the shared
-	// memo page for private or protected memos.
+	allowAnonymous := s.Profile != nil && s.Profile.AllowAnonymous()
+	if decision := access.CheckMemoRead(memo, parent, nil, allowAnonymous, nil); decision.Allowed() {
+		return decision.Class, nil
+	}
+
+	var sharedMemoID *int32
 	if shareToken := (*c).QueryParam("share_token"); shareToken != "" {
 		ms, err := s.Store.GetMemoShare(ctx, &store.FindMemoShare{UID: &shareToken})
-		if err == nil && ms != nil && !isMemoShareExpired(ms) && ms.MemoID == memo.ID {
-			return nil
+		if err != nil {
+			return access.MemoReadClassPrivate, echo.NewHTTPError(http.StatusInternalServerError, "failed to get memo share").Wrap(err)
+		}
+		if ms != nil && !isMemoShareExpired(ms) {
+			sharedMemoID = &ms.MemoID
+			if decision := access.CheckMemoRead(memo, parent, nil, allowAnonymous, sharedMemoID); decision.Allowed() {
+				return decision.Class, nil
+			}
 		}
 	}
 
 	user, err := s.getCurrentUser(ctx, c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get current user").Wrap(err)
+		return access.MemoReadClassPrivate, echo.NewHTTPError(http.StatusInternalServerError, "failed to get current user").Wrap(err)
 	}
-	if user == nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized access")
+	decision := access.CheckMemoRead(memo, parent, user, allowAnonymous, sharedMemoID)
+	switch decision.Denial {
+	case access.MemoReadDenialNone:
+		return decision.Class, nil
+	case access.MemoReadDenialNotFound:
+		return access.MemoReadClassPrivate, echo.NewHTTPError(http.StatusNotFound, "memo not found")
+	case access.MemoReadDenialUnauthenticated:
+		return access.MemoReadClassPrivate, echo.NewHTTPError(http.StatusUnauthorized, "unauthorized access")
+	default:
+		return access.MemoReadClassPrivate, echo.NewHTTPError(http.StatusForbidden, "forbidden access")
 	}
-
-	if memo.Visibility == store.Private && user.ID != memo.CreatorID && user.Role != store.RoleAdmin {
-		return echo.NewHTTPError(http.StatusForbidden, "forbidden access")
-	}
-
-	return nil
 }
 
 // getCurrentUser retrieves the current authenticated user from the request.
@@ -766,7 +791,9 @@ func setSecurityHeaders(c *echo.Context) {
 func setMediaHeaders(c *echo.Context, contentType, originalType string) {
 	h := c.Response().Header()
 	h.Set(echo.HeaderContentType, contentType)
-	h.Set(echo.HeaderCacheControl, cacheMaxAge)
+	if h.Get(echo.HeaderCacheControl) == "" {
+		h.Set(echo.HeaderCacheControl, cacheMaxAge)
+	}
 
 	// Support HDR/wide color gamut for images and videos.
 	if strings.HasPrefix(originalType, "image/") || strings.HasPrefix(originalType, "video/") {

--- a/server/router/fileserver/fileserver_test.go
+++ b/server/router/fileserver/fileserver_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/labstack/echo/v5"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/usememos/memos/internal/markdown"
@@ -82,6 +83,97 @@ func TestServeAttachmentFile_ShareTokenAllowsDirectMemoAttachment(t *testing.T) 
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, "memo attachment", rec.Body.String())
+}
+
+func TestServeAttachmentFile_CanonicalRouteAndVisibilityAwareCache(t *testing.T) {
+	ctx := context.Background()
+	svc, fs, _, cleanup := newShareAttachmentTestServices(ctx, t)
+	defer cleanup()
+
+	creator, err := svc.Store.CreateUser(ctx, &store.User{
+		Username: "canonical-route-owner",
+		Role:     store.RoleUser,
+		Email:    "canonical-route-owner@example.com",
+	})
+	require.NoError(t, err)
+	creatorCtx := context.WithValue(ctx, auth.UserIDContextKey, creator.ID)
+	attachment, err := svc.CreateAttachment(creatorCtx, &apiv1.CreateAttachmentRequest{Attachment: &apiv1.Attachment{
+		Filename: "canonical.png",
+		Type:     "image/png",
+		Content:  []byte("canonical image"),
+	}})
+	require.NoError(t, err)
+	memo, err := svc.CreateMemo(creatorCtx, &apiv1.CreateMemoRequest{Memo: &apiv1.Memo{
+		Content:     "canonical route",
+		Visibility:  apiv1.Visibility_PUBLIC,
+		Attachments: []*apiv1.Attachment{{Name: attachment.Name}},
+	}})
+	require.NoError(t, err)
+
+	e := echo.New()
+	fs.RegisterRoutes(e)
+	url := "/file/" + attachment.Name
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, url, nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "canonical image", rec.Body.String())
+	require.Equal(t, publicAttachmentCacheControl, rec.Header().Get(echo.HeaderCacheControl))
+
+	_, err = svc.UpdateMemo(creatorCtx, &apiv1.UpdateMemoRequest{
+		Memo:       &apiv1.Memo{Name: memo.Name, Visibility: apiv1.Visibility_PROTECTED},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"visibility"}},
+	})
+	require.NoError(t, err)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, url, nil))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Equal(t, privateAttachmentCacheControl, rec.Header().Get(echo.HeaderCacheControl))
+}
+
+func TestServeAttachmentFile_CommentFollowsCurrentParentVisibility(t *testing.T) {
+	ctx := context.Background()
+	svc, fs, _, cleanup := newShareAttachmentTestServices(ctx, t)
+	defer cleanup()
+
+	owner, err := svc.Store.CreateUser(ctx, &store.User{Username: "comment-parent-owner", Role: store.RoleUser, Email: "parent@example.com"})
+	require.NoError(t, err)
+	commenter, err := svc.Store.CreateUser(ctx, &store.User{Username: "comment-file-owner", Role: store.RoleUser, Email: "commenter@example.com"})
+	require.NoError(t, err)
+	ownerCtx := context.WithValue(ctx, auth.UserIDContextKey, owner.ID)
+	commenterCtx := context.WithValue(ctx, auth.UserIDContextKey, commenter.ID)
+	parent, err := svc.CreateMemo(ownerCtx, &apiv1.CreateMemoRequest{Memo: &apiv1.Memo{Content: "parent", Visibility: apiv1.Visibility_PUBLIC}})
+	require.NoError(t, err)
+	attachment, err := svc.CreateAttachment(commenterCtx, &apiv1.CreateAttachmentRequest{Attachment: &apiv1.Attachment{
+		Filename: "comment.png",
+		Type:     "image/png",
+		Content:  []byte("comment image"),
+	}})
+	require.NoError(t, err)
+	_, err = svc.CreateMemoComment(commenterCtx, &apiv1.CreateMemoCommentRequest{
+		Name: parent.Name,
+		Comment: &apiv1.Memo{
+			Content:     "comment",
+			Attachments: []*apiv1.Attachment{{Name: attachment.Name}},
+		},
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	fs.RegisterRoutes(e)
+	url := "/file/" + attachment.Name
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, url, nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	_, err = svc.UpdateMemo(ownerCtx, &apiv1.UpdateMemoRequest{
+		Memo:       &apiv1.Memo{Name: parent.Name, Visibility: apiv1.Visibility_PRIVATE},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"visibility"}},
+	})
+	require.NoError(t, err)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, url, nil))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.Equal(t, privateAttachmentCacheControl, rec.Header().Get(echo.HeaderCacheControl))
 }
 
 func TestServeAttachmentFile_LocalStaticFileSupportsRangeRequests(t *testing.T) {

--- a/server/router/rss/rss.go
+++ b/server/router/rss/rss.go
@@ -287,10 +287,10 @@ func (s *RSSService) generateRSSFromMemoList(ctx context.Context, memoList []*st
 		if attachments, ok := attachmentsByMemoID[memo.ID]; ok && len(attachments) > 0 {
 			attachment := attachments[0]
 			enclosure := feeds.Enclosure{}
-			if attachment.StorageType == storepb.AttachmentStorageType_EXTERNAL || attachment.StorageType == storepb.AttachmentStorageType_S3 {
+			if attachment.StorageType == storepb.AttachmentStorageType_EXTERNAL {
 				enclosure.Url = attachment.Reference
 			} else {
-				enclosure.Url = fmt.Sprintf("%s/file/attachments/%s/%s", baseURL, attachment.UID, attachment.Filename)
+				enclosure.Url = fmt.Sprintf("%s/file/attachments/%s", baseURL, attachment.UID)
 			}
 			enclosure.Length = strconv.Itoa(int(attachment.Size))
 			enclosure.Type = attachment.Type

--- a/store/attachment.go
+++ b/store/attachment.go
@@ -41,19 +41,20 @@ type Attachment struct {
 }
 
 type FindAttachment struct {
-	GetBlob        bool
-	ID             *int32
-	UID            *string
-	CreatorID      *int32
-	Filename       *string
-	FilenameSearch *string
-	MemoID         *int32
-	MemoIDList     []int32
-	HasRelatedMemo bool
-	StorageType    *storepb.AttachmentStorageType
-	Filters        []string
-	Limit          *int
-	Offset         *int
+	GetBlob          bool
+	ID               *int32
+	UID              *string
+	CreatorID        *int32
+	Filename         *string
+	FilenameSearch   *string
+	MemoID           *int32
+	MemoIDList       []int32
+	HasRelatedMemo   bool
+	StorageType      *storepb.AttachmentStorageType
+	Filters          []string
+	Limit            *int
+	Offset           *int
+	SkipDefaultLimit bool
 }
 
 type UpdateAttachment struct {
@@ -95,7 +96,7 @@ func (s *Store) CreateAttachment(ctx context.Context, create *Attachment) (*Atta
 
 func (s *Store) ListAttachments(ctx context.Context, find *FindAttachment) ([]*Attachment, error) {
 	// Set default limits to prevent loading too many attachments at once
-	shouldApplyDefaultLimit := find.Limit == nil && len(find.MemoIDList) == 0
+	shouldApplyDefaultLimit := find.Limit == nil && find.MemoID == nil && len(find.MemoIDList) == 0 && !find.SkipDefaultLimit
 	if shouldApplyDefaultLimit && find.GetBlob {
 		// When fetching blobs, we should be especially careful with limits
 		defaultLimit := 10

--- a/store/db/mysql/memo.go
+++ b/store/db/mysql/memo.go
@@ -215,45 +215,7 @@ func (d *DB) GetMemo(ctx context.Context, find *store.FindMemo) (*store.Memo, er
 }
 
 func (d *DB) UpdateMemo(ctx context.Context, update *store.UpdateMemo) error {
-	set, args := []string{}, []any{}
-	if v := update.UID; v != nil {
-		set, args = append(set, "`uid` = ?"), append(args, *v)
-	}
-	if v := update.CreatedTs; v != nil {
-		set, args = append(set, "`created_ts` = FROM_UNIXTIME(?)"), append(args, *v)
-	}
-	if v := update.UpdatedTs; v != nil {
-		set, args = append(set, "`updated_ts` = FROM_UNIXTIME(?)"), append(args, *v)
-	}
-	if v := update.RowStatus; v != nil {
-		set, args = append(set, "`row_status` = ?"), append(args, *v)
-	}
-	if v := update.Content; v != nil {
-		set, args = append(set, "`content` = ?"), append(args, *v)
-	}
-	if v := update.Visibility; v != nil {
-		set, args = append(set, "`visibility` = ?"), append(args, *v)
-	}
-	if v := update.Pinned; v != nil {
-		set, args = append(set, "`pinned` = ?"), append(args, *v)
-	}
-	if v := update.Payload; v != nil {
-		payloadBytes, err := protojson.Marshal(v)
-		if err != nil {
-			return err
-		}
-		set, args = append(set, "`payload` = ?"), append(args, string(payloadBytes))
-	}
-	if len(set) == 0 {
-		return nil
-	}
-	args = append(args, update.ID)
-
-	stmt := "UPDATE `memo` SET " + strings.Join(set, ", ") + " WHERE `id` = ?"
-	if _, err := d.db.ExecContext(ctx, stmt, args...); err != nil {
-		return err
-	}
-	return nil
+	return applyMemoUpdate(ctx, d.db, update)
 }
 
 func (d *DB) DeleteMemo(ctx context.Context, delete *store.DeleteMemo) error {

--- a/store/db/mysql/memo_attachment.go
+++ b/store/db/mysql/memo_attachment.go
@@ -11,11 +11,11 @@ import (
 	"github.com/usememos/memos/store"
 )
 
-// ApplyMemoAttachmentMutation atomically updates a memo and its attachment bindings.
-func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.MemoAttachmentMutation) error {
+// ApplyMemoMutation atomically updates a memo, attachment bindings, and reference relations.
+func (d *DB) ApplyMemoMutation(ctx context.Context, mutation *store.MemoMutation) error {
 	tx, err := d.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		return errors.Wrap(err, "failed to begin memo attachment transaction")
+		return errors.Wrap(err, "failed to begin memo transaction")
 	}
 	defer func() {
 		_ = tx.Rollback()
@@ -25,12 +25,12 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 	var content string
 	if err := tx.QueryRowContext(ctx, "SELECT `creator_id`, `content` FROM `memo` WHERE `id` = ? FOR UPDATE", mutation.MemoID).Scan(&creatorID, &content); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return errors.Wrap(store.ErrMemoAttachmentConflict, "memo no longer exists")
+			return errors.Wrap(store.ErrMemoMutationConflict, "memo no longer exists")
 		}
 		return errors.Wrap(err, "failed to lock memo")
 	}
 	if creatorID != mutation.MemoCreatorID || content != mutation.ExpectedMemoContent {
-		return errors.Wrap(store.ErrMemoAttachmentConflict, "memo changed while updating attachments")
+		return errors.Wrap(store.ErrMemoMutationConflict, "memo changed while applying mutation")
 	}
 
 	for _, binding := range mutation.Bindings {
@@ -38,16 +38,16 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 		var memoID sql.NullInt32
 		if err := tx.QueryRowContext(ctx, "SELECT `creator_id`, `memo_id` FROM `attachment` WHERE `id` = ? FOR UPDATE", binding.ID).Scan(&attachmentCreatorID, &memoID); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s no longer exists", binding.UID)
+				return errors.Wrapf(store.ErrMemoMutationConflict, "attachment %s no longer exists", binding.UID)
 			}
 			return errors.Wrap(err, "failed to lock attachment")
 		}
 		if binding.WasBoundToMemo {
 			if !memoID.Valid || memoID.Int32 != mutation.MemoID {
-				return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s is no longer bound to the memo", binding.UID)
+				return errors.Wrapf(store.ErrMemoMutationConflict, "attachment %s is no longer bound to the memo", binding.UID)
 			}
 		} else if attachmentCreatorID != mutation.MemoCreatorID || memoID.Valid {
-			return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s is no longer available", binding.UID)
+			return errors.Wrapf(store.ErrMemoMutationConflict, "attachment %s is no longer available", binding.UID)
 		}
 		if _, err := tx.ExecContext(ctx, "UPDATE `attachment` SET `memo_id` = ?, `updated_ts` = FROM_UNIXTIME(?) WHERE `id` = ?", mutation.MemoID, binding.UpdatedTs, binding.ID); err != nil {
 			return errors.Wrap(err, "failed to bind attachment")
@@ -60,7 +60,7 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 			return errors.Wrap(err, "failed to detach attachment")
 		}
 		if rows, err := result.RowsAffected(); err != nil || rows != 1 {
-			return errors.Wrap(store.ErrMemoAttachmentConflict, "attachment is no longer bound to the memo")
+			return errors.Wrap(store.ErrMemoMutationConflict, "attachment is no longer bound to the memo")
 		}
 	}
 
@@ -68,7 +68,7 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 		var exists int
 		if err := tx.QueryRowContext(ctx, "SELECT 1 FROM `attachment` WHERE `id` = ? AND `memo_id` = ? FOR UPDATE", attachmentID, mutation.MemoID).Scan(&exists); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return errors.Wrap(store.ErrMemoAttachmentConflict, "a referenced attachment is no longer bound to the memo")
+				return errors.Wrap(store.ErrMemoMutationConflict, "a referenced attachment is no longer bound to the memo")
 			}
 			return errors.Wrap(err, "failed to verify referenced attachment")
 		}
@@ -82,8 +82,31 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 			return err
 		}
 	}
+	if mutation.ReplaceReferenceRelations {
+		if err := replaceMemoReferenceRelations(ctx, tx, mutation.MemoID, mutation.ReferenceRelations); err != nil {
+			return err
+		}
+	}
 	if err := tx.Commit(); err != nil {
-		return errors.Wrap(err, "failed to commit memo attachment transaction")
+		return errors.Wrap(err, "failed to commit memo transaction")
+	}
+	return nil
+}
+
+func replaceMemoReferenceRelations(ctx context.Context, tx *sql.Tx, memoID int32, relations []*store.MemoRelation) error {
+	if _, err := tx.ExecContext(ctx, "DELETE FROM `memo_relation` WHERE `memo_id` = ? AND `type` = ?", memoID, store.MemoRelationReference); err != nil {
+		return errors.Wrap(err, "failed to delete memo reference relations")
+	}
+	for _, relation := range relations {
+		if relation == nil || relation.MemoID != memoID || relation.Type != store.MemoRelationReference {
+			return errors.New("invalid memo reference relation mutation")
+		}
+		if _, err := tx.ExecContext(ctx,
+			"INSERT INTO `memo_relation` (`memo_id`, `related_memo_id`, `type`) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE `type` = `type`",
+			relation.MemoID, relation.RelatedMemoID, relation.Type,
+		); err != nil {
+			return errors.Wrap(err, "failed to insert memo reference relation")
+		}
 	}
 	return nil
 }

--- a/store/db/mysql/memo_attachment.go
+++ b/store/db/mysql/memo_attachment.go
@@ -1,0 +1,133 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/usememos/memos/store"
+)
+
+// ApplyMemoAttachmentMutation atomically updates a memo and its attachment bindings.
+func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.MemoAttachmentMutation) error {
+	tx, err := d.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return errors.Wrap(err, "failed to begin memo attachment transaction")
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	var creatorID int32
+	var content string
+	if err := tx.QueryRowContext(ctx, "SELECT `creator_id`, `content` FROM `memo` WHERE `id` = ? FOR UPDATE", mutation.MemoID).Scan(&creatorID, &content); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errors.Wrap(store.ErrMemoAttachmentConflict, "memo no longer exists")
+		}
+		return errors.Wrap(err, "failed to lock memo")
+	}
+	if creatorID != mutation.MemoCreatorID || content != mutation.ExpectedMemoContent {
+		return errors.Wrap(store.ErrMemoAttachmentConflict, "memo changed while updating attachments")
+	}
+
+	for _, binding := range mutation.Bindings {
+		var attachmentCreatorID int32
+		var memoID sql.NullInt32
+		if err := tx.QueryRowContext(ctx, "SELECT `creator_id`, `memo_id` FROM `attachment` WHERE `id` = ? FOR UPDATE", binding.ID).Scan(&attachmentCreatorID, &memoID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s no longer exists", binding.UID)
+			}
+			return errors.Wrap(err, "failed to lock attachment")
+		}
+		if binding.WasBoundToMemo {
+			if !memoID.Valid || memoID.Int32 != mutation.MemoID {
+				return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s is no longer bound to the memo", binding.UID)
+			}
+		} else if attachmentCreatorID != mutation.MemoCreatorID || memoID.Valid {
+			return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s is no longer available", binding.UID)
+		}
+		if _, err := tx.ExecContext(ctx, "UPDATE `attachment` SET `memo_id` = ?, `updated_ts` = FROM_UNIXTIME(?) WHERE `id` = ?", mutation.MemoID, binding.UpdatedTs, binding.ID); err != nil {
+			return errors.Wrap(err, "failed to bind attachment")
+		}
+	}
+
+	for _, attachmentID := range mutation.RemovedAttachmentIDs {
+		result, err := tx.ExecContext(ctx, "UPDATE `attachment` SET `memo_id` = NULL WHERE `id` = ? AND `memo_id` = ?", attachmentID, mutation.MemoID)
+		if err != nil {
+			return errors.Wrap(err, "failed to detach attachment")
+		}
+		if rows, err := result.RowsAffected(); err != nil || rows != 1 {
+			return errors.Wrap(store.ErrMemoAttachmentConflict, "attachment is no longer bound to the memo")
+		}
+	}
+
+	for _, attachmentID := range mutation.RequiredAttachmentIDs {
+		var exists int
+		if err := tx.QueryRowContext(ctx, "SELECT 1 FROM `attachment` WHERE `id` = ? AND `memo_id` = ? FOR UPDATE", attachmentID, mutation.MemoID).Scan(&exists); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return errors.Wrap(store.ErrMemoAttachmentConflict, "a referenced attachment is no longer bound to the memo")
+			}
+			return errors.Wrap(err, "failed to verify referenced attachment")
+		}
+	}
+
+	if mutation.MemoUpdate != nil {
+		if mutation.MemoUpdate.ID != mutation.MemoID {
+			return errors.New("memo update target does not match attachment mutation")
+		}
+		if err := applyMemoUpdate(ctx, tx, mutation.MemoUpdate); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "failed to commit memo attachment transaction")
+	}
+	return nil
+}
+
+type memoUpdateExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func applyMemoUpdate(ctx context.Context, executor memoUpdateExecer, update *store.UpdateMemo) error {
+	set, args := []string{}, []any{}
+	if v := update.UID; v != nil {
+		set, args = append(set, "`uid` = ?"), append(args, *v)
+	}
+	if v := update.CreatedTs; v != nil {
+		set, args = append(set, "`created_ts` = FROM_UNIXTIME(?)"), append(args, *v)
+	}
+	if v := update.UpdatedTs; v != nil {
+		set, args = append(set, "`updated_ts` = FROM_UNIXTIME(?)"), append(args, *v)
+	}
+	if v := update.RowStatus; v != nil {
+		set, args = append(set, "`row_status` = ?"), append(args, *v)
+	}
+	if v := update.Content; v != nil {
+		set, args = append(set, "`content` = ?"), append(args, *v)
+	}
+	if v := update.Visibility; v != nil {
+		set, args = append(set, "`visibility` = ?"), append(args, *v)
+	}
+	if v := update.Pinned; v != nil {
+		set, args = append(set, "`pinned` = ?"), append(args, *v)
+	}
+	if v := update.Payload; v != nil {
+		payload, err := protojson.Marshal(v)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal memo payload")
+		}
+		set, args = append(set, "`payload` = ?"), append(args, string(payload))
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	args = append(args, update.ID)
+	if _, err := executor.ExecContext(ctx, "UPDATE `memo` SET "+strings.Join(set, ", ")+" WHERE `id` = ?", args...); err != nil {
+		return errors.Wrap(err, "failed to update memo")
+	}
+	return nil
+}

--- a/store/db/mysql/memo_relation.go
+++ b/store/db/mysql/memo_relation.go
@@ -70,6 +70,10 @@ func (d *DB) ListMemoRelations(ctx context.Context, find *store.FindMemoRelation
 		}
 		where = append(where, fmt.Sprintf("`related_memo_id` IN (%s)", strings.Join(placeholders, ", ")))
 	}
+	if find.SourceMemoRowStatus != nil {
+		where = append(where, "`memo_id` IN (SELECT `id` FROM `memo` WHERE `row_status` = ?)")
+		args = append(args, *find.SourceMemoRowStatus)
+	}
 	if find.MemoFilter != nil {
 		engine, err := filter.DefaultEngine()
 		if err != nil {

--- a/store/db/postgres/memo.go
+++ b/store/db/postgres/memo.go
@@ -200,45 +200,7 @@ func (d *DB) GetMemo(ctx context.Context, find *store.FindMemo) (*store.Memo, er
 }
 
 func (d *DB) UpdateMemo(ctx context.Context, update *store.UpdateMemo) error {
-	set, args := []string{}, []any{}
-	if v := update.UID; v != nil {
-		set, args = append(set, "uid = "+placeholder(len(args)+1)), append(args, *v)
-	}
-	if v := update.CreatedTs; v != nil {
-		set, args = append(set, "created_ts = "+placeholder(len(args)+1)), append(args, *v)
-	}
-	if v := update.UpdatedTs; v != nil {
-		set, args = append(set, "updated_ts = "+placeholder(len(args)+1)), append(args, *v)
-	}
-	if v := update.RowStatus; v != nil {
-		set, args = append(set, "row_status = "+placeholder(len(args)+1)), append(args, *v)
-	}
-	if v := update.Content; v != nil {
-		set, args = append(set, "content = "+placeholder(len(args)+1)), append(args, *v)
-	}
-	if v := update.Visibility; v != nil {
-		set, args = append(set, "visibility = "+placeholder(len(args)+1)), append(args, *v)
-	}
-	if v := update.Pinned; v != nil {
-		set, args = append(set, "pinned = "+placeholder(len(args)+1)), append(args, *v)
-	}
-	if v := update.Payload; v != nil {
-		payloadBytes, err := protojson.Marshal(v)
-		if err != nil {
-			return err
-		}
-		set, args = append(set, "payload = "+placeholder(len(args)+1)), append(args, string(payloadBytes))
-	}
-	if len(set) == 0 {
-		return nil
-	}
-
-	stmt := `UPDATE memo SET ` + strings.Join(set, ", ") + ` WHERE id = ` + placeholder(len(args)+1)
-	args = append(args, update.ID)
-	if _, err := d.db.ExecContext(ctx, stmt, args...); err != nil {
-		return err
-	}
-	return nil
+	return applyMemoUpdate(ctx, d.db, update)
 }
 
 func (d *DB) DeleteMemo(ctx context.Context, delete *store.DeleteMemo) error {

--- a/store/db/postgres/memo_attachment.go
+++ b/store/db/postgres/memo_attachment.go
@@ -11,11 +11,11 @@ import (
 	"github.com/usememos/memos/store"
 )
 
-// ApplyMemoAttachmentMutation atomically updates a memo and its attachment bindings.
-func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.MemoAttachmentMutation) error {
+// ApplyMemoMutation atomically updates a memo, attachment bindings, and reference relations.
+func (d *DB) ApplyMemoMutation(ctx context.Context, mutation *store.MemoMutation) error {
 	tx, err := d.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		return errors.Wrap(err, "failed to begin memo attachment transaction")
+		return errors.Wrap(err, "failed to begin memo transaction")
 	}
 	defer func() {
 		_ = tx.Rollback()
@@ -25,12 +25,12 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 	var content string
 	if err := tx.QueryRowContext(ctx, `SELECT creator_id, content FROM memo WHERE id = $1 FOR UPDATE`, mutation.MemoID).Scan(&creatorID, &content); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return errors.Wrap(store.ErrMemoAttachmentConflict, "memo no longer exists")
+			return errors.Wrap(store.ErrMemoMutationConflict, "memo no longer exists")
 		}
 		return errors.Wrap(err, "failed to lock memo")
 	}
 	if creatorID != mutation.MemoCreatorID || content != mutation.ExpectedMemoContent {
-		return errors.Wrap(store.ErrMemoAttachmentConflict, "memo changed while updating attachments")
+		return errors.Wrap(store.ErrMemoMutationConflict, "memo changed while applying mutation")
 	}
 
 	for _, binding := range mutation.Bindings {
@@ -38,16 +38,16 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 		var memoID sql.NullInt32
 		if err := tx.QueryRowContext(ctx, `SELECT creator_id, memo_id FROM attachment WHERE id = $1 FOR UPDATE`, binding.ID).Scan(&attachmentCreatorID, &memoID); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s no longer exists", binding.UID)
+				return errors.Wrapf(store.ErrMemoMutationConflict, "attachment %s no longer exists", binding.UID)
 			}
 			return errors.Wrap(err, "failed to lock attachment")
 		}
 		if binding.WasBoundToMemo {
 			if !memoID.Valid || memoID.Int32 != mutation.MemoID {
-				return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s is no longer bound to the memo", binding.UID)
+				return errors.Wrapf(store.ErrMemoMutationConflict, "attachment %s is no longer bound to the memo", binding.UID)
 			}
 		} else if attachmentCreatorID != mutation.MemoCreatorID || memoID.Valid {
-			return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s is no longer available", binding.UID)
+			return errors.Wrapf(store.ErrMemoMutationConflict, "attachment %s is no longer available", binding.UID)
 		}
 		if _, err := tx.ExecContext(ctx, `UPDATE attachment SET memo_id = $1, updated_ts = $2 WHERE id = $3`, mutation.MemoID, binding.UpdatedTs, binding.ID); err != nil {
 			return errors.Wrap(err, "failed to bind attachment")
@@ -60,7 +60,7 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 			return errors.Wrap(err, "failed to detach attachment")
 		}
 		if rows, err := result.RowsAffected(); err != nil || rows != 1 {
-			return errors.Wrap(store.ErrMemoAttachmentConflict, "attachment is no longer bound to the memo")
+			return errors.Wrap(store.ErrMemoMutationConflict, "attachment is no longer bound to the memo")
 		}
 	}
 
@@ -68,7 +68,7 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 		var exists int
 		if err := tx.QueryRowContext(ctx, `SELECT 1 FROM attachment WHERE id = $1 AND memo_id = $2 FOR UPDATE`, attachmentID, mutation.MemoID).Scan(&exists); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return errors.Wrap(store.ErrMemoAttachmentConflict, "a referenced attachment is no longer bound to the memo")
+				return errors.Wrap(store.ErrMemoMutationConflict, "a referenced attachment is no longer bound to the memo")
 			}
 			return errors.Wrap(err, "failed to verify referenced attachment")
 		}
@@ -82,8 +82,32 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 			return err
 		}
 	}
+	if mutation.ReplaceReferenceRelations {
+		if err := replaceMemoReferenceRelations(ctx, tx, mutation.MemoID, mutation.ReferenceRelations); err != nil {
+			return err
+		}
+	}
 	if err := tx.Commit(); err != nil {
-		return errors.Wrap(err, "failed to commit memo attachment transaction")
+		return errors.Wrap(err, "failed to commit memo transaction")
+	}
+	return nil
+}
+
+func replaceMemoReferenceRelations(ctx context.Context, tx *sql.Tx, memoID int32, relations []*store.MemoRelation) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM memo_relation WHERE memo_id = $1 AND type = $2`, memoID, store.MemoRelationReference); err != nil {
+		return errors.Wrap(err, "failed to delete memo reference relations")
+	}
+	for _, relation := range relations {
+		if relation == nil || relation.MemoID != memoID || relation.Type != store.MemoRelationReference {
+			return errors.New("invalid memo reference relation mutation")
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO memo_relation (memo_id, related_memo_id, type)
+			VALUES ($1, $2, $3)
+			ON CONFLICT (memo_id, related_memo_id, type) DO UPDATE SET type = EXCLUDED.type
+		`, relation.MemoID, relation.RelatedMemoID, relation.Type); err != nil {
+			return errors.Wrap(err, "failed to insert memo reference relation")
+		}
 	}
 	return nil
 }

--- a/store/db/postgres/memo_attachment.go
+++ b/store/db/postgres/memo_attachment.go
@@ -1,0 +1,137 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/usememos/memos/store"
+)
+
+// ApplyMemoAttachmentMutation atomically updates a memo and its attachment bindings.
+func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.MemoAttachmentMutation) error {
+	tx, err := d.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return errors.Wrap(err, "failed to begin memo attachment transaction")
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	var creatorID int32
+	var content string
+	if err := tx.QueryRowContext(ctx, `SELECT creator_id, content FROM memo WHERE id = $1 FOR UPDATE`, mutation.MemoID).Scan(&creatorID, &content); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errors.Wrap(store.ErrMemoAttachmentConflict, "memo no longer exists")
+		}
+		return errors.Wrap(err, "failed to lock memo")
+	}
+	if creatorID != mutation.MemoCreatorID || content != mutation.ExpectedMemoContent {
+		return errors.Wrap(store.ErrMemoAttachmentConflict, "memo changed while updating attachments")
+	}
+
+	for _, binding := range mutation.Bindings {
+		var attachmentCreatorID int32
+		var memoID sql.NullInt32
+		if err := tx.QueryRowContext(ctx, `SELECT creator_id, memo_id FROM attachment WHERE id = $1 FOR UPDATE`, binding.ID).Scan(&attachmentCreatorID, &memoID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s no longer exists", binding.UID)
+			}
+			return errors.Wrap(err, "failed to lock attachment")
+		}
+		if binding.WasBoundToMemo {
+			if !memoID.Valid || memoID.Int32 != mutation.MemoID {
+				return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s is no longer bound to the memo", binding.UID)
+			}
+		} else if attachmentCreatorID != mutation.MemoCreatorID || memoID.Valid {
+			return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s is no longer available", binding.UID)
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE attachment SET memo_id = $1, updated_ts = $2 WHERE id = $3`, mutation.MemoID, binding.UpdatedTs, binding.ID); err != nil {
+			return errors.Wrap(err, "failed to bind attachment")
+		}
+	}
+
+	for _, attachmentID := range mutation.RemovedAttachmentIDs {
+		result, err := tx.ExecContext(ctx, `UPDATE attachment SET memo_id = NULL WHERE id = $1 AND memo_id = $2`, attachmentID, mutation.MemoID)
+		if err != nil {
+			return errors.Wrap(err, "failed to detach attachment")
+		}
+		if rows, err := result.RowsAffected(); err != nil || rows != 1 {
+			return errors.Wrap(store.ErrMemoAttachmentConflict, "attachment is no longer bound to the memo")
+		}
+	}
+
+	for _, attachmentID := range mutation.RequiredAttachmentIDs {
+		var exists int
+		if err := tx.QueryRowContext(ctx, `SELECT 1 FROM attachment WHERE id = $1 AND memo_id = $2 FOR UPDATE`, attachmentID, mutation.MemoID).Scan(&exists); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return errors.Wrap(store.ErrMemoAttachmentConflict, "a referenced attachment is no longer bound to the memo")
+			}
+			return errors.Wrap(err, "failed to verify referenced attachment")
+		}
+	}
+
+	if mutation.MemoUpdate != nil {
+		if mutation.MemoUpdate.ID != mutation.MemoID {
+			return errors.New("memo update target does not match attachment mutation")
+		}
+		if err := applyMemoUpdate(ctx, tx, mutation.MemoUpdate); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "failed to commit memo attachment transaction")
+	}
+	return nil
+}
+
+type memoUpdateExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func applyMemoUpdate(ctx context.Context, executor memoUpdateExecer, update *store.UpdateMemo) error {
+	set, args := []string{}, []any{}
+	appendValue := func(column string, value any) {
+		args = append(args, value)
+		set = append(set, column+" = "+placeholder(len(args)))
+	}
+	if v := update.UID; v != nil {
+		appendValue("uid", *v)
+	}
+	if v := update.CreatedTs; v != nil {
+		appendValue("created_ts", *v)
+	}
+	if v := update.UpdatedTs; v != nil {
+		appendValue("updated_ts", *v)
+	}
+	if v := update.RowStatus; v != nil {
+		appendValue("row_status", *v)
+	}
+	if v := update.Content; v != nil {
+		appendValue("content", *v)
+	}
+	if v := update.Visibility; v != nil {
+		appendValue("visibility", *v)
+	}
+	if v := update.Pinned; v != nil {
+		appendValue("pinned", *v)
+	}
+	if v := update.Payload; v != nil {
+		payload, err := protojson.Marshal(v)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal memo payload")
+		}
+		appendValue("payload", string(payload))
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	args = append(args, update.ID)
+	if _, err := executor.ExecContext(ctx, "UPDATE memo SET "+strings.Join(set, ", ")+" WHERE id = "+placeholder(len(args)), args...); err != nil {
+		return errors.Wrap(err, "failed to update memo")
+	}
+	return nil
+}

--- a/store/db/postgres/memo_relation.go
+++ b/store/db/postgres/memo_relation.go
@@ -79,6 +79,10 @@ func (d *DB) ListMemoRelations(ctx context.Context, find *store.FindMemoRelation
 		}
 		where = append(where, fmt.Sprintf("related_memo_id IN (%s)", strings.Join(placeholders, ", ")))
 	}
+	if find.SourceMemoRowStatus != nil {
+		where = append(where, "memo_id IN (SELECT id FROM memo WHERE row_status = "+placeholder(len(args)+1)+")")
+		args = append(args, *find.SourceMemoRowStatus)
+	}
 	if find.MemoFilter != nil {
 		engine, err := filter.DefaultEngine()
 		if err != nil {

--- a/store/db/sqlite/memo.go
+++ b/store/db/sqlite/memo.go
@@ -193,45 +193,7 @@ func (d *DB) ListMemos(ctx context.Context, find *store.FindMemo) ([]*store.Memo
 }
 
 func (d *DB) UpdateMemo(ctx context.Context, update *store.UpdateMemo) error {
-	set, args := []string{}, []any{}
-	if v := update.UID; v != nil {
-		set, args = append(set, "`uid` = ?"), append(args, *v)
-	}
-	if v := update.CreatedTs; v != nil {
-		set, args = append(set, "`created_ts` = ?"), append(args, *v)
-	}
-	if v := update.UpdatedTs; v != nil {
-		set, args = append(set, "`updated_ts` = ?"), append(args, *v)
-	}
-	if v := update.RowStatus; v != nil {
-		set, args = append(set, "`row_status` = ?"), append(args, *v)
-	}
-	if v := update.Content; v != nil {
-		set, args = append(set, "`content` = ?"), append(args, *v)
-	}
-	if v := update.Visibility; v != nil {
-		set, args = append(set, "`visibility` = ?"), append(args, *v)
-	}
-	if v := update.Pinned; v != nil {
-		set, args = append(set, "`pinned` = ?"), append(args, *v)
-	}
-	if v := update.Payload; v != nil {
-		payloadBytes, err := protojson.Marshal(v)
-		if err != nil {
-			return err
-		}
-		set, args = append(set, "`payload` = ?"), append(args, string(payloadBytes))
-	}
-	if len(set) == 0 {
-		return nil
-	}
-	args = append(args, update.ID)
-
-	stmt := "UPDATE `memo` SET " + strings.Join(set, ", ") + " WHERE `id` = ?"
-	if _, err := d.db.ExecContext(ctx, stmt, args...); err != nil {
-		return err
-	}
-	return nil
+	return applyMemoUpdate(ctx, d.db, update)
 }
 
 func (d *DB) DeleteMemo(ctx context.Context, delete *store.DeleteMemo) error {

--- a/store/db/sqlite/memo_attachment.go
+++ b/store/db/sqlite/memo_attachment.go
@@ -11,11 +11,11 @@ import (
 	"github.com/usememos/memos/store"
 )
 
-// ApplyMemoAttachmentMutation atomically updates a memo and its attachment bindings.
-func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.MemoAttachmentMutation) error {
+// ApplyMemoMutation atomically updates a memo, attachment bindings, and reference relations.
+func (d *DB) ApplyMemoMutation(ctx context.Context, mutation *store.MemoMutation) error {
 	tx, err := d.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		return errors.Wrap(err, "failed to begin memo attachment transaction")
+		return errors.Wrap(err, "failed to begin memo transaction")
 	}
 	defer func() {
 		_ = tx.Rollback()
@@ -25,12 +25,12 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 	var content string
 	if err := tx.QueryRowContext(ctx, `SELECT creator_id, content FROM memo WHERE id = ?`, mutation.MemoID).Scan(&creatorID, &content); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return errors.Wrap(store.ErrMemoAttachmentConflict, "memo no longer exists")
+			return errors.Wrap(store.ErrMemoMutationConflict, "memo no longer exists")
 		}
 		return errors.Wrap(err, "failed to lock memo")
 	}
 	if creatorID != mutation.MemoCreatorID || content != mutation.ExpectedMemoContent {
-		return errors.Wrap(store.ErrMemoAttachmentConflict, "memo changed while updating attachments")
+		return errors.Wrap(store.ErrMemoMutationConflict, "memo changed while applying mutation")
 	}
 
 	for _, binding := range mutation.Bindings {
@@ -38,16 +38,16 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 		var memoID sql.NullInt32
 		if err := tx.QueryRowContext(ctx, `SELECT creator_id, memo_id FROM attachment WHERE id = ?`, binding.ID).Scan(&attachmentCreatorID, &memoID); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s no longer exists", binding.UID)
+				return errors.Wrapf(store.ErrMemoMutationConflict, "attachment %s no longer exists", binding.UID)
 			}
 			return errors.Wrap(err, "failed to lock attachment")
 		}
 		if binding.WasBoundToMemo {
 			if !memoID.Valid || memoID.Int32 != mutation.MemoID {
-				return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s is no longer bound to the memo", binding.UID)
+				return errors.Wrapf(store.ErrMemoMutationConflict, "attachment %s is no longer bound to the memo", binding.UID)
 			}
 		} else if attachmentCreatorID != mutation.MemoCreatorID || memoID.Valid {
-			return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s is no longer available", binding.UID)
+			return errors.Wrapf(store.ErrMemoMutationConflict, "attachment %s is no longer available", binding.UID)
 		}
 		if _, err := tx.ExecContext(ctx, `UPDATE attachment SET memo_id = ?, updated_ts = ? WHERE id = ?`, mutation.MemoID, binding.UpdatedTs, binding.ID); err != nil {
 			return errors.Wrap(err, "failed to bind attachment")
@@ -60,7 +60,7 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 			return errors.Wrap(err, "failed to detach attachment")
 		}
 		if rows, err := result.RowsAffected(); err != nil || rows != 1 {
-			return errors.Wrap(store.ErrMemoAttachmentConflict, "attachment is no longer bound to the memo")
+			return errors.Wrap(store.ErrMemoMutationConflict, "attachment is no longer bound to the memo")
 		}
 	}
 
@@ -68,7 +68,7 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 		var exists int
 		if err := tx.QueryRowContext(ctx, `SELECT 1 FROM attachment WHERE id = ? AND memo_id = ?`, attachmentID, mutation.MemoID).Scan(&exists); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return errors.Wrap(store.ErrMemoAttachmentConflict, "a referenced attachment is no longer bound to the memo")
+				return errors.Wrap(store.ErrMemoMutationConflict, "a referenced attachment is no longer bound to the memo")
 			}
 			return errors.Wrap(err, "failed to verify referenced attachment")
 		}
@@ -82,8 +82,32 @@ func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.Me
 			return err
 		}
 	}
+	if mutation.ReplaceReferenceRelations {
+		if err := replaceMemoReferenceRelations(ctx, tx, mutation.MemoID, mutation.ReferenceRelations); err != nil {
+			return err
+		}
+	}
 	if err := tx.Commit(); err != nil {
-		return errors.Wrap(err, "failed to commit memo attachment transaction")
+		return errors.Wrap(err, "failed to commit memo transaction")
+	}
+	return nil
+}
+
+func replaceMemoReferenceRelations(ctx context.Context, tx *sql.Tx, memoID int32, relations []*store.MemoRelation) error {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM memo_relation WHERE memo_id = ? AND type = ?`, memoID, store.MemoRelationReference); err != nil {
+		return errors.Wrap(err, "failed to delete memo reference relations")
+	}
+	for _, relation := range relations {
+		if relation == nil || relation.MemoID != memoID || relation.Type != store.MemoRelationReference {
+			return errors.New("invalid memo reference relation mutation")
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO memo_relation (memo_id, related_memo_id, type)
+			VALUES (?, ?, ?)
+			ON CONFLICT(memo_id, related_memo_id, type) DO UPDATE SET type = excluded.type
+		`, relation.MemoID, relation.RelatedMemoID, relation.Type); err != nil {
+			return errors.Wrap(err, "failed to insert memo reference relation")
+		}
 	}
 	return nil
 }

--- a/store/db/sqlite/memo_attachment.go
+++ b/store/db/sqlite/memo_attachment.go
@@ -1,0 +1,133 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/usememos/memos/store"
+)
+
+// ApplyMemoAttachmentMutation atomically updates a memo and its attachment bindings.
+func (d *DB) ApplyMemoAttachmentMutation(ctx context.Context, mutation *store.MemoAttachmentMutation) error {
+	tx, err := d.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return errors.Wrap(err, "failed to begin memo attachment transaction")
+	}
+	defer func() {
+		_ = tx.Rollback()
+	}()
+
+	var creatorID int32
+	var content string
+	if err := tx.QueryRowContext(ctx, `SELECT creator_id, content FROM memo WHERE id = ?`, mutation.MemoID).Scan(&creatorID, &content); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return errors.Wrap(store.ErrMemoAttachmentConflict, "memo no longer exists")
+		}
+		return errors.Wrap(err, "failed to lock memo")
+	}
+	if creatorID != mutation.MemoCreatorID || content != mutation.ExpectedMemoContent {
+		return errors.Wrap(store.ErrMemoAttachmentConflict, "memo changed while updating attachments")
+	}
+
+	for _, binding := range mutation.Bindings {
+		var attachmentCreatorID int32
+		var memoID sql.NullInt32
+		if err := tx.QueryRowContext(ctx, `SELECT creator_id, memo_id FROM attachment WHERE id = ?`, binding.ID).Scan(&attachmentCreatorID, &memoID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s no longer exists", binding.UID)
+			}
+			return errors.Wrap(err, "failed to lock attachment")
+		}
+		if binding.WasBoundToMemo {
+			if !memoID.Valid || memoID.Int32 != mutation.MemoID {
+				return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s is no longer bound to the memo", binding.UID)
+			}
+		} else if attachmentCreatorID != mutation.MemoCreatorID || memoID.Valid {
+			return errors.Wrapf(store.ErrMemoAttachmentConflict, "attachment %s is no longer available", binding.UID)
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE attachment SET memo_id = ?, updated_ts = ? WHERE id = ?`, mutation.MemoID, binding.UpdatedTs, binding.ID); err != nil {
+			return errors.Wrap(err, "failed to bind attachment")
+		}
+	}
+
+	for _, attachmentID := range mutation.RemovedAttachmentIDs {
+		result, err := tx.ExecContext(ctx, `UPDATE attachment SET memo_id = NULL WHERE id = ? AND memo_id = ?`, attachmentID, mutation.MemoID)
+		if err != nil {
+			return errors.Wrap(err, "failed to detach attachment")
+		}
+		if rows, err := result.RowsAffected(); err != nil || rows != 1 {
+			return errors.Wrap(store.ErrMemoAttachmentConflict, "attachment is no longer bound to the memo")
+		}
+	}
+
+	for _, attachmentID := range mutation.RequiredAttachmentIDs {
+		var exists int
+		if err := tx.QueryRowContext(ctx, `SELECT 1 FROM attachment WHERE id = ? AND memo_id = ?`, attachmentID, mutation.MemoID).Scan(&exists); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return errors.Wrap(store.ErrMemoAttachmentConflict, "a referenced attachment is no longer bound to the memo")
+			}
+			return errors.Wrap(err, "failed to verify referenced attachment")
+		}
+	}
+
+	if mutation.MemoUpdate != nil {
+		if mutation.MemoUpdate.ID != mutation.MemoID {
+			return errors.New("memo update target does not match attachment mutation")
+		}
+		if err := applyMemoUpdate(ctx, tx, mutation.MemoUpdate); err != nil {
+			return err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return errors.Wrap(err, "failed to commit memo attachment transaction")
+	}
+	return nil
+}
+
+type memoUpdateExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func applyMemoUpdate(ctx context.Context, executor memoUpdateExecer, update *store.UpdateMemo) error {
+	set, args := []string{}, []any{}
+	if v := update.UID; v != nil {
+		set, args = append(set, "`uid` = ?"), append(args, *v)
+	}
+	if v := update.CreatedTs; v != nil {
+		set, args = append(set, "`created_ts` = ?"), append(args, *v)
+	}
+	if v := update.UpdatedTs; v != nil {
+		set, args = append(set, "`updated_ts` = ?"), append(args, *v)
+	}
+	if v := update.RowStatus; v != nil {
+		set, args = append(set, "`row_status` = ?"), append(args, *v)
+	}
+	if v := update.Content; v != nil {
+		set, args = append(set, "`content` = ?"), append(args, *v)
+	}
+	if v := update.Visibility; v != nil {
+		set, args = append(set, "`visibility` = ?"), append(args, *v)
+	}
+	if v := update.Pinned; v != nil {
+		set, args = append(set, "`pinned` = ?"), append(args, *v)
+	}
+	if v := update.Payload; v != nil {
+		payload, err := protojson.Marshal(v)
+		if err != nil {
+			return errors.Wrap(err, "failed to marshal memo payload")
+		}
+		set, args = append(set, "`payload` = ?"), append(args, string(payload))
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	args = append(args, update.ID)
+	if _, err := executor.ExecContext(ctx, "UPDATE `memo` SET "+strings.Join(set, ", ")+" WHERE `id` = ?", args...); err != nil {
+		return errors.Wrap(err, "failed to update memo")
+	}
+	return nil
+}

--- a/store/db/sqlite/memo_relation.go
+++ b/store/db/sqlite/memo_relation.go
@@ -77,6 +77,10 @@ func (d *DB) ListMemoRelations(ctx context.Context, find *store.FindMemoRelation
 		}
 		where = append(where, fmt.Sprintf("related_memo_id IN (%s)", strings.Join(placeholders, ", ")))
 	}
+	if find.SourceMemoRowStatus != nil {
+		where = append(where, "memo_id IN (SELECT id FROM memo WHERE row_status = ?)")
+		args = append(args, *find.SourceMemoRowStatus)
+	}
 	if find.MemoFilter != nil {
 		engine, err := filter.DefaultEngine()
 		if err != nil {

--- a/store/driver.go
+++ b/store/driver.go
@@ -24,7 +24,7 @@ type Driver interface {
 	UpdateAttachment(ctx context.Context, update *UpdateAttachment) error
 	DeleteAttachment(ctx context.Context, delete *DeleteAttachment) error
 	DeleteAttachments(ctx context.Context, deletes []*DeleteAttachment) error
-	ApplyMemoAttachmentMutation(ctx context.Context, mutation *MemoAttachmentMutation) error
+	ApplyMemoMutation(ctx context.Context, mutation *MemoMutation) error
 
 	// Memo model related methods.
 	CreateMemo(ctx context.Context, create *Memo) (*Memo, error)

--- a/store/driver.go
+++ b/store/driver.go
@@ -24,6 +24,7 @@ type Driver interface {
 	UpdateAttachment(ctx context.Context, update *UpdateAttachment) error
 	DeleteAttachment(ctx context.Context, delete *DeleteAttachment) error
 	DeleteAttachments(ctx context.Context, deletes []*DeleteAttachment) error
+	ApplyMemoAttachmentMutation(ctx context.Context, mutation *MemoAttachmentMutation) error
 
 	// Memo model related methods.
 	CreateMemo(ctx context.Context, create *Memo) (*Memo, error)

--- a/store/memo_attachment.go
+++ b/store/memo_attachment.go
@@ -1,0 +1,43 @@
+package store
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrMemoAttachmentConflict indicates that memo or attachment state changed
+// after an API request prepared its mutation.
+var ErrMemoAttachmentConflict = errors.New("memo attachment state changed")
+
+// MemoAttachmentBinding describes one attachment that should be bound to a
+// memo. WasBoundToMemo distinguishes an existing binding from a new one so the
+// driver can reject ownership transfers while preserving legacy rows already
+// attached to the memo.
+type MemoAttachmentBinding struct {
+	ID             int32
+	UID            string
+	UpdatedTs      int64
+	WasBoundToMemo bool
+}
+
+// MemoAttachmentMutation atomically updates a memo and its attachment
+// bindings. Removed attachment rows are detached in the transaction and are
+// deleted from storage separately, so a storage failure remains retriable.
+type MemoAttachmentMutation struct {
+	MemoID                int32
+	MemoCreatorID         int32
+	ExpectedMemoContent   string
+	MemoUpdate            *UpdateMemo
+	Bindings              []*MemoAttachmentBinding
+	RemovedAttachmentIDs  []int32
+	RequiredAttachmentIDs []int32
+}
+
+// ApplyMemoAttachmentMutation atomically applies memo fields and attachment
+// binding changes after rechecking the state used by API validation.
+func (s *Store) ApplyMemoAttachmentMutation(ctx context.Context, mutation *MemoAttachmentMutation) error {
+	if mutation == nil {
+		return errors.New("memo attachment mutation is required")
+	}
+	return s.driver.ApplyMemoAttachmentMutation(ctx, mutation)
+}

--- a/store/memo_attachment.go
+++ b/store/memo_attachment.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 )
 
-// ErrMemoAttachmentConflict indicates that memo or attachment state changed
+// ErrMemoMutationConflict indicates that memo or attachment state changed
 // after an API request prepared its mutation.
-var ErrMemoAttachmentConflict = errors.New("memo attachment state changed")
+var ErrMemoMutationConflict = errors.New("memo state changed")
 
 // MemoAttachmentBinding describes one attachment that should be bound to a
 // memo. WasBoundToMemo distinguishes an existing binding from a new one so the
@@ -20,24 +20,27 @@ type MemoAttachmentBinding struct {
 	WasBoundToMemo bool
 }
 
-// MemoAttachmentMutation atomically updates a memo and its attachment
-// bindings. Removed attachment rows are detached in the transaction and are
-// deleted from storage separately, so a storage failure remains retriable.
-type MemoAttachmentMutation struct {
-	MemoID                int32
-	MemoCreatorID         int32
-	ExpectedMemoContent   string
-	MemoUpdate            *UpdateMemo
-	Bindings              []*MemoAttachmentBinding
-	RemovedAttachmentIDs  []int32
-	RequiredAttachmentIDs []int32
+// MemoMutation atomically updates a memo, its attachment bindings, and its
+// reference relations. Removed attachment rows are detached in the transaction
+// and are deleted from storage separately, so a storage failure remains
+// retriable.
+type MemoMutation struct {
+	MemoID                    int32
+	MemoCreatorID             int32
+	ExpectedMemoContent       string
+	MemoUpdate                *UpdateMemo
+	Bindings                  []*MemoAttachmentBinding
+	RemovedAttachmentIDs      []int32
+	RequiredAttachmentIDs     []int32
+	ReplaceReferenceRelations bool
+	ReferenceRelations        []*MemoRelation
 }
 
-// ApplyMemoAttachmentMutation atomically applies memo fields and attachment
-// binding changes after rechecking the state used by API validation.
-func (s *Store) ApplyMemoAttachmentMutation(ctx context.Context, mutation *MemoAttachmentMutation) error {
+// ApplyMemoMutation atomically applies memo fields, attachment bindings, and
+// reference relations after rechecking the state used by API validation.
+func (s *Store) ApplyMemoMutation(ctx context.Context, mutation *MemoMutation) error {
 	if mutation == nil {
-		return errors.New("memo attachment mutation is required")
+		return errors.New("memo mutation is required")
 	}
-	return s.driver.ApplyMemoAttachmentMutation(ctx, mutation)
+	return s.driver.ApplyMemoMutation(ctx, mutation)
 }

--- a/store/memo_relation.go
+++ b/store/memo_relation.go
@@ -24,6 +24,8 @@ type FindMemoRelation struct {
 	RelatedMemoID *int32
 	Type          *MemoRelationType
 	MemoFilter    *string
+	// SourceMemoRowStatus filters the relation source memo before pagination.
+	SourceMemoRowStatus *RowStatus
 	// MemoIDList matches relations where memo_id OR related_memo_id is in the list.
 	MemoIDList []int32
 	// SourceMemoIDList matches relations where memo_id is in the list.

--- a/store/test/attachment_test.go
+++ b/store/test/attachment_test.go
@@ -123,7 +123,7 @@ func TestAttachmentStore(t *testing.T) {
 	ts.Close()
 }
 
-func TestMemoAttachmentMutationRollsBackOnBindingConflict(t *testing.T) {
+func TestMemoMutationRollsBackOnBindingConflict(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	ts := NewTestingStore(ctx, t)
@@ -161,7 +161,7 @@ func TestMemoAttachmentMutationRollsBackOnBindingConflict(t *testing.T) {
 	require.NoError(t, err)
 
 	updatedContent := "updated"
-	err = ts.ApplyMemoAttachmentMutation(ctx, &store.MemoAttachmentMutation{
+	err = ts.ApplyMemoMutation(ctx, &store.MemoMutation{
 		MemoID:              memo.ID,
 		MemoCreatorID:       user.ID,
 		ExpectedMemoContent: memo.Content,
@@ -171,7 +171,7 @@ func TestMemoAttachmentMutationRollsBackOnBindingConflict(t *testing.T) {
 			{ID: conflicting.ID, UID: conflicting.UID, UpdatedTs: time.Now().Unix() + 1},
 		},
 	})
-	require.ErrorIs(t, err, store.ErrMemoAttachmentConflict)
+	require.ErrorIs(t, err, store.ErrMemoMutationConflict)
 
 	storedMemo, err := ts.GetMemo(ctx, &store.FindMemo{ID: &memo.ID})
 	require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestMemoAttachmentMutationRollsBackOnBindingConflict(t *testing.T) {
 	require.Equal(t, otherMemo.ID, *storedConflicting.MemoID)
 }
 
-func TestMemoAttachmentMutationUpdatesMemoAndBindingsTogether(t *testing.T) {
+func TestMemoMutationUpdatesMemoAndBindingsTogether(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	ts := NewTestingStore(ctx, t)
@@ -204,7 +204,7 @@ func TestMemoAttachmentMutationUpdatesMemoAndBindingsTogether(t *testing.T) {
 	require.NoError(t, err)
 
 	updatedContent := "new"
-	err = ts.ApplyMemoAttachmentMutation(ctx, &store.MemoAttachmentMutation{
+	err = ts.ApplyMemoMutation(ctx, &store.MemoMutation{
 		MemoID:              memo.ID,
 		MemoCreatorID:       user.ID,
 		ExpectedMemoContent: memo.Content,
@@ -229,7 +229,7 @@ func TestMemoAttachmentMutationUpdatesMemoAndBindingsTogether(t *testing.T) {
 	require.Nil(t, storedRemoved.MemoID)
 }
 
-func TestMemoAttachmentMutationRollsBackWhenRequiredAttachmentIsMissing(t *testing.T) {
+func TestMemoMutationRollsBackWhenRequiredAttachmentIsMissing(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	ts := NewTestingStore(ctx, t)
@@ -248,7 +248,7 @@ func TestMemoAttachmentMutationRollsBackWhenRequiredAttachmentIsMissing(t *testi
 	require.NoError(t, err)
 
 	updatedContent := "new"
-	err = ts.ApplyMemoAttachmentMutation(ctx, &store.MemoAttachmentMutation{
+	err = ts.ApplyMemoMutation(ctx, &store.MemoMutation{
 		MemoID:              memo.ID,
 		MemoCreatorID:       user.ID,
 		ExpectedMemoContent: memo.Content,
@@ -259,7 +259,7 @@ func TestMemoAttachmentMutationRollsBackWhenRequiredAttachmentIsMissing(t *testi
 		RemovedAttachmentIDs:  []int32{removed.ID},
 		RequiredAttachmentIDs: []int32{added.ID + removed.ID + 1000},
 	})
-	require.ErrorIs(t, err, store.ErrMemoAttachmentConflict)
+	require.ErrorIs(t, err, store.ErrMemoMutationConflict)
 
 	storedMemo, err := ts.GetMemo(ctx, &store.FindMemo{ID: &memo.ID})
 	require.NoError(t, err)
@@ -271,6 +271,48 @@ func TestMemoAttachmentMutationRollsBackWhenRequiredAttachmentIsMissing(t *testi
 	require.NoError(t, err)
 	require.NotNil(t, storedRemoved.MemoID)
 	require.Equal(t, memo.ID, *storedRemoved.MemoID)
+}
+
+func TestMemoMutationRollsBackMemoAndRelationsTogether(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ts := NewTestingStore(ctx, t)
+	defer ts.Close()
+	user, err := createTestingHostUser(ctx, ts)
+	require.NoError(t, err)
+	source, err := ts.CreateMemo(ctx, &store.Memo{UID: shortuuid.New(), CreatorID: user.ID, Content: "original", Visibility: store.Private})
+	require.NoError(t, err)
+	originalTarget, err := ts.CreateMemo(ctx, &store.Memo{UID: shortuuid.New(), CreatorID: user.ID, Content: "original target", Visibility: store.Private})
+	require.NoError(t, err)
+	replacementTarget, err := ts.CreateMemo(ctx, &store.Memo{UID: shortuuid.New(), CreatorID: user.ID, Content: "replacement target", Visibility: store.Private})
+	require.NoError(t, err)
+	_, err = ts.UpsertMemoRelation(ctx, &store.MemoRelation{
+		MemoID: source.ID, RelatedMemoID: originalTarget.ID, Type: store.MemoRelationReference,
+	})
+	require.NoError(t, err)
+
+	updatedContent := "must roll back"
+	err = ts.ApplyMemoMutation(ctx, &store.MemoMutation{
+		MemoID:                    source.ID,
+		MemoCreatorID:             user.ID,
+		ExpectedMemoContent:       source.Content,
+		MemoUpdate:                &store.UpdateMemo{ID: source.ID, Content: &updatedContent},
+		ReplaceReferenceRelations: true,
+		ReferenceRelations: []*store.MemoRelation{
+			{MemoID: source.ID, RelatedMemoID: replacementTarget.ID, Type: store.MemoRelationReference},
+			{MemoID: source.ID, RelatedMemoID: originalTarget.ID, Type: store.MemoRelationComment},
+		},
+	})
+	require.Error(t, err)
+
+	stored, err := ts.GetMemo(ctx, &store.FindMemo{ID: &source.ID})
+	require.NoError(t, err)
+	require.Equal(t, "original", stored.Content)
+	referenceType := store.MemoRelationReference
+	relations, err := ts.ListMemoRelations(ctx, &store.FindMemoRelation{MemoID: &source.ID, Type: &referenceType})
+	require.NoError(t, err)
+	require.Len(t, relations, 1)
+	require.Equal(t, originalTarget.ID, relations[0].RelatedMemoID)
 }
 
 func TestAttachmentStoreWithFilter(t *testing.T) {

--- a/store/test/attachment_test.go
+++ b/store/test/attachment_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/lithammer/shortuuid/v4"
 	"github.com/stretchr/testify/require"
@@ -120,6 +121,156 @@ func TestAttachmentStore(t *testing.T) {
 	})
 	require.ErrorContains(t, err, "attachment not found")
 	ts.Close()
+}
+
+func TestMemoAttachmentMutationRollsBackOnBindingConflict(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ts := NewTestingStore(ctx, t)
+	defer ts.Close()
+	user, err := createTestingHostUser(ctx, ts)
+	require.NoError(t, err)
+	memo, err := ts.CreateMemo(ctx, &store.Memo{
+		UID:        shortuuid.New(),
+		CreatorID:  user.ID,
+		Content:    "original",
+		Visibility: store.Private,
+	})
+	require.NoError(t, err)
+	otherMemo, err := ts.CreateMemo(ctx, &store.Memo{
+		UID:        shortuuid.New(),
+		CreatorID:  user.ID,
+		Content:    "other",
+		Visibility: store.Private,
+	})
+	require.NoError(t, err)
+	available, err := ts.CreateAttachment(ctx, &store.Attachment{
+		UID:       shortuuid.New(),
+		CreatorID: user.ID,
+		Filename:  "available.png",
+		Type:      "image/png",
+	})
+	require.NoError(t, err)
+	conflicting, err := ts.CreateAttachment(ctx, &store.Attachment{
+		UID:       shortuuid.New(),
+		CreatorID: user.ID,
+		Filename:  "conflicting.png",
+		Type:      "image/png",
+		MemoID:    &otherMemo.ID,
+	})
+	require.NoError(t, err)
+
+	updatedContent := "updated"
+	err = ts.ApplyMemoAttachmentMutation(ctx, &store.MemoAttachmentMutation{
+		MemoID:              memo.ID,
+		MemoCreatorID:       user.ID,
+		ExpectedMemoContent: memo.Content,
+		MemoUpdate:          &store.UpdateMemo{ID: memo.ID, Content: &updatedContent},
+		Bindings: []*store.MemoAttachmentBinding{
+			{ID: available.ID, UID: available.UID, UpdatedTs: time.Now().Unix()},
+			{ID: conflicting.ID, UID: conflicting.UID, UpdatedTs: time.Now().Unix() + 1},
+		},
+	})
+	require.ErrorIs(t, err, store.ErrMemoAttachmentConflict)
+
+	storedMemo, err := ts.GetMemo(ctx, &store.FindMemo{ID: &memo.ID})
+	require.NoError(t, err)
+	require.Equal(t, "original", storedMemo.Content)
+	storedAvailable, err := ts.GetAttachment(ctx, &store.FindAttachment{ID: &available.ID})
+	require.NoError(t, err)
+	require.Nil(t, storedAvailable.MemoID)
+	storedConflicting, err := ts.GetAttachment(ctx, &store.FindAttachment{ID: &conflicting.ID})
+	require.NoError(t, err)
+	require.NotNil(t, storedConflicting.MemoID)
+	require.Equal(t, otherMemo.ID, *storedConflicting.MemoID)
+}
+
+func TestMemoAttachmentMutationUpdatesMemoAndBindingsTogether(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ts := NewTestingStore(ctx, t)
+	defer ts.Close()
+	user, err := createTestingHostUser(ctx, ts)
+	require.NoError(t, err)
+	memo, err := ts.CreateMemo(ctx, &store.Memo{UID: shortuuid.New(), CreatorID: user.ID, Content: "old", Visibility: store.Private})
+	require.NoError(t, err)
+	removed, err := ts.CreateAttachment(ctx, &store.Attachment{
+		UID: shortuuid.New(), CreatorID: user.ID, Filename: "removed.png", Type: "image/png", MemoID: &memo.ID,
+	})
+	require.NoError(t, err)
+	added, err := ts.CreateAttachment(ctx, &store.Attachment{
+		UID: shortuuid.New(), CreatorID: user.ID, Filename: "added.png", Type: "image/png",
+	})
+	require.NoError(t, err)
+
+	updatedContent := "new"
+	err = ts.ApplyMemoAttachmentMutation(ctx, &store.MemoAttachmentMutation{
+		MemoID:              memo.ID,
+		MemoCreatorID:       user.ID,
+		ExpectedMemoContent: memo.Content,
+		MemoUpdate:          &store.UpdateMemo{ID: memo.ID, Content: &updatedContent},
+		Bindings: []*store.MemoAttachmentBinding{
+			{ID: added.ID, UID: added.UID, UpdatedTs: time.Now().Unix()},
+		},
+		RemovedAttachmentIDs:  []int32{removed.ID},
+		RequiredAttachmentIDs: []int32{added.ID},
+	})
+	require.NoError(t, err)
+
+	storedMemo, err := ts.GetMemo(ctx, &store.FindMemo{ID: &memo.ID})
+	require.NoError(t, err)
+	require.Equal(t, "new", storedMemo.Content)
+	storedAdded, err := ts.GetAttachment(ctx, &store.FindAttachment{ID: &added.ID})
+	require.NoError(t, err)
+	require.NotNil(t, storedAdded.MemoID)
+	require.Equal(t, memo.ID, *storedAdded.MemoID)
+	storedRemoved, err := ts.GetAttachment(ctx, &store.FindAttachment{ID: &removed.ID})
+	require.NoError(t, err)
+	require.Nil(t, storedRemoved.MemoID)
+}
+
+func TestMemoAttachmentMutationRollsBackWhenRequiredAttachmentIsMissing(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ts := NewTestingStore(ctx, t)
+	defer ts.Close()
+	user, err := createTestingHostUser(ctx, ts)
+	require.NoError(t, err)
+	memo, err := ts.CreateMemo(ctx, &store.Memo{UID: shortuuid.New(), CreatorID: user.ID, Content: "old", Visibility: store.Private})
+	require.NoError(t, err)
+	removed, err := ts.CreateAttachment(ctx, &store.Attachment{
+		UID: shortuuid.New(), CreatorID: user.ID, Filename: "kept.png", Type: "image/png", MemoID: &memo.ID,
+	})
+	require.NoError(t, err)
+	added, err := ts.CreateAttachment(ctx, &store.Attachment{
+		UID: shortuuid.New(), CreatorID: user.ID, Filename: "rolled-back.png", Type: "image/png",
+	})
+	require.NoError(t, err)
+
+	updatedContent := "new"
+	err = ts.ApplyMemoAttachmentMutation(ctx, &store.MemoAttachmentMutation{
+		MemoID:              memo.ID,
+		MemoCreatorID:       user.ID,
+		ExpectedMemoContent: memo.Content,
+		MemoUpdate:          &store.UpdateMemo{ID: memo.ID, Content: &updatedContent},
+		Bindings: []*store.MemoAttachmentBinding{
+			{ID: added.ID, UID: added.UID, UpdatedTs: time.Now().Unix()},
+		},
+		RemovedAttachmentIDs:  []int32{removed.ID},
+		RequiredAttachmentIDs: []int32{added.ID + removed.ID + 1000},
+	})
+	require.ErrorIs(t, err, store.ErrMemoAttachmentConflict)
+
+	storedMemo, err := ts.GetMemo(ctx, &store.FindMemo{ID: &memo.ID})
+	require.NoError(t, err)
+	require.Equal(t, "old", storedMemo.Content)
+	storedAdded, err := ts.GetAttachment(ctx, &store.FindAttachment{ID: &added.ID})
+	require.NoError(t, err)
+	require.Nil(t, storedAdded.MemoID)
+	storedRemoved, err := ts.GetAttachment(ctx, &store.FindAttachment{ID: &removed.ID})
+	require.NoError(t, err)
+	require.NotNil(t, storedRemoved.MemoID)
+	require.Equal(t, memo.ID, *storedRemoved.MemoID)
 }
 
 func TestAttachmentStoreWithFilter(t *testing.T) {

--- a/store/test/memo_relation_test.go
+++ b/store/test/memo_relation_test.go
@@ -944,3 +944,37 @@ func TestMemoRelationMultipleRelationsToSameMemo(t *testing.T) {
 
 	ts.Close()
 }
+
+func TestMemoRelationFiltersSourceStatusBeforePagination(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	ts := NewTestingStore(ctx, t)
+	defer ts.Close()
+	user, err := createTestingHostUser(ctx, ts)
+	require.NoError(t, err)
+	parent, err := ts.CreateMemo(ctx, &store.Memo{UID: "status-parent", CreatorID: user.ID, Content: "parent", Visibility: store.Public})
+	require.NoError(t, err)
+	normalMemo, err := ts.CreateMemo(ctx, &store.Memo{UID: "status-normal", CreatorID: user.ID, Content: "normal", Visibility: store.Public})
+	require.NoError(t, err)
+	archivedMemo, err := ts.CreateMemo(ctx, &store.Memo{UID: "status-archived", CreatorID: user.ID, Content: "archived", Visibility: store.Public})
+	require.NoError(t, err)
+	archived := store.Archived
+	require.NoError(t, ts.UpdateMemo(ctx, &store.UpdateMemo{ID: archivedMemo.ID, RowStatus: &archived}))
+	for _, memoID := range []int32{normalMemo.ID, archivedMemo.ID} {
+		_, err := ts.UpsertMemoRelation(ctx, &store.MemoRelation{MemoID: memoID, RelatedMemoID: parent.ID, Type: store.MemoRelationComment})
+		require.NoError(t, err)
+	}
+
+	normal := store.Normal
+	commentType := store.MemoRelationComment
+	limit := 1
+	relations, err := ts.ListMemoRelations(ctx, &store.FindMemoRelation{
+		RelatedMemoID:       &parent.ID,
+		Type:                &commentType,
+		SourceMemoRowStatus: &normal,
+		Limit:               &limit,
+	})
+	require.NoError(t, err)
+	require.Len(t, relations, 1)
+	require.Equal(t, normalMemo.ID, relations[0].MemoID)
+}


### PR DESCRIPTION
## Summary

- validate same-origin Markdown image references against memo attachment bindings
- enforce memo-derived visibility across attachment APIs, file serving, comments, shares, and RSS
- update memo relations and attachment bindings atomically across SQLite, MySQL, and PostgreSQL
- cover ownership, reparenting, visibility, cache, rollback, and malformed-reference edge cases

## Compatibility notes

- clients adding a managed image reference must bind the attachment in the same memo mutation or bind it beforehand
- custom out-of-tree `store.Driver` implementations must implement the new attachment mutation method
- S3 attachments no longer expose a presigned URL through `external_link`; clients should use the attachment file route
- admin access to another user’s private memo attachments is now denied consistently with memo read access
- legacy comment share links and archived memo share links are no longer readable

## Verification

- `go test ./...`
- `go test -race ./server/...`
- `golangci-lint run`
- `git diff --check`