### PR TITLE
feat: add CLI version flags

### DIFF
--- a/cmd/memos/main.go
+++ b/cmd/memos/main.go
@@ -33,9 +33,14 @@ func initSlogDefault() {
 var (
 	rootCmd = &cobra.Command{
 		Use:           "memos",
+		Version:       version.GetCurrentVersion(),
 		SilenceErrors: true,
 		SilenceUsage:  true,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if showVersion, _ := cmd.Flags().GetBool("version-short"); showVersion {
+				fmt.Println(version.GetCurrentVersion())
+				return nil
+			}
 			return runServer()
 		},
 	}
@@ -50,11 +55,13 @@ var (
 
 func init() {
 	cobra.OnInitialize(initSlogDefault)
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
 
 	viper.SetDefault("demo", false)
 	viper.SetDefault("driver", "sqlite")
 	viper.SetDefault("port", 8081)
 
+	rootCmd.Flags().BoolP("version-short", "V", false, "print version")
 	rootCmd.Flags().Bool("demo", false, "enable demo mode")
 	rootCmd.Flags().String("addr", "", "address of server")
 	rootCmd.Flags().Int("port", 8081, "port of server")

--- a/cmd/memos/main_test.go
+++ b/cmd/memos/main_test.go
@@ -7,6 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestVersionFlagsAreAvailable(t *testing.T) {
+	require.NotEmpty(t, rootCmd.Version)
+	versionFlag := rootCmd.Flags().Lookup("version-short")
+	require.NotNil(t, versionFlag)
+	require.Equal(t, "V", versionFlag.Shorthand)
+}
+
 func TestServerFlagsAreNotInheritedBySubcommands(t *testing.T) {
 	require.Nil(t, versionCmd.InheritedFlags().Lookup("dsn"))
 	require.Nil(t, versionCmd.InheritedFlags().Lookup("instance-url"))


### PR DESCRIPTION
Add `-V` and `--version` aliases for the existing `version` command. Re: #6289

All three commands print the same version string:

```sh
memos version
memos -V
memos --version
```

- existing version behavior unchanged
- adds support for BSD/POSIX and GNU (and Cobra) conventions