### PR TITLE
feat: add markdown formatting shortcuts

### DIFF
--- a/web/src/components/MemoEditor/Editor/extensions.ts
+++ b/web/src/components/MemoEditor/Editor/extensions.ts
@@ -1,11 +1,29 @@
-import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  indentWithTab,
+} from "@codemirror/commands";
 import { markdown } from "@codemirror/lang-markdown";
 import { indentUnit } from "@codemirror/language";
 import { Compartment, type Extension } from "@codemirror/state";
-import { placeholder as cmPlaceholder, dropCursor, EditorView, type KeyBinding, keymap } from "@codemirror/view";
+import {
+  placeholder as cmPlaceholder,
+  dropCursor,
+  EditorView,
+  type KeyBinding,
+  keymap,
+} from "@codemirror/view";
 import { memoMarkdownExtensions } from "@/utils/memo-markdown-extension";
+import type { EditorCommandId } from "../formatting/commands";
+import { runFormattingCommand } from "./formatting";
 import { headingDecorations } from "./headingDecorations";
-import { liftListItem, sinkListItem } from "./listIndent";
+import {
+  leadingWhitespace,
+  liftListItem,
+  selectedLineNumbers,
+  sinkListItem,
+} from "./listIndent";
 import { tagAutocomplete } from "./tagAutocomplete";
 import { tagMentionDecorations } from "./tagMentionDecorations";
 import { memoEditorTheme } from "./theme";
@@ -27,6 +45,39 @@ const editorKeys: KeyBinding[] = [
   { key: "Tab", run: sinkListItem },
   { key: "Shift-Tab", run: liftListItem },
 ];
