### PR TITLE
fix(attachments): stream uploads through temporary files

### DIFF
--- a/internal/motionphoto/reader.go
+++ b/internal/motionphoto/reader.go
@@ -1,0 +1,55 @@
+package motionphoto
+
+import (
+	"bytes"
+	"io"
+	"strconv"
+)
+
+// DetectJPEGReader detects embedded video without loading the JPEG into memory.
+func DetectJPEGReader(reader io.ReaderAt, size int64) (*Detection, error) {
+	if size < 16 {
+		return nil, nil
+	}
+	header := make([]byte, min(size, maxMetadataScanBytes))
+	if _, err := reader.ReadAt(header, 0); err != nil {
+		return nil, err
+	}
+	if !bytes.HasPrefix(header, []byte{0xFF, 0xD8}) || !motionPhotoMarkerRegex.Match(header) {
+		return nil, nil
+	}
+	text := string(header)
+	makeDetection := func(start int64) *Detection {
+		return &Detection{VideoStart: int(start), PresentationTimestampUs: parsePresentationTimestampUs(text)}
+	}
+	if matches := microVideoOffsetRegex.FindStringSubmatch(text); len(matches) == 2 {
+		if offset, err := strconv.ParseInt(matches[1], 10, 64); err == nil && offset > 0 && offset < size && offset >= 12 {
+			var probe [12]byte
+			if _, err := reader.ReadAt(probe[:], size-offset); err != nil {
+				return nil, err
+			}
+			if looksLikeMP4(probe[:]) {
+				return makeDetection(size - offset), nil
+			}
+		}
+	}
+
+	// Match the byte-slice detector's last valid ftyp box, scanning backwards
+	// with overlap so a box header crossing a block boundary is still found.
+	buffer := make([]byte, 64*1024)
+	for end := size; end >= 12; {
+		start := max(int64(0), end-int64(len(buffer)))
+		block := buffer[:end-start]
+		if _, err := reader.ReadAt(block, start); err != nil {
+			return nil, err
+		}
+		if index := findEmbeddedMP4Start(block); index >= 0 {
+			return makeDetection(start + int64(index)), nil
+		}
+		if start == 0 {
+			break
+		}
+		end = start + 11
+	}
+	return nil, nil
+}

--- a/internal/motionphoto/reader_test.go
+++ b/internal/motionphoto/reader_test.go
@@ -1,0 +1,41 @@
+package motionphoto
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/usememos/memos/internal/testutil"
+)
+
+func TestDetectJPEGReader(t *testing.T) {
+	fixture := testutil.BuildMotionPhotoJPEG()
+	for _, blob := range [][]byte{nil, []byte("not a JPEG"), fixture} {
+		detected, err := DetectJPEGReader(bytes.NewReader(blob), int64(len(blob)))
+		require.NoError(t, err)
+		require.Equal(t, DetectJPEG(blob), detected)
+	}
+
+	// Exercise MP4 headers straddling both sides of the backwards scan boundary.
+	for offset := -12; offset <= 12; offset++ {
+		blob := make([]byte, 200_000)
+		copy(blob, []byte("\xff\xd8 Camera:MotionPhoto=\"1\""))
+		start := len(blob) - 64*1024 + offset
+		copy(blob[start:], []byte{0, 0, 0, 16, 'f', 't', 'y', 'p', 'm', 'p', '4', '2'})
+		detected, err := DetectJPEGReader(bytes.NewReader(blob), int64(len(blob)))
+		require.NoError(t, err)
+		require.Equal(t, DetectJPEG(blob), detected, "offset %d", offset)
+		require.Equal(t, start, detected.VideoStart)
+	}
+
+	// Prefer the explicit MicroVideoOffset even when a later ftyp box exists.
+	blob := make([]byte, 1024)
+	copy(blob, []byte("\xff\xd8 Camera:MotionPhoto=\"1\" Camera:MicroVideoOffset=\"128\""))
+	copy(blob[896:], []byte{0, 0, 0, 16, 'f', 't', 'y', 'p', 'm', 'p', '4', '2'})
+	copy(blob[1000:], []byte{0, 0, 0, 16, 'f', 't', 'y', 'p', 'm', 'p', '4', '2'})
+	detected, err := DetectJPEGReader(bytes.NewReader(blob), int64(len(blob)))
+	require.NoError(t, err)
+	require.Equal(t, DetectJPEG(blob), detected)
+	require.Equal(t, 896, detected.VideoStart)
+}

--- a/server/router/api/v1/attachment_service.go
+++ b/server/router/api/v1/attachment_service.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"log/slog"
 	"mime"
