### PR TITLE
fix(scheduler): correct cron calendar day matching

### DIFF
--- a/internal/scheduler/parser.go
+++ b/internal/scheduler/parser.go
@@ -11,13 +11,14 @@ import (
 
 // Schedule represents a parsed cron expression.
 type Schedule struct {
-	seconds  fieldMatcher // 0-59 (optional, for 6-field format)
-	minutes  fieldMatcher // 0-59
-	hours    fieldMatcher // 0-23
-	days     fieldMatcher // 1-31
-	months   fieldMatcher // 1-12
-	weekdays fieldMatcher // 0-7 (0 and 7 are Sunday)
-	hasSecs  bool
+	seconds     fieldMatcher // 0-59 (optional, for 6-field format)
+	minutes     fieldMatcher // 0-59
+	hours       fieldMatcher // 0-23
+	days        fieldMatcher // 1-31
+	months      fieldMatcher // 1-12
+	weekdays    fieldMatcher // 0-7 (0 and 7 are Sunday)
+	hasSecs     bool
+	dayWildcard bool
 }
 
 // fieldMatcher determines if a field value matches.
@@ -84,6 +85,7 @@ func ParseCronExpression(expr string) (*Schedule, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid weekdays field")
 	}
+	s.dayWildcard = strings.HasPrefix(fields[offset+2], "*") || strings.HasPrefix(fields[offset+4], "*")
 
 	return s, nil
 }
@@ -119,11 +121,24 @@ func (s *Schedule) Next(from time.Time) time.Time {
 
 // matches checks if the given time matches the schedule.
 func (s *Schedule) matches(t time.Time) bool {
-	return s.seconds.matches(t.Second()) &&
-		s.minutes.matches(t.Minute()) &&
-		s.hours.matches(t.Hour()) &&
-		s.months.matches(int(t.Month())) &&
-		(s.days.matches(t.Day()) || s.weekdays.matches(int(t.Weekday())))
+	if !s.seconds.matches(t.Second()) || !s.minutes.matches(t.Minute()) ||
+		!s.hours.matches(t.Hour()) || !s.months.matches(int(t.Month())) {
+		return false
+	}
+
+	dayMatches := s.days.matches(t.Day())
+	weekdayMatches := s.weekdays.matches(int(t.Weekday()))
+	if t.Weekday() == time.Sunday {
+		weekdayMatches = weekdayMatches || s.weekdays.matches(7)
+	}
+
+	// Cron combines restricted day fields with OR, but wildcard fields (including steps) use AND.
+	calendarMatches := dayMatches || weekdayMatches
+	if s.dayWildcard {
+		calendarMatches = dayMatches && weekdayMatches
+	}
+
+	return calendarMatches
 }
 
 // parseField parses a single cron field (supports *, ranges, lists, steps).

--- a/internal/scheduler/parser_calendar_test.go
+++ b/internal/scheduler/parser_calendar_test.go
@@ -1,0 +1,58 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduleNextCalendarDays(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		from string
+		want string
+	}{
+		{"weekly", "0 0 * * 0", "2025-01-01T10:00:00Z", "2025-01-05T00:00:00Z"},
+		{"monthly", "0 0 1 * *", "2025-01-02T00:00:00Z", "2025-02-01T00:00:00Z"},
+		{"weekdays skip weekend", "0 9 * * 1-5", "2025-01-03T09:00:00Z", "2025-01-06T09:00:00Z"},
+		{"day step with weekday", "0 0 */2 * 3", "2025-01-01T00:00:00Z", "2025-01-15T00:00:00Z"},
+		{"weekday step with day", "0 0 13 * */2", "2025-01-01T00:00:00Z", "2025-02-13T00:00:00Z"},
+		{"both day steps", "0 0 */2 * */2", "2025-01-01T00:00:00Z", "2025-01-05T00:00:00Z"},
+		{"restricted fields match day", "0 0 15 * 1", "2025-01-13T00:00:00Z", "2025-01-15T00:00:00Z"},
+		{"restricted fields match weekday", "0 0 15 * 1", "2025-01-15T00:00:00Z", "2025-01-20T00:00:00Z"},
+		{"explicit full range uses OR", "0 0 1-31 * 1", "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z"},
+		{"Sunday zero with restricted day", "0 0 31 * 0", "2025-01-04T00:00:00Z", "2025-01-05T00:00:00Z"},
+		{"Sunday seven with restricted day", "0 0 31 * 7", "2025-01-04T00:00:00Z", "2025-01-05T00:00:00Z"},
+		{"Sunday seven with wildcard day", "0 0 * * 7", "2025-01-06T00:00:00Z", "2025-01-12T00:00:00Z"},
+		{"Sunday seven in list", "0 0 31 * 1,7", "2025-01-04T00:00:00Z", "2025-01-05T00:00:00Z"},
+		{"Sunday seven in range", "0 0 31 * 5-7", "2025-01-04T00:00:00Z", "2025-01-05T00:00:00Z"},
+		{"Sunday aliases do not repeat", "0 0 * * 0,7", "2025-01-05T00:00:00Z", "2025-01-12T00:00:00Z"},
+	}
+
+	for _, format := range []struct {
+		name   string
+		prefix string
+	}{
+		{"five fields", ""},
+		{"six fields", "0 "},
+	} {
+		t.Run(format.name, func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					from, err := time.Parse(time.RFC3339, tt.from)
+					require.NoError(t, err)
+					want, err := time.Parse(time.RFC3339, tt.want)
+					require.NoError(t, err)
+					schedule, err := ParseCronExpression(format.prefix + tt.expr)
+					require.NoError(t, err)
+
+					next := schedule.Next(from)
+
+					require.Equal(t, want, next)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Cron schedules such as `0 0 * * 0` and `0 0 1 * *` currently run daily because the wildcard day field overrides the other restriction. Combine day-of-month and day-of-week with AND when either uses a wildcard (including `*/N`), retaining OR when both fields are explicitly restricted.

Also recognize weekday `7` as Sunday alongside `0`, including lists and ranges. For example, `0 0 31 * 7` after January 4, 2025 now selects January 5 instead of January 31. Public APIs and dependencies are unchanged.

Related: #6090 already proposes the Sunday-7 correction in the same parser. This PR overlaps that part and offers a broader calendar-matching fix: it also corrects the independent day-of-month/day-of-week wildcard semantics and tests both behaviors together. The Sunday changes should be reconciled when either PR is merged.

Validation:

- Added 30 regression cases across five- and six-field formats, verified failing before the fix and passing afterward.
- `go test -v -race ./internal/...`
- `go test -race ./internal/scheduler -count=1`
- `go vet ./internal/scheduler`
- `git diff --check`
- Standalone public-API checks for weekly, monthly and Sunday schedules.

`gopls` and `golangci-lint` were not installed locally, so LSP diagnostics and the full lint check were not run.
