### PR TITLE
fix(email): encode non-ASCII header text as RFC 2047 words

### DIFF
--- a/internal/email/message.go
+++ b/internal/email/message.go
@@ -3,6 +3,7 @@ package email
 import (
 	"errors"
 	"fmt"
+	"mime"
 	"strings"
 	"time"
 )
@@ -36,11 +37,11 @@ func (m *Message) Validate() error {
 func (m *Message) Format(fromEmail, fromName string) string {
 	var sb strings.Builder
 	fromEmail = sanitizeEmailHeaderValue(fromEmail)
-	fromName = sanitizeEmailHeaderValue(fromName)
+	fromName = encodeEmailHeaderText(sanitizeEmailHeaderValue(fromName))
 	to := sanitizeEmailHeaderValues(m.To)
 	cc := sanitizeEmailHeaderValues(m.Cc)
 	replyTo := sanitizeEmailHeaderValue(m.ReplyTo)
-	subject := sanitizeEmailHeaderValue(m.Subject)
+	subject := encodeEmailHeaderText(sanitizeEmailHeaderValue(m.Subject))
 
 	// From header
 	if fromName != "" {
@@ -90,6 +91,13 @@ func (m *Message) Format(fromEmail, fromName string) string {
 func sanitizeEmailHeaderValue(value string) string {
 	value = strings.NewReplacer("\r", " ", "\n", " ").Replace(value)
 	return strings.Join(strings.Fields(value), " ")
+}
+
+// encodeEmailHeaderText encodes free-form header text as RFC 2047 encoded-words when it
+// contains non-ASCII characters; ASCII-only values are returned unchanged. It must not be
+// used on headers carrying addr-specs, which cannot be encoded this way.
+func encodeEmailHeaderText(value string) string {
+	return mime.QEncoding.Encode("utf-8", value)
 }
 
 func sanitizeEmailHeaderValues(values []string) []string {

--- a/internal/email/message_test.go
+++ b/internal/email/message_test.go
@@ -1,8 +1,10 @@
 package email
 
 import (
+	"mime"
 	"strings"
 	"testing"
+	"unicode"
 )
 
 func TestMessageValidation(t *testing.T) {
@@ -167,6 +169,51 @@ func TestMessageFormatSanitizesHeaderValues(t *testing.T) {
 	if !strings.Contains(headers, "From: Sender X-Injected-Name: bad <sender@example.com X-Injected-From: bad>") {
 		t.Error("from header was not normalized")
 	}
+}
+
+func TestMessageFormatEncodesNonASCIIHeaderText(t *testing.T) {
+	msg := Message{
+		To:      []string{"user@example.com"},
+		Subject: "[Memos] 小明 commented on your memo",
+		Body:    "Test Body",
+	}
+
+	formatted := msg.Format("sender@example.com", "备忘录")
+	headers := strings.SplitN(formatted, "\r\n\r\n", 2)[0]
+
+	for i := 0; i < len(headers); i++ {
+		if headers[i] > unicode.MaxASCII {
+			t.Fatalf("header block must be US-ASCII, got a raw non-ASCII byte:\n%s", headers)
+		}
+	}
+
+	decoder := new(mime.WordDecoder)
+	subject, err := decoder.DecodeHeader(formattedHeaderValue(t, headers, "Subject: "))
+	if err != nil {
+		t.Fatalf("decoding Subject header: %v", err)
+	}
+	if subject != msg.Subject {
+		t.Errorf("decoded Subject = %q, want %q", subject, msg.Subject)
+	}
+
+	from, err := decoder.DecodeHeader(formattedHeaderValue(t, headers, "From: "))
+	if err != nil {
+		t.Fatalf("decoding From header: %v", err)
+	}
+	if want := "备忘录 <sender@example.com>"; from != want {
+		t.Errorf("decoded From = %q, want %q", from, want)
+	}
+}
+
+func formattedHeaderValue(t *testing.T, headers, prefix string) string {
+	t.Helper()
+	for _, line := range strings.Split(headers, "\r\n") {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimPrefix(line, prefix)
+		}
+	}
+	t.Fatalf("header %q not found in:\n%s", prefix, headers)
+	return ""
 }
 
 func TestGetAllRecipients(t *testing.T) {


### PR DESCRIPTION
If someone with a non-Latin nickname comments on your memo, the notification email
turns up with a garbled subject — `[Memos] å°æ commented on your memo` where it
should read `[Memos] 小明 commented on your memo`. The same thing happens to the
`From` line on any instance that sets a localized sender name in its SMTP
notification settings. The message body is fine; it's only the header lines that
come out wrong.

That's coming from `Message.Format` in `internal/email/message.go`. It sanitizes
every header value for CR/LF injection — which is the part that matters and which
I've left exactly as it was — and then writes the result straight into the header
block: `From: %s <%s>` on line 47, `Subject: %s` on line 66. RFC 5322 §2.2 only
allows US-ASCII in header field bodies, so those raw UTF-8 octets go out on the
wire as-is and receiving clients fall back to reading them as latin-1. It surfaces
here specifically because the subject is built from user-controlled text:
`buildMemoCommentEmailMessage` and `buildMemoMentionEmailMessage` in
`server/notification/email.go` both format the subject around
`displayNameForEmail(sender)`, which is just whatever nickname the commenter set.
The body escaped the problem only because it already declares `charset=utf-8`.

The fix is the standard one — RFC 2047 encoded-words via `mime.QEncoding` — applied
to the two headers that carry free-form display text. I put it behind a small
`encodeEmailHeaderText` helper sitting next to the existing sanitizer, and kept the
order as sanitize-then-encode so the injection guarantee `sanitizeEmailHeaderValue`
provides is untouched. Go's encoder is a no-op on input that's already ASCII, so
every English notification and the test email are byte-for-byte identical to what
they were before this change.

I deliberately left `To`, `Cc` and `Reply-To` alone. Those carry addr-specs, which
must not be encoded as words; internationalized addresses are an SMTPUTF8 question
and a different change entirely.

For evidence I added `TestMessageFormatEncodesNonASCIIHeaderText`, which formats a
message with a Chinese nickname in the subject and a Chinese sender name, then
checks two things: that the whole header block is US-ASCII, and that
`mime.WordDecoder` decodes `Subject` and `From` back to exactly the text that went
in. Against the unfixed code it fails on the first check, with the raw 小明 still
sitting in the header block.

I ran the repo's own `go build ./... && go test ./...` plus the new test:

```
/internal/markdown/extensions	(cached)
ok  	github.com/usememos/memos/internal/markdown/parser	(cached)
ok  	github.com/usememos/memos/internal/markdown/parser/tagdata	(cached)
ok  	github.com/usememos/memos/internal/markdown/renderer	(cached)
ok  	github.com/usememos/memos/internal/motionphoto	(cached)
ok  	github.com/usememos/memos/internal/profile	(cached)
ok  	github.com/usememos/memos/internal/scheduler	(cached)
ok  	github.com/usememos/memos/internal/storage	(cached)
ok  	github.com/usememos/memos/internal/storage/s3	(cached)
?   	github.com/usememos/memos/internal/testutil	[no test files]
?   	github.com/usememos/memos/internal/testutil/fakes3	[no test files]
?   	github.com/usememos/memos/internal/testutil/minio	[no test files]
ok  	github.com/usememos/memos/internal/util	(cached)
ok  	github.com/usememos/memos/internal/version	(cached)
ok  	github.com/usememos/memos/internal/webhook	(cached)
?   	github.com/usememos/memos/proto	[no test files]
?   	github.com/usememos/memos/proto/gen/api/v1	[no test files]
?   	github.com/usememos/memos/proto/gen/api/v1/apiv1connect	[no test files]
?   	github.com/usememos/memos/proto/gen/store	[no test files]
ok  	github.com/usememos/memos/scripts	(cached)
ok  	github.com/usememos/memos/server	0.018s
ok  	github.com/usememos/memos/server/access	(cached)
ok  	github.com/usememos/memos/server/auth	(cached)
ok  	github.com/usememos/memos/server/notification	0.054s
ok  	github.com/usememos/memos/server/router/api/v1	1.838s
ok  	github.com/usememos/memos/server/router/api/v1/test	5.235s
ok  	github.com/usememos/memos/server/router/fileserver	0.221s
ok  	github.com/usememos/memos/server/router/frontend	(cached)
ok  	github.com/usememos/memos/server/router/mcp	0.585s
?   	github.com/usememos/memos/server/runner/memopayload	[no test files]
ok  	github.com/usememos/memos/server/test	6.583s
ok  	github.com/usememos/memos/store	(cached)
ok  	github.com/usememos/memos/store/cache	(cached)
?   	github.com/usememos/memos/store/db	[no test files]
ok  	github.com/usememos/memos/store/db/mysql	(cached)
ok  	github.com/usememos/memos/store/db/postgres	(cached)
ok  	github.com/usememos/memos/store/db/sqlite	(cached)
ok  	github.com/usememos/memos/store/test	5.950s
=== RUN   TestMessageFormatEncodesNonASCIIHeaderText
--- PASS: TestMessageFormatEncodesNonASCIIHeaderText (0.00s)
PASS
ok  	github.com/usememos/memos/internal/email	0.005s
```
