### PR TITLE
fix(i18n): align Chinese sensitive content labels

### DIFF
--- a/web/src/locales/zh-Hans.json
+++ b/web/src/locales/zh-Hans.json
@@ -263,8 +263,8 @@
   "memo": {
     "archived-at": "归档于",
     "back-to": "返回{{source}}",
-    "click-to-hide-sensitive-content": "点击隐藏 NSFW 内容",
-    "click-to-show-sensitive-content": "点击显示 NSFW 内容",
+    "click-to-hide-sensitive-content": "点击隐藏敏感内容",
+    "click-to-show-sensitive-content": "点击显示敏感内容",
     "code": "代码",
     "comment": {
       "self": "评论",
@@ -751,7 +751,7 @@
       "double-click-edit-description": "允许用户双击备忘录进入编辑。",
       "editing-description": "控制备忘录编辑行为和服务端内容长度限制。",
       "editing-title": "编辑",
-      "enable-blur-sensitive-content": "启用 NSFW 内容模糊处理（在下方添加 NSFW 标签）",
+      "enable-blur-sensitive-content": "启用敏感内容模糊处理",
       "enable-memo-comments": "启用备忘录评论",
       "enable-memo-location": "启用备忘录定位",
       "reactions": "表态",

--- a/web/src/locales/zh-Hant.json
+++ b/web/src/locales/zh-Hant.json
@@ -338,8 +338,8 @@
   },
   "memo": {
     "archived-at": "封存於",
-    "click-to-hide-sensitive-content": "點擊隱藏 NSFW 內容",
-    "click-to-show-sensitive-content": "點擊顯示 NSFW 內容",
+    "click-to-hide-sensitive-content": "點擊隱藏敏感內容",
+    "click-to-show-sensitive-content": "點擊顯示敏感內容",
     "code": "程式碼",
     "comment": {
       "self": "評論",
@@ -660,7 +660,7 @@
       "double-click-edit-description": "允許使用者雙擊備忘錄以開啟編輯。",
       "editing-description": "控制備忘錄編輯行為和伺服器端內容限制。",
       "editing-title": "編輯",
-      "enable-blur-sensitive-content": "啟用 NSFW 內容模糊化（在下方添加 NSFW 標籤）",
+      "enable-blur-sensitive-content": "啟用敏感內容模糊化",
       "enable-memo-comments": "啟用備忘錄評論",
       "enable-memo-location": "啟用備忘錄定位",
       "label": "備忘錄",


### PR DESCRIPTION
## Summary

- replace outdated NSFW wording with generic sensitive-content terminology in Simplified Chinese
- apply the same terminology consistently to Traditional Chinese
- align the related blur-setting labels in both locales

Fixes #6270

## Testing

- `cd web && pnpm lint`
- `cd web && pnpm test` (149 files, 1186 tests)
- manually verified the blurred-memo reveal label in both Chinese locales at 1280x720
- verified that revealing the memo still removes the blur overlay