### PR TITLE
fix(email): preserve sender names and support IPv6 SMTP hosts

### DIFF
--- a/internal/email/config.go
+++ b/internal/email/config.go
@@ -1,7 +1,8 @@
 package email
 
 import (
-	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/pkg/errors"
 )
@@ -43,5 +44,5 @@ func (c *Config) Validate() error {
 
 // GetServerAddress returns the SMTP server address in the format "host:port".
 func (c *Config) GetServerAddress() string {
-	return fmt.Sprintf("%s:%d", c.SMTPHost, c.SMTPPort)
+	return net.JoinHostPort(c.SMTPHost, strconv.Itoa(c.SMTPPort))
 }

--- a/internal/email/config_address_test.go
+++ b/internal/email/config_address_test.go
@@ -1,0 +1,22 @@
+package email
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigServerAddressPreservesHost(t *testing.T) {
+	for _, host := range []string{"smtp.example.com", "127.0.0.1", "::1", "2001:db8::1", "fe80::1%eth0"} {
+		t.Run(host, func(t *testing.T) {
+			config := Config{SMTPHost: host, SMTPPort: 587}
+
+			address := config.GetServerAddress()
+			gotHost, gotPort, err := net.SplitHostPort(address)
+			require.NoError(t, err, "SMTP address: %s", address)
+			require.Equal(t, host, gotHost)
+			require.Equal(t, "587", gotPort)
+		})
+	}
+}

--- a/internal/email/message.go
+++ b/internal/email/message.go
@@ -3,6 +3,7 @@ package email
 import (
 	"errors"
 	"fmt"
+	"net/mail"
 	"strings"
 	"time"
 )
@@ -44,7 +45,8 @@ func (m *Message) Format(fromEmail, fromName string) string {
 
 	// From header
 	if fromName != "" {
-		fmt.Fprintf(&sb, "From: %s <%s>\r\n", fromName, fromEmail)
+		from := mail.Address{Name: fromName, Address: fromEmail}
+		fmt.Fprintf(&sb, "From: %s\r\n", from.String())
 	} else {
 		fmt.Fprintf(&sb, "From: %s\r\n", fromEmail)
 	}

--- a/internal/email/message_sender_test.go
+++ b/internal/email/message_sender_test.go
@@ -1,0 +1,36 @@
+package email
+
+import (
+	"net/mail"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessageFormatPreservesSenderDisplayName(t *testing.T) {
+	for _, name := range []string{
+		"Sender Name",
+		"Memos, Inc.",
+		"Memos (Notifications)",
+		`Memos "Team"`,
+		"Notifiche di Nicolò",
+	} {
+		t.Run(name, func(t *testing.T) {
+			message := Message{
+				To:      []string{"user@example.com"},
+				Subject: "Test",
+				Body:    "Test body",
+			}
+
+			formatted := message.Format("sender@example.com", name)
+			parsed, err := mail.ReadMessage(strings.NewReader(formatted))
+			require.NoError(t, err)
+			senders, err := parsed.Header.AddressList("From")
+			require.NoError(t, err, "From header: %s", parsed.Header.Get("From"))
+			require.Len(t, senders, 1)
+			require.Equal(t, "sender@example.com", senders[0].Address)
+			require.Equal(t, name, senders[0].Name)
+		})
+	}
+}

--- a/internal/email/message_test.go
+++ b/internal/email/message_test.go
@@ -80,7 +80,7 @@ func TestMessageFormatPlainText(t *testing.T) {
 	formatted := msg.Format("sender@example.com", "Sender Name")
 
 	// Check required headers
-	if !strings.Contains(formatted, "From: Sender Name <sender@example.com>") {
+	if !strings.Contains(formatted, "From: \"Sender Name\" <sender@example.com>") {
 		t.Error("Missing or incorrect From header")
 	}
 	if !strings.Contains(formatted, "To: user@example.com") {
@@ -164,7 +164,7 @@ func TestMessageFormatSanitizesHeaderValues(t *testing.T) {
 	if !strings.Contains(headers, "Subject: Test X-Injected-Subject: bad") {
 		t.Error("subject header was not normalized")
 	}
-	if !strings.Contains(headers, "From: Sender X-Injected-Name: bad <sender@example.com X-Injected-From: bad>") {
+	if !strings.Contains(headers, "From: \"Sender X-Injected-Name: bad\" <sender@example.com X-Injected-From: bad>") {
 		t.Error("from header was not normalized")
 	}
 }

--- a/internal/email/smtp_delivery_test.go
+++ b/internal/email/smtp_delivery_test.go
@@ -1,0 +1,103 @@
+package email
+
+import (
+	"net"
+	"net/mail"
+	"net/textproto"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendPreservesSenderOverSMTP(t *testing.T) {
+	for _, host := range []string{"127.0.0.1", "::1"} {
+		t.Run(host, func(t *testing.T) {
+			listener, err := net.Listen("tcp", net.JoinHostPort(host, "0"))
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = listener.Close() })
+
+			type delivery struct {
+				body []byte
+				err  error
+			}
+			received := make(chan delivery, 1)
+			go func() {
+				body, err := receiveSMTPMessage(listener)
+				received <- delivery{body: body, err: err}
+			}()
+
+			config := &Config{
+				SMTPHost:  host,
+				SMTPPort:  listener.Addr().(*net.TCPAddr).Port,
+				FromEmail: "sender@example.com",
+				FromName:  "Memos, Inc. (Notifiche)",
+			}
+			message := &Message{
+				To:      []string{"recipient@example.com"},
+				Subject: "SMTP delivery",
+				Body:    "A notification from Memos.",
+			}
+			require.NoError(t, Send(config, message))
+
+			select {
+			case result := <-received:
+				require.NoError(t, result.err)
+				parsed, err := mail.ReadMessage(strings.NewReader(string(result.body)))
+				require.NoError(t, err)
+				senders, err := parsed.Header.AddressList("From")
+				require.NoError(t, err)
+				require.Len(t, senders, 1)
+				require.Equal(t, config.FromName, senders[0].Name)
+				require.Equal(t, config.FromEmail, senders[0].Address)
+			case <-time.After(5 * time.Second):
+				t.Fatal("SMTP server did not receive the notification")
+			}
+		})
+	}
+}
+
+func receiveSMTPMessage(listener net.Listener) ([]byte, error) {
+	conn, err := listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		return nil, err
+	}
+	client := textproto.NewConn(conn)
+	if err := client.PrintfLine("220 localhost ESMTP"); err != nil {
+		return nil, err
+	}
+	var body []byte
+	for {
+		line, err := client.ReadLine()
+		if err != nil {
+			return nil, err
+		}
+		command, _, _ := strings.Cut(line, " ")
+		switch command {
+		case "EHLO", "HELO", "MAIL", "RCPT":
+			err = client.PrintfLine("250 OK")
+		case "DATA":
+			if err := client.PrintfLine("354 Send message"); err != nil {
+				return nil, err
+			}
+			body, err = client.ReadDotBytes()
+			if err != nil {
+				return nil, err
+			}
+			err = client.PrintfLine("250 Accepted")
+		case "QUIT":
+			return body, client.PrintfLine("221 Goodbye")
+		default:
+			return nil, errors.Errorf("unexpected SMTP command: %s", line)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+}


### PR DESCRIPTION
Sender display names such as `Memos, Inc.` produced invalid From headers, while parentheses and quotes could be lost when parsed. Format the sender with `net/mail.Address` so punctuation and non-ASCII names are preserved after the existing header sanitization.

SMTP hosts such as `::1` produced addresses like `::1:587`, causing dialing to fail with `too many colons in address`. Use `net.JoinHostPort` for hostname, IPv4, IPv6, and scoped IPv6 addresses.

Validation:
- Regression tests cover sender-name parsing, header sanitization, and SMTP address round trips.
- Local SMTP delivery tests exercise the public `Send` path over IPv4 and IPv6 and parse the received From header.
- `go test -v -race ./internal/...`
- `go build ./internal/email`
- `go vet ./internal/email`

`golangci-lint` was unavailable locally.

Related: #6272 addresses RFC 2047 encoding of Subject and From text. This PR also fixes ASCII punctuation in sender names (for example `Memos, Inc.`), which encoded-word handling alone leaves unchanged, and SMTP IPv6 dialing. `mail.Address.String` already performs the required encoded-word handling for non-ASCII display names; Subject encoding remains covered by #6272. The From changes should be coordinated when merging both PRs to avoid pre-encoding a name before passing it to `mail.Address`.
