### PR TITLE
fix(editor): enable native mobile text assistance

### DIFF
--- a/web/src/components/MemoEditor/Editor/extensions.ts
+++ b/web/src/components/MemoEditor/Editor/extensions.ts
@@ -81,12 +81,16 @@ export function buildEditorExtensions({
     markdown({ extensions: memoMarkdownExtensions }),
     ...memoEditorTheme,
     EditorView.lineWrapping,
-    // CodeMirror defaults to autocorrect="off" because it is primarily a code
-    // editor. Memos is a prose editor, and leaving that default in place also
-    // routes Windows TSF input (including the Win+. emoji picker) through
-    // Chrome's autocorrect-suppression path, which has dropped committed text.
-    // Restore the browser default used by the textarea editor before v0.30.
-    EditorView.contentAttributes.of({ autocorrect: "on" }),
+    // CodeMirror disables native text assistance because it is primarily a code
+    // editor. Memos is a prose editor, so restore the browser behavior used by
+    // the textarea editor before v0.30. Autocorrect also keeps Windows TSF input
+    // out of Chrome's autocorrect-suppression path, which has dropped committed
+    // text from the emoji picker.
+    EditorView.contentAttributes.of({
+      autocorrect: "on",
+      autocapitalize: "on",
+      spellcheck: "true",
+    }),
     placeholderCompartment.of(cmPlaceholder(placeholder)),
     EditorView.domEventHandlers({
       paste: (event, view) => {

--- a/web/tests/editor.test.tsx
+++ b/web/tests/editor.test.tsx
@@ -105,7 +105,7 @@ describe("Editor", () => {
     expect(onChange).not.toHaveBeenCalledWith("server value");
   });
 
-  it("keeps native autocorrection enabled for Windows text services", () => {
+  it("enables native text assistance for prose input", () => {
     const props = {
       className: "x",
       initialContent: "",
@@ -116,7 +116,10 @@ describe("Editor", () => {
     };
     const { container } = render(<Editor {...props} />);
 
-    expect(container.querySelector(".cm-content")).toHaveAttribute("autocorrect", "on");
+    const content = container.querySelector(".cm-content");
+    expect(content).toHaveAttribute("autocorrect", "on");
+    expect(content).toHaveAttribute("autocapitalize", "on");
+    expect(content).toHaveAttribute("spellcheck", "true");
   });
 
   it("reconfigures the placeholder when its translation changes", () => {


### PR DESCRIPTION
## Summary

- enable native autocorrection, sentence capitalization, and spellcheck on the shared CodeMirror editor
- keep the attributes in the existing editor extension instead of duplicating configuration at the React call site
- cover all three rendered content attributes with a regression test

## Testing

- `pnpm lint`
- `pnpm test` (143 files, 1,119 tests)

Closes #6222

Supersedes #6223