### PR TITLE
feat: support ordered SSO claim fallbacks

### DIFF
--- a/internal/idp/oauth2/oauth2.go
+++ b/internal/idp/oauth2/oauth2.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -112,31 +113,30 @@ func (p *IdentityProvider) UserInfo(ctx context.Context, token string) (*idp.Ide
 		return nil, errors.Wrap(err, "failed to unmarshal response body")
 	}
 	userInfo := &idp.IdentityProviderUserInfo{}
-	if v, ok := claims[p.config.FieldMapping.Identifier].(string); ok {
-		userInfo.Identifier = v
-	}
+	userInfo.Identifier = firstMappedClaim(claims, p.config.FieldMapping.Identifier)
 	if userInfo.Identifier == "" {
 		return nil, errors.Errorf("the field %q is not found in claims or has empty value", p.config.FieldMapping.Identifier)
 	}
 
 	// Best effort to map optional fields
-	if p.config.FieldMapping.DisplayName != "" {
-		if v, ok := claims[p.config.FieldMapping.DisplayName].(string); ok {
-			userInfo.DisplayName = v
-		}
-	}
+	userInfo.DisplayName = firstMappedClaim(claims, p.config.FieldMapping.DisplayName)
 	if userInfo.DisplayName == "" {
 		userInfo.DisplayName = userInfo.Identifier
 	}
-	if p.config.FieldMapping.Email != "" {
-		if v, ok := claims[p.config.FieldMapping.Email].(string); ok {
-			userInfo.Email = v
-		}
-	}
-	if p.config.FieldMapping.AvatarUrl != "" {
-		if v, ok := claims[p.config.FieldMapping.AvatarUrl].(string); ok {
-			userInfo.AvatarURL = v
-		}
-	}
+	userInfo.Email = firstMappedClaim(claims, p.config.FieldMapping.Email)
+	userInfo.AvatarURL = firstMappedClaim(claims, p.config.FieldMapping.AvatarUrl)
 	return userInfo, nil
+}
+
+func firstMappedClaim(claims map[string]any, mapping string) string {
+	for _, field := range strings.FieldsFunc(mapping, isClaimMappingSeparator) {
+		if value, ok := claims[field].(string); ok && value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func isClaimMappingSeparator(r rune) bool {
+	return r == ',' || r == ' ' || r == '\t' || r == '\n'
 }

--- a/internal/idp/oauth2/oauth2_test.go
+++ b/internal/idp/oauth2/oauth2_test.go
@@ -163,6 +163,31 @@ func TestIdentityProvider(t *testing.T) {
 	assert.Equal(t, wantUserInfo, userInfoResult)
 }
 
+func TestIdentityProviderUsesOrderedClaimFallbacks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, `{"sub":"","uid":"stable-subject","nickname":"","name":"Alice Name","email":"alice@example.com","picture":"https://example.com/alice.png"}`)
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	provider, err := NewIdentityProvider(&storepb.OAuth2Config{
+		ClientId:     "client",
+		ClientSecret: "secret",
+		TokenUrl:     "https://example.com/token",
+		UserInfoUrl:  server.URL,
+		FieldMapping: &storepb.FieldMapping{Identifier: "sub uid", DisplayName: "nickname name", Email: "primary_email email", AvatarUrl: "avatar picture"},
+	})
+	require.NoError(t, err)
+
+	userInfo, err := provider.UserInfo(context.Background(), "token")
+	require.NoError(t, err)
+	require.Equal(t, "stable-subject", userInfo.Identifier)
+	require.Equal(t, "Alice Name", userInfo.DisplayName)
+	require.Equal(t, "alice@example.com", userInfo.Email)
+	require.Equal(t, "https://example.com/alice.png", userInfo.AvatarURL)
+}
+
 func TestIdentityProviderExchangeTokenClientAuthentication(t *testing.T) {
 	const (
 		clientID     = "test-client-id"


### PR DESCRIPTION
Re: #6290

This allows a priority-ordered string like `nickname name preferred_username` to be used for _Display Name_, or any claim mapping.

- Support space-delimited ordered fallback chains for SSO claim mappings
- Use the first mapped claim with a non-empty string value
- Applies to all claim mappings: Identifier, Display Name, Email, and Avatar URL

Pairs well with #6295