### PR TITLE
feat(web): add a feature to auto-fill tag texts as a suffix into memo

### DIFF
--- a/web/src/components/MemoEditor/hooks/useMemoSave.ts
+++ b/web/src/components/MemoEditor/hooks/useMemoSave.ts
@@ -49,15 +49,17 @@ export function useMemoSave({
     const { valid, reason, detail } = validationService.canSave(state);
     const extractTagTextsStr = () => {
       // 1. Generate Existing tag text list from the content
-      const regex = /#[^\s#]+/g;
+      // Based on internal/markdown/parser/tag.go
+      const regex = /#[\p{L}\p{N}\p{M}_+\-&]+(?:\/[\p{L}\p{N}\p{M}_+\-&]+)*/gu;
       const existTagTextList: string[] = state.content.match(regex) ?? [];
       // 2. Search and merge tags as a string appended tag texts.
       var tagTextStr = "";
       filters.map((filter) => {
         // If filter is tag and the tag is not already in the content, append it as tagTexts string
         if (filter.factor === "tagSearch" && filter.value) {
-          if (!existTagTextList.includes("#" + filter.value)) {
-            tagTextStr += " #" + filter.value;
+          const tagText = "#" + filter.value;
+          if (!existTagTextList.includes(tagText)) {
+            tagTextStr += " " + tagText;
           }
         }
       });

--- a/web/src/components/MemoEditor/hooks/useMemoSave.ts
+++ b/web/src/components/MemoEditor/hooks/useMemoSave.ts
@@ -47,14 +47,21 @@ export function useMemoSave({
   return useCallback(async () => {
     const state = getState();
     const { valid, reason, detail } = validationService.canSave(state);
-    const extractTagTexts = () => {
-      var tagTexts = "";
+    const extractTagTextsStr = () => {
+      // 1. Generate Existing tag text list from the content
+      const regex = /#[^\s#]+/g;
+      const existTagTextList: string[] = state.content.match(regex) ?? [];
+      // 2. Search and merge tags as a string appended tag texts.
+      var tagTextStr = "";
       filters.map((filter) => {
+        // If filter is tag and the tag is not already in the content, append it as tagTexts string
         if (filter.factor === "tagSearch" && filter.value) {
-          tagTexts += " #" + filter.value;
+          if (!existTagTextList.includes("#" + filter.value)) {
+            tagTextStr += " #" + filter.value;
+          }
         }
       });
-      return tagTexts;
+      return tagTextStr;
     };
 
     if (!valid) {
@@ -65,7 +72,7 @@ export function useMemoSave({
     dispatch(actions.setLoading("saving", true));
 
     try {
-      const result = await memoService.save(state, { memoName, parentMemoName, space: defaultSpace, withSuffix: extractTagTexts() });
+      const result = await memoService.save(state, { memoName, parentMemoName, space: defaultSpace, withSuffix: extractTagTextsStr() });
 
       if (!result.hasChanges) {
         toast.error(t("editor.no-changes-detected"));

--- a/web/src/components/MemoEditor/hooks/useMemoSave.ts
+++ b/web/src/components/MemoEditor/hooks/useMemoSave.ts
@@ -11,7 +11,10 @@ import { useTranslate } from "@/utils/i18n";
 import { errorService, memoService, validationService } from "../services";
 import { useEditorContext } from "../state";
 import { useMemoFilterContext } from "@/contexts/MemoFilterContext";
-import { findTagMatches } from "@/utils/tag-grammar";
+import { findMarkdownTagMatches } from "../Editor/markdownTagRanges";
+import { EditorState } from "@codemirror/state";
+import { markdown } from "@codemirror/lang-markdown";
+import { memoMarkdownExtensions } from "@/utils/memo-markdown-extension";
 
 interface UseMemoSaveOptions {
   memoName?: string;
@@ -49,12 +52,14 @@ export function useMemoSave({
     const state = getState();
     const { valid, reason, detail } = validationService.canSave(state);
     const extractTagTextsStr = () => {
+      const editorState = EditorState.create({ doc: state.content, extensions: [markdown({ extensions: memoMarkdownExtensions })] });
+      const uniqueFilters = [...new Set(filters)];
       // Search and merge tags as a string appended tag texts.
       var tagTextStr = "";
-      filters.map((filter) => {
+      uniqueFilters.map((filter) => {
         // If filter is tag and the tag is not already in the content, append it as tagTexts string
         if (filter.factor === "tagSearch" && filter.value) {
-          if (!findTagMatches(state.content).some((match) => match.value === filter.value)) {
+          if (!findMarkdownTagMatches(editorState, 0, state.content.length).some((match) => match.value === filter.value)) {
             tagTextStr += " " + "#" + filter.value;
           }
         }

--- a/web/src/components/MemoEditor/hooks/useMemoSave.ts
+++ b/web/src/components/MemoEditor/hooks/useMemoSave.ts
@@ -11,6 +11,7 @@ import { useTranslate } from "@/utils/i18n";
 import { errorService, memoService, validationService } from "../services";
 import { useEditorContext } from "../state";
 import { useMemoFilterContext } from "@/contexts/MemoFilterContext";
+import { findTagMatches } from "@/utils/tag-grammar";
 
 interface UseMemoSaveOptions {
   memoName?: string;
@@ -48,18 +49,13 @@ export function useMemoSave({
     const state = getState();
     const { valid, reason, detail } = validationService.canSave(state);
     const extractTagTextsStr = () => {
-      // 1. Generate Existing tag text list from the content
-      // Based on internal/markdown/parser/tag.go
-      const regex = /#[\p{L}\p{N}\p{M}_+\-&]+(?:\/[\p{L}\p{N}\p{M}_+\-&]+)*/gu;
-      const existTagTextList: string[] = state.content.match(regex) ?? [];
-      // 2. Search and merge tags as a string appended tag texts.
+      // Search and merge tags as a string appended tag texts.
       var tagTextStr = "";
       filters.map((filter) => {
         // If filter is tag and the tag is not already in the content, append it as tagTexts string
         if (filter.factor === "tagSearch" && filter.value) {
-          const tagText = "#" + filter.value;
-          if (!existTagTextList.includes(tagText)) {
-            tagTextStr += " " + tagText;
+          if (!findTagMatches(state.content).some((match) => match.value === filter.value)) {
+            tagTextStr += " " + "#" + filter.value;
           }
         }
       });

--- a/web/src/components/MemoEditor/hooks/useMemoSave.ts
+++ b/web/src/components/MemoEditor/hooks/useMemoSave.ts
@@ -10,6 +10,7 @@ import type { Visibility } from "@/types/proto/api/v1/memo_service_pb";
 import { useTranslate } from "@/utils/i18n";
 import { errorService, memoService, validationService } from "../services";
 import { useEditorContext } from "../state";
+import { useMemoFilterContext } from "@/contexts/MemoFilterContext";
 
 interface UseMemoSaveOptions {
   memoName?: string;
@@ -41,10 +42,21 @@ export function useMemoSave({
   const queryClient = useQueryClient();
   const { markNewMemo } = useNewMemo();
   const { actions, dispatch, getState } = useEditorContext();
+  const { filters } = useMemoFilterContext();
 
   return useCallback(async () => {
     const state = getState();
     const { valid, reason, detail } = validationService.canSave(state);
+    const extractTagTexts = () => {
+      var tagTexts = "";
+      filters.map((filter) => {
+        if (filter.factor === "tagSearch" && filter.value) {
+          tagTexts += " #" + filter.value;
+        }
+      });
+      return tagTexts;
+    };
+
     if (!valid) {
       toast.error(reason ? t(reason, detail ? { url: detail } : undefined) : t("editor.validation.cannot-save"));
       return;
@@ -53,7 +65,7 @@ export function useMemoSave({
     dispatch(actions.setLoading("saving", true));
 
     try {
-      const result = await memoService.save(state, { memoName, parentMemoName, space: defaultSpace });
+      const result = await memoService.save(state, { memoName, parentMemoName, space: defaultSpace, withSuffix: extractTagTexts() });
 
       if (!result.hasChanges) {
         toast.error(t("editor.no-changes-detected"));
@@ -113,6 +125,7 @@ export function useMemoSave({
     onConfirm,
     parentMemoName,
     queryClient,
+    filters,
     t,
   ]);
 }

--- a/web/src/components/MemoEditor/services/memoService.ts
+++ b/web/src/components/MemoEditor/services/memoService.ts
@@ -83,6 +83,7 @@ export const memoService = {
       memoName?: string;
       parentMemoName?: string;
       space?: string;
+      withSuffix?: string;
     },
   ): Promise<{ memoName: string; hasChanges: boolean }> {
     // 1. Upload local files first
@@ -104,10 +105,10 @@ export const memoService = {
       });
       return { memoName: memo.name, hasChanges: true };
     }
-
+    
     // 3. Create new memo or comment
     const memoData = create(MemoSchema, {
-      content: state.content,
+      content: state.content + (options.withSuffix ? options.withSuffix : ""),
       visibility: state.metadata.visibility,
       attachments: toAttachmentReferences(allAttachments),
       relations: state.metadata.relations,
@@ -119,9 +120,9 @@ export const memoService = {
 
     const memo = options.parentMemoName
       ? await memoServiceClient.createMemoComment({
-          name: options.parentMemoName,
-          comment: memoData,
-        })
+        name: options.parentMemoName,
+        comment: memoData,
+      })
       : await memoServiceClient.createMemo({ memo: memoData });
 
     return { memoName: memo.name, hasChanges: true };

--- a/web/src/components/MemoEditor/services/memoService.ts
+++ b/web/src/components/MemoEditor/services/memoService.ts
@@ -105,7 +105,7 @@ export const memoService = {
       });
       return { memoName: memo.name, hasChanges: true };
     }
-    
+
     // 3. Create new memo or comment
     const memoData = create(MemoSchema, {
       content: state.content + (options.withSuffix ? options.withSuffix : ""),
@@ -120,9 +120,9 @@ export const memoService = {
 
     const memo = options.parentMemoName
       ? await memoServiceClient.createMemoComment({
-        name: options.parentMemoName,
-        comment: memoData,
-      })
+          name: options.parentMemoName,
+          comment: memoData,
+        })
       : await memoServiceClient.createMemo({ memo: memoData });
 
     return { memoName: memo.name, hasChanges: true };


### PR DESCRIPTION
# Summary 

I've make a feature to auto-fill tag texts into memo.
Please refer to https://github.com/orgs/usememos/discussions/6204

# Tests

- In tag filtered state, memo is merged tag text as a suffix before sending 
- In no filter state, memo is not merged tag text as a suffix before sending 
- In tag filtered state, this feature is not executed even if an exist memo is edited and sent.

# Demo Video

https://github.com/user-attachments/assets/a7406805-e6a5-44e2-9598-e79c3e604607