### PR TITLE
fix(i18n): correct French memo link label

### DIFF
--- a/web/src/locales/fr.json
+++ b/web/src/locales/fr.json
@@ -128,7 +128,7 @@
     "focus-mode": "Mode concentration",
     "insert-menu": {
       "add-location": "Ajouter un emplacement",
-      "link-memo": "Mémo de lien",
+      "link-memo": "Lien vers un mémo",
       "upload-file": "Télécharger le fichier"
     },
     "no-changes-detected": "Aucun changement détecté",


### PR DESCRIPTION
﻿## What changed

- Correct the French label for the memo-link action from `Mémo de lien` to `Lien vers un mémo`.

## Why

The previous wording is not idiomatic French and does not convey the intended action clearly. The new label matches the wording requested in #6179.

## Validation

- Parsed `web/src/locales/fr.json` successfully as JSON.
- Verified the branch changes only one translation line in one file.

Fixes #6179
