### PR TITLE
refactor(webhook): iterate hostname labels with SplitSeq

### DIFF
--- a/internal/webhook/validate.go
+++ b/internal/webhook/validate.go
@@ -127,7 +127,7 @@ func normalizeHostname(hostname string) (string, error) {
 		return "", errors.Errorf("hostname must contain between 1 and 253 characters")
 	}
 
-	for _, label := range strings.Split(hostname, ".") {
+	for label := range strings.SplitSeq(hostname, ".") {
 		if label == "" || len(label) > 63 {
 			return "", errors.Errorf("hostname labels must contain between 1 and 63 characters")
 		}


### PR DESCRIPTION
normalizeHostname only consumes each dot-separated label once. 

Use strings.SplitSeq to validate labels lazily while preserving empty-label, maximum-length, and normalization behavior.