### PR TITLE
fix(web): restore default focus behavior in dialogs

### DIFF
--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -55,13 +55,7 @@ const DialogContent = React.forwardRef<
 >(({ className, children, showCloseButton = true, size, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
-    <DialogPrimitive.Popup
-      ref={ref}
-      className={cn(dialogContentVariants({ size }), className)}
-      initialFocus={false}
-      finalFocus={false}
-      {...props}
-    >
+    <DialogPrimitive.Popup ref={ref} className={cn(dialogContentVariants({ size }), className)} {...props}>
       <div className="overflow-y-auto overflow-x-hidden flex-1 flex flex-col gap-4">{children}</div>
       {showCloseButton && (
         <DialogPrimitive.Close className="ring-offset-background absolute top-4 end-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">


### PR DESCRIPTION
## Description

`DialogContent` hardcodes `initialFocus={false}` and `finalFocus={false}`, so no dialog in the app moves focus on open or restores it on close. The most visible symptom is the delete-memo confirm dialog opened from the memo action menu: focus stays on the "…" trigger outside the now-modal dialog, so keyboard users have to tab blindly and screen readers announce nothing.

This behavior is inherited rather than intentional:

- #4998 added focus suppression to `SheetContent` as a mobile workaround (an auto-focused sidebar search input popping up the virtual keyboard on touch devices), referencing radix-ui/primitives#1241.
- 6d1485d1 then copied the same handlers wholesale into `DialogContent`, bundled with an unrelated dialog state-reset fix.
- 9c3bd44a (Base UI migration) mechanically mapped them to `initialFocus={false}` / `finalFocus={false}`.

The original mobile concern is already covered by Base UI defaults: when a dialog is opened by touch, focus goes to the popup itself instead of the first tabbable element, so the virtual keyboard doesn't pop up.

## Changes

Remove the hardcoded `initialFocus`/`finalFocus` from `DialogContent` and let Base UI defaults apply: focus moves to the first tabbable element on open (for confirm dialogs, that's the Cancel button — the standard choice for destructive actions) and returns to the trigger on close. Per-consumer overrides still work through the existing prop spread, as already done in `GlobalMemoEditorContext`.

## Testing

- `pnpm lint`, `pnpm test` (154 files, 1260 tests), and `pnpm build` all pass.
