### PR TITLE
fix add toggle calendar function

### DIFF
--- a/web/src/components/StatisticsView/MonthNavigator.tsx
+++ b/web/src/components/StatisticsView/MonthNavigator.tsx
@@ -21,18 +21,25 @@ export const MonthNavigator = memo(({ visibleMonth, onMonthChange, collapsed, on
 
   return (
     <header className={cn(SIDEBAR_ROW_BOX_CLASSES, "mb-1.5 justify-between px-0")}>
-      <button
-        type="button"
-        onClick={onToggleCollapsed}
-        aria-expanded={!collapsed}
-        className="flex min-w-0 items-center gap-1 rounded-md py-0.5 pr-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-      >
-        <ChevronDownIcon
-          className={cn("size-3.5 shrink-0 text-muted-foreground/60 transition-transform duration-200", collapsed && "-rotate-90")}
-          strokeWidth={1.8}
-        />
-        <h2 className="min-w-0 truncate font-medium tracking-[-0.015em] text-foreground/90 select-none">{monthLabel}</h2>
-      </button>
+      <h2 className="min-w-0">
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          aria-expanded={!collapsed}
+          className="flex min-w-0 items-center gap-1 rounded-md py-0.5 pr-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        >
+          <ChevronDownIcon
+            className={cn(
+              "size-3.5 shrink-0 text-muted-foreground/60 transition-transform duration-200",
+              collapsed && "-rotate-90",
+            )}
+            strokeWidth={1.8}
+          />
+          <span className="min-w-0 truncate font-medium tracking-[-0.015em] text-foreground/90 select-none">
+            {monthLabel}
+          </span>
+        </button>
+      </h2>
 
       {!collapsed && (
         <nav className="flex shrink-0 items-center gap-0.5" aria-label={t("common.month-navigation")}>

--- a/web/src/components/StatisticsView/MonthNavigator.tsx
+++ b/web/src/components/StatisticsView/MonthNavigator.tsx
@@ -1,5 +1,5 @@
 import dayjs from "dayjs";
-import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import { SIDEBAR_ROW_BOX_CLASSES } from "@/components/AppSidebar/SidebarRow";
@@ -8,37 +8,55 @@ import { addMonths } from "@/lib/calendar-utils";
 import { cn } from "@/lib/utils";
 import type { MonthNavigatorProps } from "@/types/statistics";
 
-export const MonthNavigator = memo(({ visibleMonth, onMonthChange }: MonthNavigatorProps) => {
+interface Props extends MonthNavigatorProps {
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+}
+
+export const MonthNavigator = memo(({ visibleMonth, onMonthChange, collapsed, onToggleCollapsed }: Props) => {
   const { i18n, t } = useTranslation();
   const monthLabel = dayjs(visibleMonth).toDate().toLocaleString(i18n.language, { year: "numeric", month: "long" });
   const handlePrevMonth = () => onMonthChange(addMonths(visibleMonth, -1));
   const handleNextMonth = () => onMonthChange(addMonths(visibleMonth, 1));
 
   return (
-    <header className={cn(SIDEBAR_ROW_BOX_CLASSES, "mb-1.5 justify-between")}>
-      <h2 className="min-w-0 truncate font-medium tracking-[-0.015em] text-foreground/90 select-none">{monthLabel}</h2>
+    <header className={cn(SIDEBAR_ROW_BOX_CLASSES, "mb-1.5 justify-between px-0")}>
+      <button
+        type="button"
+        onClick={onToggleCollapsed}
+        aria-expanded={!collapsed}
+        className="flex min-w-0 items-center gap-1 rounded-md py-0.5 pr-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      >
+        <ChevronDownIcon
+          className={cn("size-3.5 shrink-0 text-muted-foreground/60 transition-transform duration-200", collapsed && "-rotate-90")}
+          strokeWidth={1.8}
+        />
+        <h2 className="min-w-0 truncate font-medium tracking-[-0.015em] text-foreground/90 select-none">{monthLabel}</h2>
+      </button>
 
-      <nav className="flex shrink-0 items-center gap-0.5" aria-label={t("common.month-navigation")}>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={handlePrevMonth}
-          aria-label={t("common.previous-month")}
-          className="size-6 rounded text-muted-foreground/65 hover:bg-muted/50 hover:text-foreground/90"
-        >
-          <ChevronLeftIcon className="size-4" strokeWidth={1.75} />
-        </Button>
+      {!collapsed && (
+        <nav className="flex shrink-0 items-center gap-0.5" aria-label={t("common.month-navigation")}>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={handlePrevMonth}
+            aria-label={t("common.previous-month")}
+            className="size-6 rounded text-muted-foreground/65 hover:bg-muted/50 hover:text-foreground/90"
+          >
+            <ChevronLeftIcon className="size-4" strokeWidth={1.75} />
+          </Button>
 
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={handleNextMonth}
-          aria-label={t("common.next-month")}
-          className="size-6 rounded text-muted-foreground/65 hover:bg-muted/50 hover:text-foreground/90"
-        >
-          <ChevronRightIcon className="size-4" strokeWidth={1.75} />
-        </Button>
-      </nav>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleNextMonth}
+            aria-label={t("common.next-month")}
+            className="size-6 rounded text-muted-foreground/65 hover:bg-muted/50 hover:text-foreground/90"
+          >
+            <ChevronRightIcon className="size-4" strokeWidth={1.75} />
+          </Button>
+        </nav>
+      )}
     </header>
   );
 });

--- a/web/src/components/StatisticsView/StatisticsView.tsx
+++ b/web/src/components/StatisticsView/StatisticsView.tsx
@@ -36,7 +36,15 @@ const StatisticsView = (props: Props) => {
 
       {/* Grid-rows trick: animates height without measuring it, and collapses to zero
           without unmounting the calendar (keeps its internal state across toggles). */}
-      <div className={cn("grid transition-[grid-template-rows] duration-200 ease-out", collapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]")}>
+      <div
+        className={cn(
+          "grid transition-[grid-template-rows] duration-200 ease-out",
+          collapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]",
+        )}
+        aria-hidden={collapsed}
+        // @ts-expect-error inert is a valid HTML attribute but not yet in all React types
+        inert={collapsed ? "" : undefined}
+      >
         <div className="overflow-hidden">
           <div className="w-full animate-scale-in">
             <MonthCalendar

--- a/web/src/components/StatisticsView/StatisticsView.tsx
+++ b/web/src/components/StatisticsView/StatisticsView.tsx
@@ -2,7 +2,8 @@ import dayjs from "dayjs";
 import { useState } from "react";
 import { calculateMaxCount, MonthCalendar } from "@/components/ActivityCalendar";
 import { useMemoFilterContext } from "@/contexts/MemoFilterContext";
-import { useDateFilterNavigation } from "@/hooks";
+import { useDateFilterNavigation, useLocalStorage } from "@/hooks";
+import { cn } from "@/lib/utils";
 import type { StatisticsData } from "@/types/statistics";
 import { MonthNavigator } from "./MonthNavigator";
 
@@ -13,30 +14,44 @@ interface Props {
   navigationTarget?: string;
 }
 
+const STATISTICS_CALENDAR_COLLAPSED_KEY = "statistics-calendar-collapsed";
+
 const StatisticsView = (props: Props) => {
   const { statisticsData } = props;
   const { activityStats, timeBasis } = statisticsData;
   const { filters } = useMemoFilterContext();
   const navigateToDateFilter = useDateFilterNavigation(props.navigationTarget);
   const [visibleMonthString, setVisibleMonthString] = useState(dayjs().format("YYYY-MM"));
+  const [collapsed, setCollapsed] = useLocalStorage<boolean>(STATISTICS_CALENDAR_COLLAPSED_KEY, false);
   const selectedDate = filters.find((filter) => filter.factor === "displayTime")?.value;
 
   return (
     <div className="group flex w-full flex-col text-muted-foreground animate-fade-in">
-      <MonthNavigator visibleMonth={visibleMonthString} onMonthChange={setVisibleMonthString} />
+      <MonthNavigator
+        visibleMonth={visibleMonthString}
+        onMonthChange={setVisibleMonthString}
+        collapsed={collapsed}
+        onToggleCollapsed={() => setCollapsed(!collapsed)}
+      />
 
-      <div className="w-full animate-scale-in">
-        <MonthCalendar
-          month={visibleMonthString}
-          data={activityStats}
-          maxCount={calculateMaxCount(activityStats)}
-          selectedDate={selectedDate}
-          onClick={(date) => {
-            navigateToDateFilter(date);
-            props.onDateSelect?.();
-          }}
-          timeBasis={timeBasis}
-        />
+      {/* Grid-rows trick: animates height without measuring it, and collapses to zero
+          without unmounting the calendar (keeps its internal state across toggles). */}
+      <div className={cn("grid transition-[grid-template-rows] duration-200 ease-out", collapsed ? "grid-rows-[0fr]" : "grid-rows-[1fr]")}>
+        <div className="overflow-hidden">
+          <div className="w-full animate-scale-in">
+            <MonthCalendar
+              month={visibleMonthString}
+              data={activityStats}
+              maxCount={calculateMaxCount(activityStats)}
+              selectedDate={selectedDate}
+              onClick={(date) => {
+                navigateToDateFilter(date);
+                props.onDateSelect?.();
+              }}
+              timeBasis={timeBasis}
+            />
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
**Description**
Adds a toggle to collapse/expand the calendar in the sidebar.
Fixes #6175

**Changes Made**

- Added a collapsible toggle for the calendar component
- Users who don't use the calendar can hide it to reduce visual distraction
- State is preserved (collapsed/expanded preference is remembered)

**Testing**

-  Tested collapsing and expanding the calendar
-  Verified the preference persists after page reload
-  Checked on desktop layout

**Breaking Changes**
- Backend (no changes)
- Frontend 
  - web/src/components/StatisticsView/MonthNavigator.tsx
  - web/src/components/StatisticsView/StatisticsView.tsx