@@ -16,13 +15,12 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	v1pb "github.com/usememos/memos/proto/gen/api/v1"
+	storepb "github.com/usememos/memos/proto/gen/store"
 	"github.com/usememos/memos/store"
 )
 
 const (
-	// The upload memory buffer is 32 MiB.
-	// It should be kept low, so RAM usage doesn't get out of control.
-	// This is unrelated to maximum upload size limit, which is now set through system setting.
+	// MaxUploadBufferSizeBytes is the fallback upload size limit when no limit is configured.
 	MaxUploadBufferSizeBytes = 32 << 20
 	MebiByte                 = 1024 * 1024
 
@@ -71,7 +69,7 @@ func detectAttachmentMimeType(filename string, content []byte) string {
 	return http.DetectContentType(content)
 }
 
-func (s *APIV1Service) CreateAttachment(ctx context.Context, request *v1pb.CreateAttachmentRequest) (*v1pb.Attachment, error) {
+func (s *APIV1Service) prepareAttachment(ctx context.Context, request *v1pb.CreateAttachmentRequest) (*store.Attachment, error) {
 	user, err := s.fetchCurrentUser(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get current user: %v", err)
@@ -135,21 +133,6 @@ func (s *APIV1Service) CreateAttachment(ctx context.Context, request *v1pb.Creat
 		create.Payload.MediaMetadata = inputMediaMetadata
 	}
 
-	instanceStorageSetting, err := s.Store.GetInstanceStorageSetting(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to get instance storage setting: %v", err)
-	}
-	size := binary.Size(request.Attachment.Content)
-	uploadSizeLimit := int(instanceStorageSetting.UploadSizeLimitMb) * MebiByte
-	if uploadSizeLimit == 0 {
-		uploadSizeLimit = MaxUploadBufferSizeBytes
-	}
-	if size > uploadSizeLimit {
-		return nil, status.Errorf(codes.InvalidArgument, "file size exceeds the limit")
-	}
-	create.Size = int64(size)
-	create.Blob = request.Attachment.Content
-
 	if request.Attachment.Memo != nil {
 		memoUID, err := ExtractMemoUIDFromName(*request.Attachment.Memo)
 		if err != nil {
@@ -172,8 +155,26 @@ func (s *APIV1Service) CreateAttachment(ctx context.Context, request *v1pb.Creat
 		create.Policy = memoWritePolicy(user.ID, false)
 	}
 
+	return create, nil
+}
+
+func (s *APIV1Service) CreateAttachment(ctx context.Context, request *v1pb.CreateAttachmentRequest) (*v1pb.Attachment, error) {
+	create, err := s.prepareAttachment(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	instanceStorageSetting, err := s.Store.GetInstanceStorageSetting(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get instance storage setting: %v", err)
+	}
+	if int64(len(request.Attachment.Content)) > attachmentUploadLimit(instanceStorageSetting) {
+		return nil, status.Errorf(codes.InvalidArgument, "file size exceeds the limit")
+	}
+	create.Blob = request.Attachment.Content
+	create.Size = int64(len(create.Blob))
+
 	if create.Payload == nil || create.Payload.MotionMedia == nil {
-		if detectedMotion := detectAndroidMotionMedia(create.Blob, create.Type, attachmentUID); detectedMotion != nil {
+		if detectedMotion := detectAndroidMotionMedia(create.Blob, create.Type, create.UID); detectedMotion != nil {
 			create.Payload = ensureAttachmentPayload(create.Payload)
 			create.Payload.MotionMedia = detectedMotion
 		}
@@ -204,6 +205,10 @@ func (s *APIV1Service) CreateAttachment(ctx context.Context, request *v1pb.Creat
 		return nil, status.Errorf(codes.Internal, "failed to save attachment blob: %v", err)
 	}
 
+	return s.persistAttachment(ctx, create, instanceStorageSetting)
+}
+
+func (s *APIV1Service) persistAttachment(ctx context.Context, create *store.Attachment, instanceStorageSetting *storepb.InstanceStorageSetting) (*v1pb.Attachment, error) {
 	attachment, err := s.Store.CreateAttachment(ctx, create)
 	if err != nil {
 		createErr := mapMemoWriteError(err, "failed to create attachment")

--- a/server/router/api/v1/attachment_service_image.go
+++ b/server/router/api/v1/attachment_service_image.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"image"
+	"io"
 
 	"github.com/disintegration/imaging"
 	"github.com/pkg/errors"
@@ -77,7 +78,11 @@ func (s *APIV1Service) acquireImageProcessingSlot(ctx context.Context) (func(), 
 }
 
 func validateImagePixelCount(imageData []byte) error {
-	config, _, err := image.DecodeConfig(bytes.NewReader(imageData))
+	return validateImageReaderPixelCount(bytes.NewReader(imageData))
+}
+
+func validateImageReaderPixelCount(reader io.Reader) error {
+	config, _, err := image.DecodeConfig(reader)
 	if err != nil {
 		// Some formats supported by imaging do not expose dimensions through
 		// the standard image registry. Let the full decoder handle those.
@@ -106,33 +111,28 @@ func validateImagePixelCount(imageData []byte) error {
 //
 // Returns the cleaned image data without any EXIF metadata, or an error if processing fails.
 func stripImageExif(imageData []byte, mimeType string) ([]byte, error) {
-	if err := validateImagePixelCount(imageData); err != nil {
+	var buf bytes.Buffer
+	if err := stripImageExifTo(&buf, bytes.NewReader(imageData), mimeType); err != nil {
 		return nil, err
 	}
-
-	// Decode image with automatic EXIF orientation correction.
-	// This ensures the image displays correctly after metadata removal.
-	img, err := imaging.Decode(bytes.NewReader(imageData), imaging.AutoOrientation(true))
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode image")
-	}
-
-	// Re-encode the image without EXIF metadata.
-	var buf bytes.Buffer
-	var encodeErr error
-
-	if mimeType == "image/png" {
-		// Preserve PNG format for lossless encoding
-		encodeErr = imaging.Encode(&buf, img, imaging.PNG)
-	} else {
-		// For JPEG, TIFF, WebP, HEIC, HEIF - re-encode as JPEG.
-		// This ensures EXIF is stripped and provides good compression.
-		encodeErr = imaging.Encode(&buf, img, imaging.JPEG, imaging.JPEGQuality(defaultJPEGQuality))
-	}
-
-	if encodeErr != nil {
-		return nil, errors.Wrap(encodeErr, "failed to encode image")
-	}
-
 	return buf.Bytes(), nil
+}
+
+func stripImageExifTo(dst io.Writer, source io.ReadSeeker, mimeType string) error {
+	if err := validateImageReaderPixelCount(source); err != nil {
+		return err
+	}
+	if _, err := source.Seek(0, io.SeekStart); err != nil {
+		return errors.Wrap(err, "failed to rewind image")
+	}
+	img, err := imaging.Decode(source, imaging.AutoOrientation(true))
+	if err != nil {
+		return errors.Wrap(err, "failed to decode image")
+	}
+	if mimeType == "image/png" {
+		err = imaging.Encode(dst, img, imaging.PNG)
+	} else {
+		err = imaging.Encode(dst, img, imaging.JPEG, imaging.JPEGQuality(defaultJPEGQuality))
+	}
+	return errors.Wrap(err, "failed to encode image")
 }

--- a/server/router/api/v1/attachment_service_storage.go
+++ b/server/router/api/v1/attachment_service_storage.go
@@ -62,6 +62,17 @@ func saveAttachmentBlobWithInstanceStorageSetting(
 	create *store.Attachment,
 	instanceStorageSetting *storepb.InstanceStorageSetting,
 ) error {
+	return saveAttachmentContent(ctx, profile, stores, create, instanceStorageSetting, bytes.NewReader(create.Blob))
+}
+
+func saveAttachmentContent(
+	ctx context.Context,
+	profile *profile.Profile,
+	stores *store.Store,
+	create *store.Attachment,
+	instanceStorageSetting *storepb.InstanceStorageSetting,
+	content io.Reader,
+) error {
 	defaultStorage := store.GetDefaultStorage(instanceStorageSetting)
 	if defaultStorage == nil {
 		return errors.New("default storage is not configured")
@@ -99,9 +110,24 @@ func saveAttachmentBlobWithInstanceStorageSetting(
 			return errors.Wrap(err, "Failed to create directory")
 		}
 
-		// Write the blob to the file.
-		if err := os.WriteFile(osPath, create.Blob, 0644); err != nil {
-			return errors.Wrap(err, "Failed to write file")
+		// Keep partial content out of the final path, including on cancellation.
+		file, err := os.CreateTemp(dir, ".memos-upload-*")
+		if err != nil {
+			return errors.Wrap(err, "failed to create attachment file")
+		}
+		defer os.Remove(file.Name())
+		defer file.Close()
+		if _, err := io.Copy(file, &attachmentContextReader{ctx: ctx, reader: content}); err != nil {
+			return errors.Wrap(err, "failed to write attachment file")
+		}
+		if err := file.Chmod(0644); err != nil {
+			return errors.Wrap(err, "failed to set attachment permissions")
+		}
+		if err := file.Close(); err != nil {
+			return errors.Wrap(err, "failed to close attachment file")
+		}
+		if err := os.Rename(file.Name(), osPath); err != nil {
+			return errors.Wrap(err, "failed to finalize attachment file")
 		}
 		create.Reference = internalPath
 		create.Blob = nil
@@ -117,7 +143,7 @@ func saveAttachmentBlobWithInstanceStorageSetting(
 			filepathTemplate = filepath.Join(filepathTemplate, "{filename}")
 		}
 		filepathTemplate = replaceFilenameWithPathTemplate(filepathTemplate, create.Filename)
-		key, err := driver.UploadObject(ctx, filepathTemplate, create.Type, bytes.NewReader(create.Blob))
+		key, err := driver.UploadObject(ctx, filepathTemplate, create.Type, content)
 		if err != nil {
 			return errors.Wrap(err, "failed to upload via storage driver")
 		}

--- a/server/router/api/v1/attachment_upload.go
+++ b/server/router/api/v1/attachment_upload.go
@@ -1,0 +1,233 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"math"
+	"net/http"
+	"os"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/labstack/echo/v5"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/usememos/memos/internal/motionphoto"
+	v1pb "github.com/usememos/memos/proto/gen/api/v1"
+	storepb "github.com/usememos/memos/proto/gen/store"
+	"github.com/usememos/memos/server/auth"
+	"github.com/usememos/memos/store"
+)
+
+const (
+	attachmentUploadMetadataLimit = 64 << 10
+	attachmentUploadOverheadLimit = 1 << 20
+)
+
+func attachmentUploadLimit(setting *storepb.InstanceStorageSetting) int64 {
+	mb := setting.UploadSizeLimitMb
+	if mb <= 0 {
+		return MaxUploadBufferSizeBytes
+	}
+	// Leave room for the multipart envelope and the extra byte used to detect
+	// an oversized file, even for an incorrectly configured setting.
+	return min(mb, (math.MaxInt64-attachmentUploadOverheadLimit-1)/MebiByte) * MebiByte
+}
+
+type attachmentUploadLimitError struct{}
+
+func (*attachmentUploadLimitError) Error() string { return "file size exceeds the limit" }
+
+func (*attachmentUploadLimitError) GRPCStatus() *status.Status {
+	return status.New(codes.ResourceExhausted, "file size exceeds the limit")
+}
+
+type attachmentContextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r *attachmentContextReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(p)
+}
+
+// registerAttachmentUploadRoute adds a disk-backed alternative to the buffered
+// CreateAttachment RPC. Metadata is a proto-JSON CreateAttachmentRequest in the
+// first multipart field (metadata), followed by exactly one file field (file).
+func (s *APIV1Service) registerAttachmentUploadRoute(group *echo.Group, authorizer *Authorizer) {
+	group.POST(`/api/v1/attachments\:upload`, echo.WrapHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		setAPIResponseNoStoreHeaders(w.Header())
+		result := authorizer.Authenticate(r.Context(), r.Header.Get("Authorization"))
+		if err := authorizer.CheckAccess(r.Context(), "/memos.api.v1.AttachmentService/CreateAttachment", result); err != nil {
+			writeGatewayAuthorizationError(w, err)
+			return
+		}
+		r = r.WithContext(auth.ApplyToContext(r.Context(), result))
+		attachment, err := s.uploadAttachment(w, r)
+		if err != nil {
+			writeAttachmentUploadError(w, err)
+			return
+		}
+		body, err := (protojson.MarshalOptions{EmitDefaultValues: true}).Marshal(attachment)
+		if err != nil {
+			writeAttachmentUploadError(w, status.Errorf(codes.Internal, "failed to encode attachment: %v", err))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	})))
+}
+
+func writeAttachmentUploadError(w http.ResponseWriter, err error) {
+	var sizeError *attachmentUploadLimitError
+	var bodyError *http.MaxBytesError
+	st := status.Convert(err)
+	code := runtime.HTTPStatusFromCode(st.Code())
+	if errors.As(err, &sizeError) || errors.As(err, &bodyError) {
+		code = http.StatusRequestEntityTooLarge
+		st = (&attachmentUploadLimitError{}).GRPCStatus()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]any{"code": st.Code(), "message": st.Message()})
+}
+
+func (s *APIV1Service) uploadAttachment(w http.ResponseWriter, r *http.Request) (*v1pb.Attachment, error) {
+	ctx := r.Context()
+	setting, err := s.Store.GetInstanceStorageSetting(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get storage setting: %v", err)
+	}
+	limit := attachmentUploadLimit(setting)
+	if r.ContentLength > limit+attachmentUploadOverheadLimit {
+		return nil, &attachmentUploadLimitError{}
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, limit+attachmentUploadOverheadLimit)
+	multipartReader, err := r.MultipartReader()
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "multipart/form-data is required")
+	}
+	metadata, err := multipartReader.NextPart()
+	if err != nil || metadata.FormName() != "metadata" || metadata.FileName() != "" {
+		return nil, status.Errorf(codes.InvalidArgument, "the first part must be attachment metadata")
+	}
+	data, err := io.ReadAll(io.LimitReader(metadata, attachmentUploadMetadataLimit+1))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read attachment metadata")
+	}
+	if len(data) > attachmentUploadMetadataLimit {
+		return nil, status.Errorf(codes.InvalidArgument, "attachment metadata is too large")
+	}
+	request := &v1pb.CreateAttachmentRequest{}
+	if err := protojson.Unmarshal(data, request); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid attachment metadata: %v", err)
+	}
+	if request.Attachment == nil || len(request.Attachment.Content) != 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "attachment metadata is required and must not contain file content")
+	}
+	if request.Attachment.Size > limit {
+		return nil, &attachmentUploadLimitError{}
+	}
+	part, err := multipartReader.NextPart()
+	if err != nil || part.FormName() != "file" {
+		return nil, status.Errorf(codes.InvalidArgument, "attachment metadata must be followed by a file")
+	}
+	// Only the sniffing prefix is read before shared metadata and memo permission
+	// validation. The RPC uses this same MIME detection and validation path.
+	probe, err := io.ReadAll(io.LimitReader(part, 512))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read attachment header")
+	}
+	request.Attachment.Content = probe
+	create, err := s.prepareAttachment(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	file, err := os.CreateTemp(s.Profile.Data, ".memos-upload-*")
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to create upload file: %v", err)
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+	content := io.MultiReader(bytes.NewReader(probe), part)
+	create.Size, err = io.Copy(file, &attachmentContextReader{ctx: ctx, reader: io.LimitReader(content, limit+1)})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to receive attachment")
+	}
+	if create.Size > limit {
+		return nil, &attachmentUploadLimitError{}
+	}
+	if _, err := multipartReader.NextPart(); err != io.EOF {
+		return nil, status.Errorf(codes.InvalidArgument, "expected exactly one complete file part")
+	}
+	processed, err := s.processAttachmentFile(ctx, create, file)
+	if err != nil {
+		return nil, err
+	}
+	if processed != file {
+		defer os.Remove(processed.Name())
+		defer processed.Close()
+	}
+	if _, err := processed.Seek(0, io.SeekStart); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to rewind upload: %v", err)
+	}
+	if err := saveAttachmentContent(ctx, s.Profile, s.Store, create, setting, processed); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to save attachment: %v", err)
+	}
+	return s.persistAttachment(ctx, create, setting)
+}
+
+func (s *APIV1Service) processAttachmentFile(ctx context.Context, create *store.Attachment, file *os.File) (*os.File, error) {
+	if create.Payload.GetMotionMedia() == nil && (create.Type == "image/jpeg" || create.Type == "image/jpg") {
+		detected, err := motionphoto.DetectJPEGReader(file, create.Size)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to inspect motion photo: %v", err)
+		}
+		if detected != nil {
+			create.Payload = ensureAttachmentPayload(create.Payload)
+			create.Payload.MotionMedia = &storepb.MotionMedia{
+				Family: storepb.MotionMediaFamily_ANDROID_MOTION_PHOTO, Role: storepb.MotionMediaRole_CONTAINER,
+				GroupId: create.UID, PresentationTimestampUs: detected.PresentationTimestampUs, HasEmbeddedVideo: true,
+			}
+		}
+	}
+	if !shouldStripExif(create.Type) || isAndroidMotionContainer(create.Payload.GetMotionMedia()) {
+		return file, nil
+	}
+	release, err := s.acquireImageProcessingSlot(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.ResourceExhausted, "too many image processing requests")
+	}
+	defer release()
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to rewind image: %v", err)
+	}
+	processed, err := os.CreateTemp(s.Profile.Data, ".memos-upload-*")
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to create processed image: %v", err)
+	}
+	if err := stripImageExifTo(processed, file, create.Type); err != nil {
+		processed.Close()
+		os.Remove(processed.Name())
+		// Preserve the existing RPC's fallback when an image cannot be decoded.
+		slog.Warn("failed to strip EXIF metadata from image", "type", create.Type, "filename", create.Filename, "error", err)
+		return file, nil
+	}
+	info, err := processed.Stat()
+	if err != nil {
+		processed.Close()
+		os.Remove(processed.Name())
+		return nil, status.Errorf(codes.Internal, "failed to stat processed image: %v", err)
+	}
+	create.Size = info.Size()
+	return processed, nil
+}

