### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/internal/markdown/parser/tagdata/main.go
+++ b/internal/markdown/parser/tagdata/main.go
@@ -206,7 +206,7 @@ func parseFullyQualifiedEmoji(data []byte) ([]string, int) {
 			continue
 		}
 		var sequence strings.Builder
-		for _, field := range strings.Fields(fields[0]) {
+		for field := range strings.FieldsSeq(fields[0]) {
 			sequence.WriteRune(parseCodePoint(field))
 		}
 		emoji := sequence.String()

--- a/server/router/api/v1/auth_service_client_info_test.go
+++ b/server/router/api/v1/auth_service_client_info_test.go
@@ -219,7 +219,7 @@ func testCookieExpiry() time.Time {
 }
 
 func containsCookieAttribute(cookie, attr string) bool {
-	for _, part := range strings.Split(cookie, ";") {
+	for part := range strings.SplitSeq(cookie, ";") {
 		if strings.EqualFold(strings.TrimSpace(part), attr) {
 			return true
 		}

--- a/server/router/api/v1/auth_service_session.go
+++ b/server/router/api/v1/auth_service_session.go
@@ -198,7 +198,7 @@ func isSecureRequest(ctx context.Context) bool {
 	}
 
 	for _, value := range md.Get("x-forwarded-proto") {
-		for _, proto := range strings.Split(value, ",") {
+		for proto := range strings.SplitSeq(value, ",") {
 			if strings.EqualFold(strings.TrimSpace(proto), "https") {
 				return true
 			}

--- a/server/router/api/v1/gateway_route_resolver_test.go
+++ b/server/router/api/v1/gateway_route_resolver_test.go
@@ -306,7 +306,7 @@ func synthesizeGatewayVariable(segment string) []string {
 	}
 
 	var built []string
-	for _, part := range strings.Split(subtemplate, "/") {
+	for part := range strings.SplitSeq(subtemplate, "/") {
 		switch part {
 		case "*":
 			built = append(built, "one")


### PR DESCRIPTION
strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901