### PR TITLE
fix(web): clear memo filters from brand navigation

### DIFF
--- a/web/src/components/AppSidebar/AppSidebar.tsx
+++ b/web/src/components/AppSidebar/AppSidebar.tsx
@@ -552,14 +552,16 @@ const GlobalNavigation = () => {
 const SidebarBrand = ({ className, size = "md" }: { className?: string; size?: "md" | "header" }) => {
   const currentUser = useCurrentUser();
   const location = useLocation();
+  const { clearAllFilters } = useMemoFilterContext();
 
   if (currentUser && routeSupportsCollectionScope(location.pathname)) {
-    return <SpaceSwitcher className={className} size={size} />;
+    return <SpaceSwitcher className={className} size={size} onClick={clearAllFilters} />;
   }
 
   return (
     <Link
       to={currentUser ? ROUTES.HOME : ROUTES.EXPLORE}
+      onClick={clearAllFilters}
       className={cn(
         "transition-colors hover:bg-sidebar-accent/65 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/40",
         sidebarSurfaceVariants({ role: size === "header" ? "headerBrand" : "mobileBrand" }),

--- a/web/src/components/AppSidebar/AppSidebar.tsx
+++ b/web/src/components/AppSidebar/AppSidebar.tsx
@@ -21,7 +21,7 @@ import {
   Trash2Icon,
   UserRoundIcon,
 } from "lucide-react";
-import { type ReactNode, useEffect } from "react";
+import { type MouseEvent, type ReactNode, useEffect } from "react";
 import { Link, matchPath, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { MemoDetailSidebar } from "@/components/MemoDetailSidebar";
 import { DEFAULT_SETTING_SECTION, SETTINGS_SECTIONS } from "@/components/Settings/settingSections";
@@ -553,6 +553,10 @@ const SidebarBrand = ({ className, size = "md" }: { className?: string; size?: "
   const currentUser = useCurrentUser();
   const location = useLocation();
   const { clearAllFilters } = useMemoFilterContext();
+  const handleBrandClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    clearAllFilters();
+  };
 
   if (currentUser && routeSupportsCollectionScope(location.pathname)) {
     return <SpaceSwitcher className={className} size={size} onClick={clearAllFilters} />;
@@ -561,7 +565,7 @@ const SidebarBrand = ({ className, size = "md" }: { className?: string; size?: "
   return (
     <Link
       to={currentUser ? ROUTES.HOME : ROUTES.EXPLORE}
-      onClick={clearAllFilters}
+      onClick={handleBrandClick}
       className={cn(
         "transition-colors hover:bg-sidebar-accent/65 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/40",
         sidebarSurfaceVariants({ role: size === "header" ? "headerBrand" : "mobileBrand" }),

--- a/web/src/components/AppSidebar/SpaceSwitcher.tsx
+++ b/web/src/components/AppSidebar/SpaceSwitcher.tsx
@@ -51,7 +51,7 @@ const ContextItem = ({
   </DropdownMenuItem>
 );
 
-function SpaceSwitcher({ className, size = "md" }: { className?: string; size?: "md" | "header" }) {
+function SpaceSwitcher({ className, size = "md", onClick }: { className?: string; size?: "md" | "header"; onClick?: () => void }) {
   const t = useTranslate();
   const { spaces, duplicateSpaceTitles, selectedSpace, selectedSpaceName, isLoadingSpaces, isSpacesError, selectMemos, selectSpace } =
     useSpaceContext();
@@ -91,6 +91,7 @@ function SpaceSwitcher({ className, size = "md" }: { className?: string; size?: 
               type="button"
               aria-label={`${t("space.switch")}: ${currentContextLabel}`}
               title={currentContextLabel}
+              onClick={onClick}
               className={cn(
                 "text-start transition-colors hover:bg-sidebar-accent/65 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/40",
                 size === "header" ? sidebarSurfaceVariants({ role: "headerBrand" }) : sidebarSurfaceVariants({ role: "mobileBrand" }),

--- a/web/tests/app-sidebar-logo.test.tsx
+++ b/web/tests/app-sidebar-logo.test.tsx
@@ -15,6 +15,7 @@ const sidebarState = vi.hoisted(() => ({
   mobileOpen: false,
   setMobileOpen: vi.fn(),
   setQuickFindOpen: vi.fn(),
+  clearAllFilters: vi.fn(),
 }));
 const globalEditorState = vi.hoisted(() => ({
   canOpen: true,
@@ -98,6 +99,7 @@ vi.mock("@/contexts/MemoFilterContext", () => ({
     filters: [],
     memoView: undefined,
     setMemoView: vi.fn(),
+    clearAllFilters: sidebarState.clearAllFilters,
   }),
 }));
 
@@ -194,6 +196,7 @@ describe("App sidebar logo", () => {
     sidebarState.mobileOpen = false;
     sidebarState.setMobileOpen.mockClear();
     sidebarState.setQuickFindOpen.mockClear();
+    sidebarState.clearAllFilters.mockClear();
     globalEditorState.canOpen = true;
     globalEditorState.openEditor.mockClear();
     spaceState.spaces = [];
@@ -205,6 +208,30 @@ describe("App sidebar logo", () => {
     spaceState.selectSpace.mockClear();
     filteredStatsHook.mockClear();
     tagsSectionHook.mockClear();
+  });
+
+  it("clears filters when the instance brand is clicked", () => {
+    render(
+      <MemoryRouter initialEntries={["/about?filter=contentSearch:plan"]}>
+        <AppSidebar />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Memos logo" }));
+
+    expect(sidebarState.clearAllFilters).toHaveBeenCalledOnce();
+  });
+
+  it("clears filters when the collection brand is clicked", () => {
+    render(
+      <MemoryRouter initialEntries={["/?filter=contentSearch:plan"]}>
+        <AppSidebar />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "space.switch: common.memos" }));
+
+    expect(sidebarState.clearAllFilters).toHaveBeenCalledOnce();
   });
 
   it("shows the context switcher and opens the global memo editor", () => {

--- a/web/tests/app-sidebar-logo.test.tsx
+++ b/web/tests/app-sidebar-logo.test.tsx
@@ -196,7 +196,6 @@ describe("App sidebar logo", () => {
     sidebarState.mobileOpen = false;
     sidebarState.setMobileOpen.mockClear();
     sidebarState.setQuickFindOpen.mockClear();
-    sidebarState.clearAllFilters.mockClear();
     globalEditorState.canOpen = true;
     globalEditorState.openEditor.mockClear();
     spaceState.spaces = [];
@@ -232,6 +231,18 @@ describe("App sidebar logo", () => {
     fireEvent.click(screen.getByRole("button", { name: "space.switch: common.memos" }));
 
     expect(sidebarState.clearAllFilters).toHaveBeenCalledOnce();
+  });
+
+  it("preserves filters when the instance brand opens in a new tab", () => {
+    render(
+      <MemoryRouter initialEntries={["/about?filter=contentSearch:plan"]}>
+        <AppSidebar />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Memos logo" }), { metaKey: true });
+
+    expect(sidebarState.clearAllFilters).not.toHaveBeenCalled();
   });
 
   it("shows the context switcher and opens the global memo editor", () => {


### PR DESCRIPTION
## Summary
**symptom**: when user is in a filtered view (by search / by tags / etc.), and they click on the memos icon/brand to navigate, they expect to go to the **homepage** (the "non-filtered" view), but currently the filters are still there. This PR changes this behavior.

- Clear active memo filters when clicking the instance brand link.
- Clear active memo filters when clicking the collection brand / SpaceSwitcher trigger.
- Preserve the originating page's filters when the instance brand link is opened with a modifier key in a new tab or window.
- Add regression coverage for both brand entry points and modified brand-link clicks.

## Root cause
The brand entry points did not call `clearAllFilters()`. As a result, filter state and saved memo-view state could remain active after navigating back to the main feed, and the URL could retain the `filter` query parameter.

The brand link now only clears filters for a normal primary click. Modified clicks leave the current tab unchanged while allowing the destination to open separately.

## Testing
- `cd web && pnpm lint`
- `cd web && pnpm test`
- `cd web && pnpm build`
- Manually verified search, tag, and saved-view filtering in the local development server.