--- a/server/router/api/v1/attachment_upload.md
+++ b/server/router/api/v1/attachment_upload.md
@@ -1,0 +1,36 @@
+# Streaming attachment uploads
+
+`POST /api/v1/attachments:upload` accepts a multipart upload without buffering the
+file in process memory. It uses the same bearer-token authentication, attachment
+validation, and memo permissions as `CreateAttachment`.
+
+Send exactly two parts, in this order:
+
+1. `metadata`: a JSON-encoded `CreateAttachmentRequest`. Include
+   `attachment.filename`, and optionally its MIME `type`, `memo`, `motionMedia`,
+   `mediaMetadata`, and the request's `attachmentId`. Omit `attachment.content`.
+2. `file`: the binary file. The server counts the received bytes; it does not trust
+   `attachment.size` as the actual file size.
+
+```sh
+curl --fail-with-body \
+  -H "Authorization: Bearer $MEMOS_TOKEN" \
+  -F 'metadata={"attachment":{"filename":"video.mp4","type":"video/mp4"}}' \
+  -F 'file=@video.mp4' \
+  http://localhost:5230/api/v1/attachments:upload
+```
+
+Success returns HTTP 200 with an `Attachment` in protobuf JSON format. Errors use
+the REST API's JSON `code` and `message` fields. Oversized uploads return HTTP 413.
+
+The configured instance upload limit applies to the file bytes. Metadata is
+limited to 64 KiB, with a separate 1 MiB allowance for the multipart envelope.
+This route is independent of the buffered API's 256 MiB request limit.
+
+Uploads are staged in the instance data directory, processed if needed, then
+saved to local storage or S3. Temporary files are removed after success,
+cancellation, or failure. Local finalization can temporarily require a second
+copy on disk. Image decoding retains the existing pixel and concurrency limits.
+
+The existing REST and Connect `CreateAttachment` endpoints remain compatible and
+buffered; clients uploading large files should use the multipart endpoint.