+
+const runFormat = (command: EditorCommandId) => (view: EditorView) => {
+  runFormattingCommand(view, command);
+  return true;
+};
+
+function toggleBlockquote(view: EditorView): boolean {
+  const { state } = view;
+  const lines = selectedLineNumbers(view).map((number) =>
+    state.doc.line(number),
+  );
+  const nonBlank = lines.filter((line) => line.text.trim() !== "");
+  const targets =
+    lines.length === 1 || nonBlank.length === 0 ? lines : nonBlank;
+  const quoted = targets.map((line) => {
+    const indent = leadingWhitespace(line.text);
+    return line.text.slice(indent).startsWith("> ");
+  });
+  const allQuoted = quoted.every(Boolean);
+  const changes = targets.map((line) => {
+    const indent = leadingWhitespace(line.text);
+    return allQuoted
+      ? { from: line.from + indent, to: line.from + indent + 2, insert: "" }
+      : { from: line.from + indent, to: line.from + indent, insert: "> " };
+  });
+  if (changes.length === 0) return true;
+  const changeSet = state.changes(changes);
+  view.dispatch({
+    changes: changeSet,
+    selection: state.selection.map(changeSet, 1),
+  });
+  return true;
+}
 
 export interface EditorExtensionsOptions {
   placeholder: string;
@@ -66,9 +117,26 @@ export function buildEditorExtensions({
     onSubmit();
     return true;
   };
-  const submitKeys: KeyBinding[] = [
-    { key: "Meta-Enter", run: submit },
-    { key: "Ctrl-Enter", run: submit },
+  // Helper to generate both Meta and Ctrl variants for a key binding.
+  const mod = (key: string, run: KeyBinding["run"]): KeyBinding[] => [
+    { key: `Meta-${key}`, run },
+    { key: `Ctrl-${key}`, run },
+  ];
+  const submitKeys: KeyBinding[] = mod("Enter", submit);
+  const formattingKeys: KeyBinding[] = [
+    ...mod("b", runFormat("bold")),
+    ...mod("i", runFormat("italic")),
+    ...mod("Shift-x", runFormat("strikethrough")),
+    ...mod("e", runFormat("code")),
+    ...mod("j", runFormat("link")), // override since cmd/ctrl k is taken
+    ...mod("Alt-1", runFormat("heading1")),
+    ...mod("Alt-2", runFormat("heading2")),
+    ...mod("Alt-3", runFormat("heading3")),
+    // Asymmetric: on macOS the list marker `-` is shifted-7; on Windows/Linux it's
+    // shifted-8 because `/` (unshifted-7) is already on the 8 key in the US layout.
+    { key: "Meta-Shift-7", run: runFormat("bulletList") },
+    { key: "Ctrl-Shift-8", run: runFormat("bulletList") },
+    ...mod("Shift-9", toggleBlockquote),
   ];
 
   return [
@@ -102,7 +170,9 @@ export function buildEditorExtensions({
       drop: (event, view) => {
         const files = Array.from(event.dataTransfer?.files ?? []);
         if (files.length === 0) return false;
-        const position = view.posAtCoords({ x: event.clientX, y: event.clientY }) ?? view.state.selection.main.head;
+        const position =
+          view.posAtCoords({ x: event.clientX, y: event.clientY }) ??
+          view.state.selection.main.head;
         onFiles(files, position);
         return true;
       },
@@ -113,7 +183,14 @@ export function buildEditorExtensions({
     // tagAutocomplete must precede the editing keymap so the completion popup's
     // Enter/Tab/arrow bindings win while it is open.
     tagAutocomplete(getTags),
-    keymap.of([...submitKeys, ...editorKeys, indentWithTab, ...defaultKeymap, ...historyKeymap]),
+    keymap.of([
+      ...submitKeys,
+      ...formattingKeys,
+      ...editorKeys,
+      indentWithTab,
+      ...defaultKeymap,
+      ...historyKeymap,
+    ]),
     EditorView.updateListener.of((u) => {
       if (u.docChanged) onChange(u.state.doc.toString());
       // Toolbar active-state depends only on the doc and selection; skip the

--- a/web/src/components/MemoEditor/Editor/extensions.ts
+++ b/web/src/components/MemoEditor/Editor/extensions.ts
@@ -1,29 +1,13 @@
-import {
-  defaultKeymap,
-  history,
-  historyKeymap,
-  indentWithTab,
-} from "@codemirror/commands";
+import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirror/commands";
 import { markdown } from "@codemirror/lang-markdown";
 import { indentUnit } from "@codemirror/language";
 import { Compartment, type Extension } from "@codemirror/state";
-import {
-  placeholder as cmPlaceholder,
-  dropCursor,
-  EditorView,
-  type KeyBinding,
-  keymap,
-} from "@codemirror/view";
+import { placeholder as cmPlaceholder, dropCursor, EditorView, type KeyBinding, keymap } from "@codemirror/view";
 import { memoMarkdownExtensions } from "@/utils/memo-markdown-extension";
 import type { EditorCommandId } from "../formatting/commands";
 import { runFormattingCommand } from "./formatting";
 import { headingDecorations } from "./headingDecorations";
-import {
-  leadingWhitespace,
-  liftListItem,
-  selectedLineNumbers,
-  sinkListItem,
-} from "./listIndent";
+import { leadingWhitespace, liftListItem, selectedLineNumbers, sinkListItem } from "./listIndent";
 import { tagAutocomplete } from "./tagAutocomplete";
 import { tagMentionDecorations } from "./tagMentionDecorations";
 import { memoEditorTheme } from "./theme";
@@ -53,21 +37,22 @@ const runFormat = (command: EditorCommandId) => (view: EditorView) => {
 
 function toggleBlockquote(view: EditorView): boolean {
   const { state } = view;
-  const lines = selectedLineNumbers(view).map((number) =>
-    state.doc.line(number),
-  );
+  const lines = selectedLineNumbers(view).map((number) => state.doc.line(number));
   const nonBlank = lines.filter((line) => line.text.trim() !== "");
-  const targets =
-    lines.length === 1 || nonBlank.length === 0 ? lines : nonBlank;
-  const quoted = targets.map((line) => {
+  const targets = lines.length === 1 || nonBlank.length === 0 ? lines : nonBlank;
+  const quoteMarkerLengths = targets.map((line) => {
     const indent = leadingWhitespace(line.text);
-    return line.text.slice(indent).startsWith("> ");
+    return /^> ?/.exec(line.text.slice(indent))?.[0].length ?? 0;
   });
-  const allQuoted = quoted.every(Boolean);
-  const changes = targets.map((line) => {
+  const allQuoted = quoteMarkerLengths.every((length) => length > 0);
+  const changes = targets.map((line, index) => {
     const indent = leadingWhitespace(line.text);
     return allQuoted
-      ? { from: line.from + indent, to: line.from + indent + 2, insert: "" }
+      ? {
+          from: line.from + indent,
+          to: line.from + indent + quoteMarkerLengths[index],
+          insert: "",
+        }
       : { from: line.from + indent, to: line.from + indent, insert: "> " };
   });
   if (changes.length === 0) return true;
@@ -170,9 +155,7 @@ export function buildEditorExtensions({
       drop: (event, view) => {
         const files = Array.from(event.dataTransfer?.files ?? []);
         if (files.length === 0) return false;
-        const position =
-          view.posAtCoords({ x: event.clientX, y: event.clientY }) ??
-          view.state.selection.main.head;
+        const position = view.posAtCoords({ x: event.clientX, y: event.clientY }) ?? view.state.selection.main.head;
         onFiles(files, position);
         return true;
       },
@@ -183,14 +166,7 @@ export function buildEditorExtensions({
     // tagAutocomplete must precede the editing keymap so the completion popup's
     // Enter/Tab/arrow bindings win while it is open.
     tagAutocomplete(getTags),
-    keymap.of([
-      ...submitKeys,
-      ...formattingKeys,
-      ...editorKeys,
-      indentWithTab,
-      ...defaultKeymap,
-      ...historyKeymap,
-    ]),
+    keymap.of([...submitKeys, ...formattingKeys, ...editorKeys, indentWithTab, ...defaultKeymap, ...historyKeymap]),
     EditorView.updateListener.of((u) => {
       if (u.docChanged) onChange(u.state.doc.toString());
       // Toolbar active-state depends only on the doc and selection; skip the

--- a/web/src/components/MemoEditor/Editor/formatting.ts
+++ b/web/src/components/MemoEditor/Editor/formatting.ts
@@ -316,28 +316,41 @@ function unwrapLink(view: EditorView): boolean {
   return false;
 }
 
+const HEADING_LEVELS: Record<string, number> = {
+  heading1: 1,
+  heading2: 2,
+  heading3: 3,
+  paragraph: 0,
+};
+
+export function runFormattingCommand(view: EditorView, command: EditorCommandId, ctx?: EditorCommandContext): void {
+  if (isMarkCommand(command)) return toggleMark(view, command);
+  if (command === "codeBlock") return toggleCodeBlock(view);
+  if (command === "bulletList" || command === "orderedList" || command === "taskList") {
+    return toggleListLine(view, command);
+  }
+
+  if (command in HEADING_LEVELS) return setHeading(view, HEADING_LEVELS[command]);
+
+  if (command === "link") {
+    // Toggle: inside an existing link, unwrap it to its label.
+    if (unwrapLink(view)) return;
+    const { from, to } = view.state.selection.main;
+    const url = ctx?.url ?? "";
+    // Empty selection: the URL doubles as the label.
+    const label = view.state.sliceDoc(from, to) || url;
+    const insert = `[${label}](${url})`;
+    view.dispatch({
+      changes: { from, to, insert },
+      selection: { anchor: from + insert.length },
+    });
+  }
+}
+
 export function createFormattingController(view: EditorView, listeners: Set<() => void>): FormattingController {
   return {
     run(command: EditorCommandId, ctx?: EditorCommandContext) {
-      if (isMarkCommand(command)) return toggleMark(view, command);
-      if (command === "codeBlock") return toggleCodeBlock(view);
-      if (command === "bulletList" || command === "orderedList" || command === "taskList") {
-        return toggleListLine(view, command);
-      }
-      if (command === "heading1") return setHeading(view, 1);
-      if (command === "heading2") return setHeading(view, 2);
-      if (command === "heading3") return setHeading(view, 3);
-      if (command === "paragraph") return setHeading(view, 0);
-      if (command === "link") {
-        // Toggle: inside an existing link, unwrap it to its label.
-        if (unwrapLink(view)) return;
-        const { from, to } = view.state.selection.main;
-        const url = ctx?.url ?? "";
-        // Empty selection: the URL doubles as the label.
-        const label = view.state.sliceDoc(from, to) || url;
-        const insert = `[${label}](${url})`;
-        view.dispatch({ changes: { from, to, insert }, selection: { anchor: from + insert.length } });
-      }
+      return runFormattingCommand(view, command, ctx);
     },
     getActiveFormats(): ActiveFormatState {
       const pos = view.state.selection.main.head;

--- a/web/src/components/MemoEditor/Editor/formatting.ts
+++ b/web/src/components/MemoEditor/Editor/formatting.ts
@@ -340,9 +340,10 @@ export function runFormattingCommand(view: EditorView, command: EditorCommandId,
     // Empty selection: the URL doubles as the label.
     const label = view.state.sliceDoc(from, to) || url;
     const insert = `[${label}](${url})`;
+    const cursor = url === "" ? from + label.length + 3 : from + insert.length;
     view.dispatch({
       changes: { from, to, insert },
-      selection: { anchor: from + insert.length },
+      selection: { anchor: cursor },
     });
   }
 }

--- a/web/tests/editor-formatting.test.ts
+++ b/web/tests/editor-formatting.test.ts
@@ -3,7 +3,7 @@ import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { GFM } from "@lezer/markdown";
 import { describe, expect, it } from "vitest";
-import { createFormattingController } from "@/components/MemoEditor/Editor/formatting";
+import { createFormattingController, runFormattingCommand } from "@/components/MemoEditor/Editor/formatting";
 
 function setup(doc: string, from: number, to: number) {
   const view = new EditorView({
@@ -13,6 +13,18 @@ function setup(doc: string, from: number, to: number) {
 }
 
 describe("formatting controller", () => {
+  it("uses the same formatting dispatcher as direct command execution", () => {
+    const direct = setup("hello", 0, 5);
+    const controller = setup("hello", 0, 5);
+
+    runFormattingCommand(direct.view, "bold");
+    controller.f.run("bold");
+
+    expect(direct.view.state.doc.toString()).toBe(controller.view.state.doc.toString());
+    direct.view.destroy();
+    controller.view.destroy();
+  });
+
   it("wraps selection in bold and reports active", () => {
     const { view, f } = setup("hello world", 0, 5);
     f.run("bold");

--- a/web/tests/editor-keys.test.ts
+++ b/web/tests/editor-keys.test.ts
@@ -24,7 +24,19 @@ function makeView(doc: string, onSubmit: () => void = () => {}) {
 }
 
 function press(view: EditorView, key: string, opts: KeyboardEventInit = {}) {
-  view.contentDOM.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...opts }));
+  view.contentDOM.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key,
+      bubbles: true,
+      cancelable: true,
+      ...opts,
+    }),
+  );
+}
+
+function select(view: EditorView, text: string) {
+  const from = view.state.doc.toString().indexOf(text);
+  view.dispatch({ selection: { anchor: from, head: from + text.length } });
 }
 
 /** Place the cursor on the given 1-based line, then press Tab/Shift-Tab. */
@@ -35,6 +47,56 @@ function tabOnLine(view: EditorView, lineNumber: number, shiftKey = false) {
 }
 
 describe("editor key bindings", () => {
+  it.each([
+    ["Cmd+B", "b", { metaKey: true }, "**alpha**"],
+    ["Ctrl+B", "b", { ctrlKey: true }, "**alpha**"],
+    ["Cmd+I", "i", { metaKey: true }, "*alpha*"],
+    ["Ctrl+I", "i", { ctrlKey: true }, "*alpha*"],
+    ["Cmd+Shift+X", "x", { metaKey: true, shiftKey: true }, "~~alpha~~"],
+    ["Ctrl+Shift+X", "x", { ctrlKey: true, shiftKey: true }, "~~alpha~~"],
+    ["Cmd+E", "e", { metaKey: true }, "`alpha`"],
+    ["Ctrl+E", "e", { ctrlKey: true }, "`alpha`"],
+    ["Cmd+K", "j", { metaKey: true }, "[alpha]()"],
+    ["Ctrl+K", "j", { ctrlKey: true }, "[alpha]()"],
+  ])(
+    "%s applies the existing formatting command",
+    (_label, key, modifiers, expected) => {
+      const view = makeView("alpha");
+      select(view, "alpha");
+      press(view, key, modifiers);
+      expect(view.state.doc.toString()).toBe(expected);
+      view.destroy();
+    },
+  );
+
+  it.each([
+    ["Cmd+Option+1", "1", { metaKey: true, altKey: true }, "# alpha"],
+    ["Ctrl+Alt+1", "1", { ctrlKey: true, altKey: true }, "# alpha"],
+    ["Cmd+Option+2", "2", { metaKey: true, altKey: true }, "## alpha"],
+    ["Ctrl+Alt+2", "2", { ctrlKey: true, altKey: true }, "## alpha"],
+    ["Cmd+Option+3", "3", { metaKey: true, altKey: true }, "### alpha"],
+    ["Ctrl+Alt+3", "3", { ctrlKey: true, altKey: true }, "### alpha"],
+    ["Cmd+Shift+7", "7", { metaKey: true, shiftKey: true }, "- alpha"],
+    ["Ctrl+Shift+8", "8", { ctrlKey: true, shiftKey: true }, "- alpha"],
+    ["Cmd+Shift+9", "9", { metaKey: true, shiftKey: true }, "> alpha"],
+    ["Ctrl+Shift+9", "9", { ctrlKey: true, shiftKey: true }, "> alpha"],
+  ])("%s applies block formatting", (_label, key, modifiers, expected) => {
+    const view = makeView("alpha");
+    press(view, key, modifiers);
+    expect(view.state.doc.toString()).toBe(expected);
+    view.destroy();
+  });
+
+  it("toggles a quote prefix on selected nonblank lines while leaving blank lines empty", () => {
+    const view = makeView("  first\n\n second\nthird");
+    select(view, "first\n\n second\nthird");
+    press(view, "9", { ctrlKey: true, shiftKey: true });
+    expect(view.state.doc.toString()).toBe("  > first\n\n > second\n> third");
+    press(view, "9", { ctrlKey: true, shiftKey: true });
+    expect(view.state.doc.toString()).toBe("  first\n\n second\nthird");
+    view.destroy();
+  });
+
   it("Cmd+Enter submits without inserting a blank line", () => {
     let submitted = 0;
     const view = makeView("hello", () => {

--- a/web/tests/editor-keys.test.ts
+++ b/web/tests/editor-keys.test.ts
@@ -56,18 +56,29 @@ describe("editor key bindings", () => {
     ["Ctrl+Shift+X", "x", { ctrlKey: true, shiftKey: true }, "~~alpha~~"],
     ["Cmd+E", "e", { metaKey: true }, "`alpha`"],
     ["Ctrl+E", "e", { ctrlKey: true }, "`alpha`"],
-    ["Cmd+K", "j", { metaKey: true }, "[alpha]()"],
-    ["Ctrl+K", "j", { ctrlKey: true }, "[alpha]()"],
-  ])(
-    "%s applies the existing formatting command",
-    (_label, key, modifiers, expected) => {
-      const view = makeView("alpha");
-      select(view, "alpha");
-      press(view, key, modifiers);
-      expect(view.state.doc.toString()).toBe(expected);
-      view.destroy();
-    },
-  );
+    ["Cmd+J", "j", { metaKey: true }, "[alpha]()"],
+    ["Ctrl+J", "j", { ctrlKey: true }, "[alpha]()"],
+  ])("%s applies the existing formatting command", (_label, key, modifiers, expected) => {
+    const view = makeView("alpha");
+    select(view, "alpha");
+    press(view, key, modifiers);
+    expect(view.state.doc.toString()).toBe(expected);
+    view.destroy();
+  });
+
+  it.each([
+    ["Cmd+J", { metaKey: true }],
+    ["Ctrl+J", { ctrlKey: true }],
+  ])("%s leaves the selected link label ready for URL entry", (_label, modifiers) => {
+    const view = makeView("alpha");
+    select(view, "alpha");
+
+    press(view, "j", modifiers);
+
+    expect(view.state.doc.toString()).toBe("[alpha]()");
+    expect(view.state.selection.main).toMatchObject({ from: 8, to: 8 });
+    view.destroy();
+  });
 
   it.each([
     ["Cmd+Option+1", "1", { metaKey: true, altKey: true }, "# alpha"],
@@ -94,6 +105,18 @@ describe("editor key bindings", () => {
     expect(view.state.doc.toString()).toBe("  > first\n\n > second\n> third");
     press(view, "9", { ctrlKey: true, shiftKey: true });
     expect(view.state.doc.toString()).toBe("  first\n\n second\nthird");
+    view.destroy();
+  });
+
+  it.each([
+    [">text", "text"],
+    [">", ""],
+  ])("removes the quote marker from valid compact Markdown %s", (markdown, expected) => {
+    const view = makeView(markdown);
+
+    press(view, "9", { ctrlKey: true, shiftKey: true });
+
+    expect(view.state.doc.toString()).toBe(expected);
     view.destroy();
   });
 


### PR DESCRIPTION
closes #6253 

Had to pick cmd/ctrl j for creating links, didn't want to override the global cmd/ctrl k.