### PR TITLE
fix(webhook): block unspecified-address destinations in the SSRF guard

### DIFF
--- a/internal/webhook/validate.go
+++ b/internal/webhook/validate.go
@@ -14,14 +14,17 @@ import (
 
 // reservedNetworks lists IP ranges blocked by default for outbound webhook requests.
 // Explicit allowlist entries or the deprecated blanket override may permit them. The
-// ranges cover loopback, RFC-1918 private, link-local (including cloud IMDS at
-// 169.254.169.254), and their IPv6 equivalents.
+// ranges cover "this network" (the kernel treats it as the local host), loopback,
+// RFC-1918 private, link-local (including cloud IMDS at 169.254.169.254), and their
+// IPv6 equivalents.
 var reservedNetworks = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),      // "this network" (RFC 791), dials the local host
 	netip.MustParsePrefix("127.0.0.0/8"),    // IPv4 loopback
 	netip.MustParsePrefix("10.0.0.0/8"),     // RFC-1918 class A
 	netip.MustParsePrefix("172.16.0.0/12"),  // RFC-1918 class B
 	netip.MustParsePrefix("192.168.0.0/16"), // RFC-1918 class C
 	netip.MustParsePrefix("169.254.0.0/16"), // Link-local / cloud IMDS
+	netip.MustParsePrefix("::/128"),         // IPv6 unspecified address, dials the local host
 	netip.MustParsePrefix("::1/128"),        // IPv6 loopback
 	netip.MustParsePrefix("fc00::/7"),       // IPv6 unique local
 	netip.MustParsePrefix("fe80::/10"),      // IPv6 link-local

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -300,3 +300,36 @@ func TestPostWithoutSecretSetsNoSignatureHeaders(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, hasSignatureHeaders, "no signature headers should be set when no secret is configured")
 }
+
+// TestPostRejectsUnspecifiedAddressDestination pins that a webhook URL pointing at the
+// unspecified address is refused at dial time, bcs the kernel treats it as the local host.
+func TestPostRejectsUnspecifiedAddressDestination(t *testing.T) {
+	resetPrivateDestinationPolicy(t)
+
+	var receivedRequest atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		receivedRequest.Store(true)
+		_, _ = w.Write([]byte(`{"code":0}`))
+	}))
+	defer server.Close()
+
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(server.URL, "http://"))
+	require.NoError(t, err)
+
+	err = Post(&WebhookRequestPayload{
+		URL:          "http://0.0.0.0:" + port,
+		ActivityType: "memos.memo.created",
+		Creator:      "users/1",
+	})
+	require.Error(t, err)
+	require.False(t, receivedRequest.Load(), "the webhook must not reach a local service through the unspecified address")
+}
+
+// TestValidateURLRejectsUnspecifiedAddress ensures webhook URL validation also refuses
+// the unspecified address, so such URLs never even reach the dispatch path.
+func TestValidateURLRejectsUnspecifiedAddress(t *testing.T) {
+	resetPrivateDestinationPolicy(t)
+
+	require.Error(t, ValidateURL("http://0.0.0.0:8080/hook"))
+	require.Error(t, ValidateURL("http://[::]:8080/hook"))
+}


### PR DESCRIPTION
> **Context:** sibling to #6256 (which adds the CGNAT range 100.64.0.0/10 to the same guard list). this one covers a different hole in the same list: the unspecified address, which no open PR or issue touches

## Proposed change

0.0.0.0 and :: are IP literals, and the kernel dials both as the local host. the webhook SSRF guard resolves the URL host and checks every resolved IP against reservedNetworks, but that list had no entry for the unspecified address on either stack, so isReservedIP(0.0.0.0) was false and safeDialContext dialed straight into a service bound on the loopback interface

add 0.0.0.0/8 and ::/128 to reservedNetworks so both ValidateURL (config time) and safeDialContext (dispatch time, which also covers DNS rebinding) refuse the destination, matching the IsUnspecified coverage the link-metadata fetcher already has

### Steps to reproduce
1. run a service on the loopback interface, then dispatch a webhook to http://0.0.0.0:<its port> with AllowPrivateIPs off
2. Expected: the dial is refused bcs the destination is a reserved address
3. Actual (raw output on untouched main 9da3765, the two new tests with the fix stashed):

```
--- FAIL: TestPostRejectsUnspecifiedAddressDestination (0.00s)
    webhook_test.go:324:
        	Error Trace:	/home/hktitof/Harness/Projects/Global Talent Application/global-talent-open-source-contribution/open_source_sandboxes/usememos__memos/internal/webhook/webhook_test.go:324
        	Error:      	An error is expected but got nil.
--- FAIL: TestValidateURLRejectsUnspecifiedAddress (0.00s)
    webhook_test.go:333:
        	Error Trace:	/home/hktitof/Harness/Projects/Global Talent Application/global-talent-open-source-contribution/open_source_sandboxes/usememos__memos/internal/webhook/webhook_test.go:333
        	Error:      	An error is expected but got nil.
FAIL
FAIL	github.com/usememos/memos/internal/webhook	0.015s
```

the delivery itself was also observed live during reproduction: an httptest server bound on 127.0.0.1 received the webhook posted to http://0.0.0.0:<its port> on untouched main

## Testing

- go test -race -count=1 ./internal/webhook/ → ok (full package)
- the two new tests fail on pristine main with the fix stashed and pass with it restored (fail without change)
- go build ./..., gofmt clean, go vet clean, golangci-lint run internal/webhook/... → 0 issues