--- a/server/router/api/v1/attachment_upload_test.go
+++ b/server/router/api/v1/attachment_upload_test.go
@@ -1,0 +1,324 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"image"
+	"image/jpeg"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/usememos/memos/internal/testutil"
+	"github.com/usememos/memos/internal/testutil/fakes3"
+	v1pb "github.com/usememos/memos/proto/gen/api/v1"
+	storepb "github.com/usememos/memos/proto/gen/store"
+	"github.com/usememos/memos/server/auth"
+	"github.com/usememos/memos/store"
+)
+
+func newAttachmentUploadTestServer(t *testing.T) (*APIV1Service, *echo.Echo, string, *store.User) {
+	t.Helper()
+	svc := newIntegrationService(t)
+	user := createSpaceTestUser(context.Background(), t, svc, "uploader", store.RoleUser)
+	token, _, err := auth.GenerateAccessTokenV2(user.ID, user.Username, string(user.Role), "ACTIVE", []byte(svc.Secret))
+	require.NoError(t, err)
+	e := echo.New()
+	require.NoError(t, svc.RegisterGateway(context.Background(), e))
+	return svc, e, token, user
+}
+
+func attachmentMultipartRequest(t *testing.T, metadata string, content io.Reader) *http.Request {
+	t.Helper()
+	reader, writer := io.Pipe()
+	form := multipart.NewWriter(writer)
+	contentType := form.FormDataContentType()
+	go func() {
+		err := form.WriteField("metadata", metadata)
+		if err == nil {
+			var part io.Writer
+			part, err = form.CreateFormFile("file", "upload.bin")
+			if err == nil {
+				_, err = io.Copy(part, content)
+			}
+		}
+		if err == nil {
+			err = form.Close()
+		}
+		_ = writer.CloseWithError(err)
+	}()
+	t.Cleanup(func() { _ = reader.Close() })
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/attachments:upload", reader)
+	req.Header.Set("Content-Type", contentType)
+	return req
+}
+
+func serveAttachmentUpload(e *echo.Echo, token string, req *http.Request) *httptest.ResponseRecorder {
+	defer req.Body.Close()
+	req.Header.Set("Authorization", "Bearer "+token)
+	response := httptest.NewRecorder()
+	e.ServeHTTP(response, req)
+	return response
+}
+
+func requireNoUploadTemps(t *testing.T, svc *APIV1Service) {
+	t.Helper()
+	require.NoError(t, filepath.WalkDir(svc.Profile.Data, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		require.False(t, strings.HasPrefix(entry.Name(), ".memos-upload-"), path)
+		return nil
+	}))
+}
+
+func setAttachmentUploadLimit(t *testing.T, svc *APIV1Service, mb int64) {
+	t.Helper()
+	_, err := svc.Store.UpsertInstanceSetting(context.Background(), &storepb.InstanceSetting{
+		Key: storepb.InstanceSettingKey_STORAGE,
+		Value: &storepb.InstanceSetting_StorageSetting{StorageSetting: &storepb.InstanceStorageSetting{
+			UploadSizeLimitMb: mb, FilepathTemplate: "assets/{filename}",
+		}},
+	})
+	require.NoError(t, err)
+}
+
+type uploadZeroReader struct{}
+
+func (uploadZeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
+}
+
+func TestAttachmentUploadLargeFileHasBoundedAllocations(t *testing.T) {
+	svc, e, token, _ := newAttachmentUploadTestServer(t)
+	setAttachmentUploadLimit(t, svc, 400)
+	const size = 300 << 20 // Exceeds the buffered RPC's 256 MiB transport limit.
+	req := attachmentMultipartRequest(t, `{"attachment":{"filename":"large.bin","type":"application/octet-stream"}}`, io.LimitReader(uploadZeroReader{}, size))
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	response := serveAttachmentUpload(e, token, req)
+	runtime.ReadMemStats(&after)
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	require.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(32<<20), "upload must not allocate a file-sized buffer")
+	t.Logf("300 MiB upload allocated %.2f MiB", float64(after.TotalAlloc-before.TotalAlloc)/(1<<20))
+	attachment := &v1pb.Attachment{}
+	require.NoError(t, protojson.Unmarshal(response.Body.Bytes(), attachment))
+	require.EqualValues(t, size, attachment.Size)
+	info, err := os.Stat(filepath.Join(svc.Profile.Data, "assets/large.bin"))
+	require.NoError(t, err)
+	require.EqualValues(t, size, info.Size())
+	requireNoUploadTemps(t, svc)
+}
+
+func TestAttachmentUploadRejectsInvalidRequests(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		metadata string
+		size     int64
+		status   int
+	}{
+		{"actual size", `{"attachment":{"filename":"a.bin","size":"1"}}`, (1 << 20) + 1, http.StatusRequestEntityTooLarge},
+		{"declared size", `{"attachment":{"filename":"a.bin","size":"2097152"}}`, 0, http.StatusRequestEntityTooLarge},
+		{"invalid metadata", `{`, 0, http.StatusBadRequest},
+		{"oversized metadata", strings.Repeat(" ", attachmentUploadMetadataLimit+1), 0, http.StatusBadRequest},
+		{"embedded content", `{"attachment":{"filename":"a.bin","content":"YQ=="}}`, 0, http.StatusBadRequest},
+		{"invalid filename", `{"attachment":{"filename":"../a.bin"}}`, 0, http.StatusBadRequest},
+		{"missing attachment", `{}`, 0, http.StatusBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, e, token, _ := newAttachmentUploadTestServer(t)
+			setAttachmentUploadLimit(t, svc, 1)
+			req := attachmentMultipartRequest(t, tc.metadata, io.LimitReader(uploadZeroReader{}, tc.size))
+			response := serveAttachmentUpload(e, token, req)
+			require.Equal(t, tc.status, response.Code, response.Body.String())
+			attachments, err := svc.Store.ListAttachments(context.Background(), &store.FindAttachment{})
+			require.NoError(t, err)
+			require.Empty(t, attachments)
+			requireNoUploadTemps(t, svc)
+		})
+	}
+}
+
+func TestAttachmentUploadAuthAndMemoPermissions(t *testing.T) {
+	svc, e, token, _ := newAttachmentUploadTestServer(t)
+	// Authentication happens before multipart parsing or reading any content.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/attachments:upload", nil)
+	response := serveAttachmentUpload(e, "", req)
+	require.Equal(t, http.StatusUnauthorized, response.Code)
+
+	other := createSpaceTestUser(context.Background(), t, svc, "other", store.RoleUser)
+	memo, err := svc.CreateMemo(userCtx(context.Background(), other.ID), &v1pb.CreateMemoRequest{
+		Memo: &v1pb.Memo{Content: "private memo", Visibility: v1pb.Visibility_PRIVATE},
+	})
+	require.NoError(t, err)
+	req = attachmentMultipartRequest(t, fmt.Sprintf(`{"attachment":{"filename":"a.txt","memo":%q}}`, memo.Name), strings.NewReader("content"))
+	response = serveAttachmentUpload(e, token, req)
+	require.Equal(t, http.StatusForbidden, response.Code, response.Body.String())
+	requireNoUploadTemps(t, svc)
+}
+
+func TestAttachmentUploadCleansUpFailedTransferAndDatabaseWrite(t *testing.T) {
+	svc, e, token, _ := newAttachmentUploadTestServer(t)
+	setAttachmentUploadLimit(t, svc, 1)
+	req := attachmentMultipartRequest(t, `{"attachmentId":"same-id","attachment":{"filename":"kept.txt"}}`, strings.NewReader("kept"))
+	require.Equal(t, http.StatusOK, serveAttachmentUpload(e, token, req).Code)
+	req = attachmentMultipartRequest(t, `{"attachmentId":"same-id","attachment":{"filename":"orphan.txt"}}`, strings.NewReader("orphan"))
+	require.Equal(t, http.StatusInternalServerError, serveAttachmentUpload(e, token, req).Code)
+	require.NoFileExists(t, filepath.Join(svc.Profile.Data, "assets/orphan.txt"))
+	kept, err := os.ReadFile(filepath.Join(svc.Profile.Data, "assets/kept.txt"))
+	require.NoError(t, err)
+	require.Equal(t, "kept", string(kept))
+
+	var body bytes.Buffer
+	form := multipart.NewWriter(&body)
+	require.NoError(t, form.WriteField("metadata", `{"attachment":{"filename":"partial.txt"}}`))
+	part, err := form.CreateFormFile("file", "partial.txt")
+	require.NoError(t, err)
+	_, err = part.Write(bytes.Repeat([]byte("a"), 4096))
+	require.NoError(t, err)
+	// Deliberately omit the final boundary, as with a disconnected upload.
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/attachments:upload", &body)
+	req.Header.Set("Content-Type", form.FormDataContentType())
+	require.NotEqual(t, http.StatusOK, serveAttachmentUpload(e, token, req).Code)
+	require.NoFileExists(t, filepath.Join(svc.Profile.Data, "assets/partial.txt"))
+	requireNoUploadTemps(t, svc)
+}
+
+func TestAttachmentUploadConcurrentFiles(t *testing.T) {
+	svc, e, token, _ := newAttachmentUploadTestServer(t)
+	var wg sync.WaitGroup
+	responses := make([]*httptest.ResponseRecorder, 3)
+	for i := range responses {
+		req := attachmentMultipartRequest(t, fmt.Sprintf(`{"attachment":{"filename":"concurrent-%d.bin"}}`, i), io.LimitReader(uploadZeroReader{}, 8<<20))
+		wg.Go(func() { responses[i] = serveAttachmentUpload(e, token, req) })
+	}
+	wg.Wait()
+	for _, response := range responses {
+		require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	}
+	requireNoUploadTemps(t, svc)
+}
+
+func TestAttachmentUploadKeepsLegacyRouteAndMatchesOnlyUploadAction(t *testing.T) {
+	_, e, token, _ := newAttachmentUploadTestServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/attachments", strings.NewReader(`{"filename":"legacy.txt","content":"aGVsbG8="}`))
+	req.Header.Set("Content-Type", "application/json")
+	response := serveAttachmentUpload(e, token, req)
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/attachments:unknown", nil)
+	response = serveAttachmentUpload(e, token, req)
+	require.Equal(t, http.StatusNotFound, response.Code, response.Body.String())
+}
+
+func TestAttachmentUploadAcceptsEmptyAndExactLimitFiles(t *testing.T) {
+	svc, e, token, _ := newAttachmentUploadTestServer(t)
+	setAttachmentUploadLimit(t, svc, 1)
+	for _, size := range []int64{0, 1 << 20} {
+		req := attachmentMultipartRequest(t, `{"attachment":{"filename":"boundary.bin"}}`, io.LimitReader(uploadZeroReader{}, size))
+		response := serveAttachmentUpload(e, token, req)
+		require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+		attachment := &v1pb.Attachment{}
+		require.NoError(t, protojson.Unmarshal(response.Body.Bytes(), attachment))
+		require.Equal(t, size, attachment.Size)
+	}
+	requireNoUploadTemps(t, svc)
+}
+
+type cancelAttachmentUploadReader struct {
+	io.ReadCloser
+	remaining int
+	cancel    context.CancelFunc
+}
+
+func (r *cancelAttachmentUploadReader) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	r.remaining -= n
+	if r.remaining <= 0 {
+		r.cancel()
+	}
+	return n, err
+}
+
+func TestAttachmentUploadCancellationRemovesPartialFile(t *testing.T) {
+	svc, e, token, _ := newAttachmentUploadTestServer(t)
+	req := attachmentMultipartRequest(t, `{"attachment":{"filename":"cancelled.bin"}}`, io.LimitReader(uploadZeroReader{}, 1<<20))
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+	req = req.WithContext(ctx)
+	req.Body = &cancelAttachmentUploadReader{ReadCloser: req.Body, remaining: 64 << 10, cancel: cancel}
+	response := serveAttachmentUpload(e, token, req)
+	require.NotEqual(t, http.StatusOK, response.Code)
+	attachments, err := svc.Store.ListAttachments(context.Background(), &store.FindAttachment{})
+	require.NoError(t, err)
+	require.Empty(t, attachments)
+	requireNoUploadTemps(t, svc)
+}
+
+func TestAttachmentUploadProcessesImagesAndPreservesClientMetadata(t *testing.T) {
+	svc, e, token, _ := newAttachmentUploadTestServer(t)
+	var content bytes.Buffer
+	require.NoError(t, jpeg.Encode(&content, image.NewRGBA(image.Rect(0, 0, 2, 3)), nil))
+	expected, err := stripImageExif(content.Bytes(), "image/jpeg")
+	require.NoError(t, err)
+	req := attachmentMultipartRequest(t, `{"attachment":{"filename":"photo.jpg","mediaMetadata":{"width":2,"height":3}}}`, &content)
+	response := serveAttachmentUpload(e, token, req)
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	attachment := &v1pb.Attachment{}
+	require.NoError(t, protojson.Unmarshal(response.Body.Bytes(), attachment))
+	require.EqualValues(t, 2, attachment.MediaMetadata.GetWidth())
+	require.EqualValues(t, 3, attachment.MediaMetadata.GetHeight())
+	uid, err := ExtractAttachmentUIDFromName(attachment.Name)
+	require.NoError(t, err)
+	stored, err := svc.Store.GetAttachment(context.Background(), &store.FindAttachment{UID: &uid})
+	require.NoError(t, err)
+	blob, err := svc.GetAttachmentBlob(context.Background(), stored)
+	require.NoError(t, err)
+	require.Equal(t, expected, blob)
+	require.EqualValues(t, len(blob), attachment.Size)
+	requireNoUploadTemps(t, svc)
+}
+
+func TestAttachmentUploadS3AndMotionPhoto(t *testing.T) {
+	svc, e, token, _ := newAttachmentUploadTestServer(t)
+	fake := fakes3.New(t, "uploads")
+	_, err := svc.Store.UpsertInstanceSetting(context.Background(), &storepb.InstanceSetting{
+		Key: storepb.InstanceSettingKey_STORAGE,
+		Value: &storepb.InstanceSetting_StorageSetting{StorageSetting: &storepb.InstanceStorageSetting{
+			DefaultStorageId: "s3", Storages: []*storepb.Storage{{
+				Id: "s3", Type: storepb.StorageType_STORAGE_TYPE_S3,
+				Config: &storepb.Storage_S3Config{S3Config: fake.Config("uploads")},
+			}},
+		}},
+	})
+	require.NoError(t, err)
+	content := testutil.BuildMotionPhotoJPEG()
+	req := attachmentMultipartRequest(t, `{"attachment":{"filename":"motion.jpg"}}`, bytes.NewReader(content))
+	response := serveAttachmentUpload(e, token, req)
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+	attachment := &v1pb.Attachment{}
+	require.NoError(t, protojson.Unmarshal(response.Body.Bytes(), attachment))
+	require.Equal(t, v1pb.MotionMediaFamily_ANDROID_MOTION_PHOTO, attachment.MotionMedia.GetFamily())
+	require.Equal(t, "image/jpeg", attachment.Type)
+	uid, err := ExtractAttachmentUIDFromName(attachment.Name)
+	require.NoError(t, err)
+	stored, err := svc.Store.GetAttachment(context.Background(), &store.FindAttachment{UID: &uid})
+	require.NoError(t, err)
+	blob, err := fake.GetObject("uploads", stored.Payload.GetS3Object().Key)
+	require.NoError(t, err)
+	require.Equal(t, content, blob)
+	require.Empty(t, stored.Blob)
+	requireNoUploadTemps(t, svc)
+}

