### PR TITLE
fix(web): enable autocapitalize, autocorrect and spellcheck for mobile keyboards

### DIFF
--- a/web/src/components/MemoEditor/Editor/index.tsx
+++ b/web/src/components/MemoEditor/Editor/index.tsx
@@ -76,16 +76,23 @@ const Editor = forwardRef(function Editor(props: EditorProps, ref: React.Forward
     const view = new EditorView({
       state: EditorState.create({
         doc: initialContent,
-        extensions: buildEditorExtensions({
-          placeholder,
-          onChange: (md) => {
-            if (!applyingExternalContentRef.current) onChangeRef.current(md);
-          },
-          onFiles: (files, position) => onFilesRef.current(files, position),
-          onUpdate: () => listenersRef.current.forEach((l) => l()),
-          onSubmit: () => onSubmitRef.current(),
-          getTags: () => tagsRef.current,
-        }),
+        extensions: [
+          buildEditorExtensions({
+            placeholder,
+            onChange: (md) => {
+              if (!applyingExternalContentRef.current) onChangeRef.current(md);
+            },
+            onFiles: (files, position) => onFilesRef.current(files, position),
+            onUpdate: () => listenersRef.current.forEach((l) => l()),
+            onSubmit: () => onSubmitRef.current(),
+            getTags: () => tagsRef.current,
+          }),
+          EditorView.contentAttributes.of({
+            autocorrect: "on",
+            autocapitalize: "on",
+            spellcheck: "true",
+          }),
+        ],
       }),
       parent: hostRef.current,
     });


### PR DESCRIPTION
Closes #6222 

Testing:
Go to the Memos instance exposed by `pnpm dev` on your phone. Test with frequently misspelled words such as `teh -> the`