--- a/server/router/api/v1/v1.go
+++ b/server/router/api/v1/v1.go
@@ -170,6 +170,7 @@ func (s *APIV1Service) RegisterGateway(ctx context.Context, echoServer *echo.Ech
 		return err
 	}
 	gwGroup := echoServer.Group("")
+	s.registerAttachmentUploadRoute(gwGroup, authorizer)
 	// Register SSE endpoint with same CORS as rest of /api/v1.
 	RegisterSSERoutes(gwGroup, s.SSEHub, s.Store, s.Secret)
 	handler := echo.WrapHandler(http.MaxBytesHandler(gwMux, MaxAPIRequestBytes))

--- a/web/src/components/MemoEditor/services/uploadService.ts
+++ b/web/src/components/MemoEditor/services/uploadService.ts
@@ -1,24 +1,35 @@
-import { create } from "@bufbuild/protobuf";
-import { attachmentServiceClient } from "@/connect";
+import { create, fromJsonString, toJsonString } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { authenticatedFetch } from "@/connect";
 import type { Attachment } from "@/types/proto/api/v1/attachment_service_pb";
-import { AttachmentSchema, MotionMediaSchema } from "@/types/proto/api/v1/attachment_service_pb";
+import { AttachmentSchema, CreateAttachmentRequestSchema, MotionMediaSchema } from "@/types/proto/api/v1/attachment_service_pb";
 import type { LocalFile } from "../types/attachment";
 
 export const uploadService = {
-  async uploadFile(localFile: LocalFile): Promise<Attachment> {
+  async uploadFile(localFile: LocalFile, signal?: AbortSignal): Promise<Attachment> {
     const { file, motionMedia } = localFile;
-    const [mediaMetadata, arrayBuffer] = await Promise.all([localFile.mediaMetadata, file.arrayBuffer()]);
-    const buffer = new Uint8Array(arrayBuffer);
-    return attachmentServiceClient.createAttachment({
+    const mediaMetadata = await localFile.mediaMetadata;
+    const metadata = create(CreateAttachmentRequestSchema, {
       attachment: create(AttachmentSchema, {
         filename: file.name,
         size: BigInt(file.size),
         type: file.type,
-        content: buffer,
         motionMedia: motionMedia ? create(MotionMediaSchema, motionMedia) : undefined,
         mediaMetadata,
       }),
     });
+    const body = new FormData();
+    body.append("metadata", toJsonString(CreateAttachmentRequestSchema, metadata));
+    body.append("file", file);
+    const response = await authenticatedFetch("/api/v1/attachments:upload", { method: "POST", body, signal });
+    if (!response.ok) {
+      const error = await response.json().catch(() => null);
+      throw new ConnectError(
+        error?.message || `Upload failed (${response.status})`,
+        error?.code || (response.status === 413 ? Code.ResourceExhausted : Code.Unknown),
+      );
+    }
+    return fromJsonString(AttachmentSchema, await response.text());
   },
 
   async uploadFiles(localFiles: LocalFile[]): Promise<Attachment[]> {

--- a/web/src/connect.ts
+++ b/web/src/connect.ts
@@ -150,6 +150,26 @@ export async function getRequestToken(): Promise<string | null> {
   return token;
 }
 
+// Native uploads use the same token preflight and one-time refresh as RPCs.
+// A FormData body can be sent again without reading its files into JavaScript.
+export async function authenticatedFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const send = (token: string | null) => {
+    const headers = new Headers(init?.headers);
+    if (token) headers.set("Authorization", `Bearer ${token}`);
+    return fetchWithCredentials(input, { ...init, headers });
+  };
+  const response = await send(await getRequestToken());
+  if (response.status !== 401) return response;
+  try {
+    const retry = await send(await refreshAndGetAccessToken());
+    if (retry.status === 401) throw new ConnectError("User not authenticated", Code.Unauthenticated);
+    return retry;
+  } catch (error) {
+    redirectOnAuthFailure();
+    throw error;
+  }
+}
+
 // ============================================================================
 // Authentication Interceptor
 // ============================================================================

--- a/web/tests/authenticated-fetch.test.ts
+++ b/web/tests/authenticated-fetch.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  token: "current-token" as string | null,
+  expired: false,
+  refresh: vi.fn(),
+  redirect: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock("@/auth-state", () => ({
+  getAccessToken: () => mocks.token,
+  hasStoredToken: () => true,
+  isTokenExpired: () => mocks.expired,
+  REQUEST_TOKEN_EXPIRY_BUFFER_MS: 30_000,
+  setAccessToken: (token: string) => {
+    mocks.token = token;
+    mocks.expired = false;
+  },
+}));
+vi.mock("@connectrpc/connect", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@connectrpc/connect")>()),
+  createClient: () => ({ refreshToken: mocks.refresh }),
+}));
+vi.mock("@/utils/auth-redirect", () => ({ redirectOnAuthFailure: mocks.redirect }));
+
+import { authenticatedFetch } from "@/connect";
+
+describe("authenticatedFetch", () => {
+  beforeEach(() => {
+    mocks.token = "current-token";
+    mocks.expired = false;
+    mocks.refresh.mockResolvedValue({ accessToken: "refreshed-token" });
+    vi.stubGlobal("fetch", mocks.fetch);
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("retries once after 401 with the same multipart body and refreshed token", async () => {
+    mocks.fetch.mockResolvedValueOnce({ status: 401 }).mockResolvedValueOnce({ status: 200 });
+    const body = new FormData();
+    body.append("file", new File(["content"], "a.txt"));
+    const response = await authenticatedFetch("/api/v1/attachments:upload", { method: "POST", body });
+
+    expect(response.status).toBe(200);
+    expect(mocks.refresh).toHaveBeenCalledOnce();
+    expect(mocks.fetch).toHaveBeenCalledTimes(2);
+    expect(mocks.fetch.mock.calls[0][1].headers.get("Authorization")).toBe("Bearer current-token");
+    expect(mocks.fetch.mock.calls[1][1].headers.get("Authorization")).toBe("Bearer refreshed-token");
+    for (const [, init] of mocks.fetch.mock.calls) {
+      expect(init.body).toBe(body);
+      expect(init.credentials).toBe("include");
+      expect(init.headers.has("Content-Type")).toBe(false);
+    }
+    expect(mocks.redirect).not.toHaveBeenCalled();
+  });
+
+  it("refreshes an expired token before sending file content", async () => {
+    mocks.expired = true;
+    mocks.fetch.mockResolvedValue({ status: 200 });
+    await authenticatedFetch("/upload");
+    expect(mocks.fetch).toHaveBeenCalledOnce();
+    expect(mocks.fetch.mock.calls[0][1].headers.get("Authorization")).toBe("Bearer refreshed-token");
+  });
+
+  it("does not retry a size rejection", async () => {
+    mocks.fetch.mockResolvedValue({ status: 413 });
+    expect((await authenticatedFetch("/upload")).status).toBe(413);
+    expect(mocks.fetch).toHaveBeenCalledOnce();
+    expect(mocks.refresh).not.toHaveBeenCalled();
+  });
+
+  it("redirects when the refreshed token is also rejected", async () => {
+    mocks.fetch.mockResolvedValue({ status: 401 });
+    await expect(authenticatedFetch("/upload")).rejects.toThrow("User not authenticated");
+    expect(mocks.fetch).toHaveBeenCalledTimes(2);
+    expect(mocks.redirect).toHaveBeenCalledOnce();
+  });
+});

--- a/web/tests/upload-media-metadata.test.ts
+++ b/web/tests/upload-media-metadata.test.ts
@@ -1,17 +1,18 @@
-import { create } from "@bufbuild/protobuf";
+import { create, fromJsonString } from "@bufbuild/protobuf";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { LocalFile } from "@/components/MemoEditor/types/attachment";
-import { MediaMetadataSchema } from "@/types/proto/api/v1/attachment_service_pb";
+import { CreateAttachmentRequestSchema, MediaMetadataSchema } from "@/types/proto/api/v1/attachment_service_pb";
 
 const mocks = vi.hoisted(() => ({
-  createAttachment: vi.fn(),
+  authenticatedFetch: vi.fn(),
   extractMetadata: vi.fn(),
 }));
 
 // The ingest helper lives beside useFileUpload, whose module graph reaches
 // AuthContext and the query hooks; stub every client they name-import.
 vi.mock("@/connect", () => ({
-  attachmentServiceClient: { createAttachment: mocks.createAttachment },
+  attachmentServiceClient: {},
+  authenticatedFetch: mocks.authenticatedFetch,
   authServiceClient: {},
   userServiceClient: {},
   memoViewServiceClient: {},
@@ -56,16 +57,45 @@ describe("media metadata at file ingest", () => {
   });
 });
 
+const submittedMetadata = () => {
+  const form = mocks.authenticatedFetch.mock.calls[0][1].body as FormData;
+  return fromJsonString(CreateAttachmentRequestSchema, form.get("metadata") as string);
+};
+
 describe("uploadService media metadata", () => {
   beforeEach(() => {
-    mocks.createAttachment.mockImplementation(async ({ attachment }) => attachment);
+    mocks.authenticatedFetch.mockResolvedValue({ ok: true, text: async () => '{"name":"attachments/uploaded"}' });
+  });
+
+  it("sends the original file without reading it into a byte array", async () => {
+    const localFile = localImage();
+    const read = vi.spyOn(localFile.file, "arrayBuffer");
+    const controller = new AbortController();
+    const attachment = await uploadService.uploadFile(localFile, controller.signal);
+    const [url, init] = mocks.authenticatedFetch.mock.calls[0];
+    expect(url).toBe("/api/v1/attachments:upload");
+    expect(init.method).toBe("POST");
+    expect(init.signal).toBe(controller.signal);
+    expect(init.body.get("file")).toBe(localFile.file);
+    expect(submittedMetadata().attachment?.content).toHaveLength(0);
+    expect(read).not.toHaveBeenCalled();
+    expect(attachment.name).toBe("attachments/uploaded");
+  });
+
+  it("surfaces upload errors from the server", async () => {
+    mocks.authenticatedFetch.mockResolvedValue({
+      ok: false,
+      status: 413,
+      json: async () => ({ code: 8, message: "file size exceeds the limit" }),
+    });
+    await expect(uploadService.uploadFile(localImage())).rejects.toThrow("file size exceeds the limit");
   });
 
   it("submits no metadata for files ingested without any", async () => {
     await uploadService.uploadFiles([localImage()]);
 
-    expect(mocks.createAttachment).toHaveBeenCalledOnce();
-    expect(mocks.createAttachment.mock.calls[0][0].attachment.mediaMetadata).toBeUndefined();
+    expect(mocks.authenticatedFetch).toHaveBeenCalledOnce();
+    expect(submittedMetadata().attachment?.mediaMetadata).toBeUndefined();
   });
 
   it("submits the metadata extracted at ingest", async () => {
@@ -73,14 +103,14 @@ describe("uploadService media metadata", () => {
 
     await uploadService.uploadFiles([localImage(Promise.resolve(metadata))]);
 
-    expect(mocks.createAttachment.mock.calls[0][0].attachment.mediaMetadata).toEqual(metadata);
+    expect(submittedMetadata().attachment?.mediaMetadata).toEqual(metadata);
   });
 
   it("continues without metadata when extraction produced no usable values", async () => {
     await uploadService.uploadFiles([localImage(Promise.resolve(undefined))]);
 
-    expect(mocks.createAttachment).toHaveBeenCalledOnce();
-    expect(mocks.createAttachment.mock.calls[0][0].attachment.mediaMetadata).toBeUndefined();
+    expect(mocks.authenticatedFetch).toHaveBeenCalledOnce();
+    expect(submittedMetadata().attachment?.mediaMetadata).toBeUndefined();
   });
 
   it("submits ingest-time metadata end to end", async () => {
@@ -90,6 +120,6 @@ describe("uploadService media metadata", () => {
 
     await uploadService.uploadFiles(toLocalFiles([file], { createBlobUrl, saveMediaMetadata: true }));
 
-    expect(mocks.createAttachment.mock.calls[0][0].attachment.mediaMetadata).toEqual(metadata);
+    expect(submittedMetadata().attachment?.mediaMetadata).toEqual(metadata);
   });
 });


### PR DESCRIPTION
Large web uploads currently load the entire file into browser and server memory before saving it. Add an authenticated multipart upload endpoint and send the original browser `File` with `FormData`, staging content on disk before saving to local storage or S3.

- Enforce the configured file limit while receiving bytes and remove temporary files on success, cancellation, and failure.
- Reuse attachment validation, memo permissions, token refresh, and database-failure compensation.
- Process images and detect Motion Photos from file readers while preserving media metadata and existing image limits.
- Keep the existing buffered REST and Connect APIs compatible. The multipart route supports uploads beyond their 256 MiB request cap.

Validation:
- Frontend lint, full test suite, additional upload/auth tests, and production build passed.
- Upload race tests cover a 300 MiB transfer, concurrent uploads, size boundaries, cancellation, failed writes, legacy routing, image processing, and S3. The large transfer allocated less than 1 MiB during the request.
- `go test -v -race ./internal/...` passed.
- `go test -v -race ./server/...` passed except `TestDetectAttachmentMimeType` and `TestUserWebhookSigningSecretLifecycle`. Both also fail on unchanged HEAD on this host: `.xyz` resolves to `chemical/x-xyz`, and the webhook test URL resolves to a reserved/private IP.

Uploads need temporary disk space; local finalization can temporarily require a second copy.

Fixes #6283.
