### PR TITLE
fix(web): untrap focus mode in the memo grid and use a dark scrim token for overlays

### DIFF
--- a/web/src/components/ColumnGrid/ColumnGrid.tsx
+++ b/web/src/components/ColumnGrid/ColumnGrid.tsx
@@ -1,5 +1,7 @@
 import { useDirection } from "@base-ui/react/direction-provider";
 import { type ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import { useColumnGridUntrapped } from "./ColumnGridContext";
 
 interface ColumnGridProps<T> {
   items: T[];
@@ -85,6 +87,7 @@ function ColumnGrid<T>({
   maxColumnWidth,
 }: ColumnGridProps<T>) {
   const direction = useDirection();
+  const { untrappedKey } = useColumnGridUntrapped();
   const containerRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const refCallbacks = useRef<Map<string, (el: HTMLDivElement | null) => void>>(new Map());
@@ -187,13 +190,14 @@ function ColumnGrid<T>({
     for (const { key, el } of ordered) {
       const target = pos.get(key);
       if (!target) continue;
-      // The leading tile (the note composer) is positioned with left/top rather than a
-      // transform so it never becomes the containing block for its own position:fixed
-      // descendants. A transform (or will-change:transform) here would trap the editor's
-      // focus-mode overlay — which is meant to cover the viewport — inside this column tile.
-      // The leading tile is pinned to column one's top and only shifts horizontally on
-      // resize (which snaps anyway), so it loses no animation by skipping the transform.
-      if (key === LEADING_KEY) {
+      // Untrapped tiles are positioned with left/top rather than a transform so they never
+      // become the containing block for their own position:fixed descendants. A transform
+      // (or will-change:transform) would trap the editor's focus-mode overlay — which is
+      // meant to cover the viewport — inside this column tile. The leading composer tile
+      // always opts out; a memo tile opts out while its inline editor is in focus mode. Both
+      // are pinned horizontally and only shift on resize (which snaps anyway), so neither
+      // loses an animation that matters.
+      if (key === LEADING_KEY || key === untrappedKey) {
         el.style.transition = "none";
         el.style.transform = "";
         el.style.left = `${target.x}px`;
@@ -202,10 +206,13 @@ function ColumnGrid<T>({
       }
       el.style.transition = "none";
       el.style.transform = `translate3d(${target.x}px, ${target.y}px, 0)`;
+      // Clear any left/top left behind by a previous untrapped stint.
+      el.style.left = "";
+      el.style.top = "";
     }
 
     setContainerHeight(Math.max(0, ...columnY.map((h) => h - GRID_GAP)));
-  }, [items, getKey, estimateHeight, priorityKey, maxColumns, maxColumnWidth, direction]);
+  }, [items, getKey, estimateHeight, priorityKey, maxColumns, maxColumnWidth, direction, untrappedKey]);
 
   // Keep a stable reference so observer callbacks always run the latest layout.
   const relayoutRef = useRef(relayout);
@@ -299,12 +306,16 @@ function ColumnGrid<T>({
       )}
       {items.map((item) => {
         const key = getKey(item);
+        const isUntrapped = key === untrappedKey;
         return (
           <div
             key={key}
             ref={getItemRef(key)}
-            className="absolute top-0 left-0 transition-transform duration-200 ease-out motion-reduce:transition-none"
-            style={{ willChange: "transform" }}
+            className={cn(
+              "absolute top-0 left-0",
+              !isUntrapped && "transition-transform duration-200 ease-out motion-reduce:transition-none",
+            )}
+            style={isUntrapped ? undefined : { willChange: "transform" }}
           >
             {renderItem(item)}
           </div>

--- a/web/src/components/ColumnGrid/ColumnGrid.tsx
+++ b/web/src/components/ColumnGrid/ColumnGrid.tsx
@@ -87,7 +87,7 @@ function ColumnGrid<T>({
   maxColumnWidth,
 }: ColumnGridProps<T>) {
   const direction = useDirection();
-  const { untrappedKey } = useColumnGridUntrapped();
+  const { untrappedKeys } = useColumnGridUntrapped();
   const containerRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const refCallbacks = useRef<Map<string, (el: HTMLDivElement | null) => void>>(new Map());
@@ -197,7 +197,7 @@ function ColumnGrid<T>({
       // always opts out; a memo tile opts out while its inline editor is in focus mode. Both
       // are pinned horizontally and only shift on resize (which snaps anyway), so neither
       // loses an animation that matters.
-      if (key === LEADING_KEY || key === untrappedKey) {
+      if (key === LEADING_KEY || untrappedKeys.has(key)) {
         el.style.transition = "none";
         el.style.transform = "";
         el.style.left = `${target.x}px`;
@@ -212,7 +212,7 @@ function ColumnGrid<T>({
     }
 
     setContainerHeight(Math.max(0, ...columnY.map((h) => h - GRID_GAP)));
-  }, [items, getKey, estimateHeight, priorityKey, maxColumns, maxColumnWidth, direction, untrappedKey]);
+  }, [items, getKey, estimateHeight, priorityKey, maxColumns, maxColumnWidth, direction, untrappedKeys]);
 
   // Keep a stable reference so observer callbacks always run the latest layout.
   const relayoutRef = useRef(relayout);
@@ -306,7 +306,7 @@ function ColumnGrid<T>({
       )}
       {items.map((item) => {
         const key = getKey(item);
-        const isUntrapped = key === untrappedKey;
+        const isUntrapped = untrappedKeys.has(key);
         return (
           <div
             key={key}

--- a/web/src/components/ColumnGrid/ColumnGridContext.tsx
+++ b/web/src/components/ColumnGrid/ColumnGridContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
+
+interface ColumnGridUntrappedValue {
+  /** Key of the tile that must not be positioned with a transform, if any. */
+  untrappedKey?: string;
+  /** Claims the untrapped slot for a tile. */
+  setUntrappedKey: (key: string) => void;
+  /** Releases the slot only if `key` still owns it. */
+  clearUntrappedKey: (key: string) => void;
+}
+
+// Defaults keep MemoView working outside a grid (flow list, detail page, comments).
+const ColumnGridUntrappedContext = createContext<ColumnGridUntrappedValue>({
+  untrappedKey: undefined,
+  setUntrappedKey: () => {},
+  clearUntrappedKey: () => {},
+});
+
+/**
+ * Lets one tile opt out of the grid's transform positioning while it hosts a
+ * `position: fixed` surface (the inline editor's focus mode). A transformed
+ * ancestor is the containing block for fixed descendants, which would trap the
+ * focus-mode overlay inside the card instead of covering the viewport. The
+ * leading composer tile already opts out the same way; see ColumnGrid.relayout.
+ */
+export function ColumnGridUntrappedProvider({ children }: { children: ReactNode }) {
+  const [untrappedKey, setUntrappedKey] = useState<string>();
+  // Ownership-scoped clear: mounting cards must not clobber a slot another
+  // card's focused editor owns.
+  const clearUntrappedKey = useCallback((key: string) => {
+    setUntrappedKey((current) => (current === key ? undefined : current));
+  }, []);
+  // Memoized so consumers re-render only when the key itself changes; both
+  // setters stay stable, so effects keyed on them do not re-run.
+  const value = useMemo(() => ({ untrappedKey, setUntrappedKey, clearUntrappedKey }), [untrappedKey, clearUntrappedKey, setUntrappedKey]);
+  return <ColumnGridUntrappedContext.Provider value={value}>{children}</ColumnGridUntrappedContext.Provider>;
+}
+
+export const useColumnGridUntrapped = () => useContext(ColumnGridUntrappedContext);

--- a/web/src/components/ColumnGrid/ColumnGridContext.tsx
+++ b/web/src/components/ColumnGrid/ColumnGridContext.tsx
@@ -1,38 +1,53 @@
 import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from "react";
 
 interface ColumnGridUntrappedValue {
-  /** Key of the tile that must not be positioned with a transform, if any. */
-  untrappedKey?: string;
-  /** Claims the untrapped slot for a tile. */
+  /** Keys of tiles that must not be positioned with a transform. */
+  untrappedKeys: ReadonlySet<string>;
+  /** Adds a tile to the untrapped set. */
   setUntrappedKey: (key: string) => void;
-  /** Releases the slot only if `key` still owns it. */
+  /** Removes a tile from the untrapped set. */
   clearUntrappedKey: (key: string) => void;
 }
 
 // Defaults keep MemoView working outside a grid (flow list, detail page, comments).
 const ColumnGridUntrappedContext = createContext<ColumnGridUntrappedValue>({
-  untrappedKey: undefined,
+  untrappedKeys: new Set(),
   setUntrappedKey: () => {},
   clearUntrappedKey: () => {},
 });
 
 /**
- * Lets one tile opt out of the grid's transform positioning while it hosts a
+ * Lets tiles opt out of the grid's transform positioning while they host a
  * `position: fixed` surface (the inline editor's focus mode). A transformed
  * ancestor is the containing block for fixed descendants, which would trap the
  * focus-mode overlay inside the card instead of covering the viewport. The
  * leading composer tile already opts out the same way; see ColumnGrid.relayout.
+ *
+ * A set, not a single key: inline editors are independently openable, so more
+ * than one card can hold focus mode at a time and each must keep its own tile
+ * untrapped.
  */
 export function ColumnGridUntrappedProvider({ children }: { children: ReactNode }) {
-  const [untrappedKey, setUntrappedKey] = useState<string>();
-  // Ownership-scoped clear: mounting cards must not clobber a slot another
-  // card's focused editor owns.
-  const clearUntrappedKey = useCallback((key: string) => {
-    setUntrappedKey((current) => (current === key ? undefined : current));
+  const [untrappedKeys, setUntrappedKeys] = useState<ReadonlySet<string>>(() => new Set());
+  const setUntrappedKey = useCallback((key: string) => {
+    setUntrappedKeys((current) => {
+      if (current.has(key)) return current;
+      const next = new Set(current);
+      next.add(key);
+      return next;
+    });
   }, []);
-  // Memoized so consumers re-render only when the key itself changes; both
-  // setters stay stable, so effects keyed on them do not re-run.
-  const value = useMemo(() => ({ untrappedKey, setUntrappedKey, clearUntrappedKey }), [untrappedKey, clearUntrappedKey, setUntrappedKey]);
+  const clearUntrappedKey = useCallback((key: string) => {
+    setUntrappedKeys((current) => {
+      if (!current.has(key)) return current;
+      const next = new Set(current);
+      next.delete(key);
+      return next;
+    });
+  }, []);
+  // Memoized so consumers re-render only when the set itself changes; both
+  // callbacks stay stable, so effects keyed on them do not re-run.
+  const value = useMemo(() => ({ untrappedKeys, setUntrappedKey, clearUntrappedKey }), [untrappedKeys, setUntrappedKey, clearUntrappedKey]);
   return <ColumnGridUntrappedContext.Provider value={value}>{children}</ColumnGridUntrappedContext.Provider>;
 }
 

--- a/web/src/components/ColumnGrid/index.ts
+++ b/web/src/components/ColumnGrid/index.ts
@@ -1,4 +1,5 @@
 import ColumnGrid from "./ColumnGrid";
 
 export { assignColumnsByEstimatedHeight, columnCountForWidth, GRID_GAP } from "./ColumnGrid";
+export { ColumnGridUntrappedProvider, useColumnGridUntrapped } from "./ColumnGridContext";
 export default ColumnGrid;

--- a/web/src/components/MemoEditor/constants.ts
+++ b/web/src/components/MemoEditor/constants.ts
@@ -1,5 +1,5 @@
 export const FOCUS_MODE_STYLES = {
-  backdrop: "fixed inset-0 bg-black/20 backdrop-blur-sm z-40",
+  backdrop: "fixed inset-0 bg-overlay/20 backdrop-blur-sm z-overlay",
   container: {
     base: "fixed z-50 w-auto max-w-5xl mx-auto shadow-2xl border-border h-auto overflow-y-auto",
     spacing: "top-2 left-2 right-2 bottom-2 sm:top-4 sm:left-4 sm:right-4 sm:bottom-4 md:top-8 md:left-8 md:right-8 md:bottom-8",

--- a/web/src/components/MemoEditor/index.tsx
+++ b/web/src/components/MemoEditor/index.tsx
@@ -45,6 +45,7 @@ const MemoEditorImpl: React.FC<MemoEditorProps> = ({
   defaultLocation,
   autoFocus,
   onFocusModeExit,
+  onFocusModeChange,
   placeholder,
   defaultCreateTime,
   onConfirm,
@@ -59,6 +60,10 @@ const MemoEditorImpl: React.FC<MemoEditorProps> = ({
   // typing (which changes content) does not re-render the editor shell and its
   // toolbar/metadata children.
   const isFocusMode = useEditorSelector((s) => s.ui.isFocusMode);
+  // Report focus-mode changes so a host can react; inline hosts pass nothing.
+  useEffect(() => {
+    onFocusModeChange?.(isFocusMode);
+  }, [isFocusMode, onFocusModeChange]);
   const isSaving = useEditorSelector((s) => s.ui.isLoading.saving);
   const hasTimestamp = useEditorSelector((s) => Boolean(s.timestamps.createTime));
   const { userGeneralSetting } = useAuth();

--- a/web/src/components/MemoEditor/types/components.ts
+++ b/web/src/components/MemoEditor/types/components.ts
@@ -24,6 +24,12 @@ export interface MemoEditorProps {
    */
   onFocusModeExit?: () => void;
   /**
+   * Reports inline focus-mode changes. A host reacts to the editor taking over
+   * the viewport, e.g. the memo grid untraps its tile so the fixed focus-mode
+   * surface is not contained by a transformed ancestor.
+   */
+  onFocusModeChange?: (isFocusMode: boolean) => void;
+  /**
    * Default `createTime` for a *new* memo (create mode only). When set, the
    * editor seeds both `createTime` and `updateTime` to this value and renders
    * the timestamp popover so the user can adjust before saving. Tracked live:

--- a/web/src/components/MemoView/MemoView.tsx
+++ b/web/src/components/MemoView/MemoView.tsx
@@ -4,6 +4,7 @@ import {
   memo,
   Suspense,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useLayoutEffect,
   useMemo,
@@ -11,6 +12,7 @@ import {
   useState,
 } from "react";
 import { useLocation } from "react-router-dom";
+import { useColumnGridUntrapped } from "@/components/ColumnGrid/ColumnGridContext";
 import { useResolvedUser } from "@/components/MemoContent/MentionResolutionContext";
 import { loadMemoEditor } from "@/components/MemoEditor/loader";
 import type { MemoEditorProps } from "@/components/MemoEditor/types";
@@ -88,6 +90,28 @@ const MemoView = forwardRef<MemoViewHandle, MemoViewProps>((props, ref) => {
       .catch(() => undefined);
   }, [EditorComponent, focusMountedEditor, showEditor]);
   const closeEditor = useCallback(() => setShowEditor(false), []);
+
+  // The grid keys tiles by memo name (see getMemoKey), so the focused editor
+  // identifies its own tile by name and untraps it for the duration.
+  const { setUntrappedKey, clearUntrappedKey } = useColumnGridUntrapped();
+  const handleFocusModeChange = useCallback(
+    (isFocusMode: boolean) => {
+      if (isFocusMode) {
+        setUntrappedKey(memoData.name);
+      } else {
+        clearUntrappedKey(memoData.name);
+      }
+    },
+    [memoData.name, setUntrappedKey, clearUntrappedKey],
+  );
+  // Release the slot when the editor closes or this card unmounts. Both calls
+  // are ownership-scoped, so mounting cards never clobber another card's slot.
+  useEffect(() => {
+    if (!showEditor) {
+      clearUntrappedKey(memoData.name);
+    }
+  }, [showEditor, memoData.name, clearUntrappedKey]);
+  useEffect(() => () => clearUntrappedKey(memoData.name), [memoData.name, clearUntrappedKey]);
 
   useImperativeHandle(ref, () => ({ openEditor }), [openEditor]);
 
@@ -214,6 +238,7 @@ const MemoView = forwardRef<MemoViewHandle, MemoViewProps>((props, ref) => {
             parentMemoName={memoData.parent || undefined}
             onConfirm={closeEditor}
             onCancel={closeEditor}
+            onFocusModeChange={handleFocusModeChange}
           />
         </div>
       ) : (

--- a/web/src/components/PagedMemoList/PagedMemoList.tsx
+++ b/web/src/components/PagedMemoList/PagedMemoList.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils";
 import { State } from "@/types/proto/api/v1/common_pb";
 import type { Memo } from "@/types/proto/api/v1/memo_service_pb";
 import { useTranslate } from "@/utils/i18n";
-import ColumnGrid, { columnCountForWidth, GRID_GAP } from "../ColumnGrid";
+import ColumnGrid, { ColumnGridUntrappedProvider, columnCountForWidth, GRID_GAP } from "../ColumnGrid";
 import MemoFilters from "../MemoFilters";
 import Placeholder from "../Placeholder";
 import MemoListError from "./MemoListError";
@@ -281,17 +281,19 @@ const PagedMemoList = (props: Props) => {
         <div className={cn("flex flex-col justify-start w-full mx-auto", useGrid ? "max-w-none" : "max-w-2xl")}>
           {useGrid ? (
             <>
-              <ColumnGrid
-                items={displayMemoList}
-                getKey={getMemoKey}
-                renderItem={(memo) => props.renderer(memo, { compact: effectiveCompact })}
-                estimateHeight={estimateMemoCardHeight}
-                header={headerContent}
-                leading={gridLeading}
-                priorityKey={priorityKey}
-                maxColumns={maxColumns}
-                maxColumnWidth={MAX_COLUMN_WIDTH}
-              />
+              <ColumnGridUntrappedProvider>
+                <ColumnGrid
+                  items={displayMemoList}
+                  getKey={getMemoKey}
+                  renderItem={(memo) => props.renderer(memo, { compact: effectiveCompact })}
+                  estimateHeight={estimateMemoCardHeight}
+                  header={headerContent}
+                  leading={gridLeading}
+                  priorityKey={priorityKey}
+                  maxColumns={maxColumns}
+                  maxColumnWidth={MAX_COLUMN_WIDTH}
+                />
+              </ColumnGridUntrappedProvider>
               {!isDisplayPending && footer}
             </>
           ) : (

--- a/web/src/components/ui/dialog.tsx
+++ b/web/src/components/ui/dialog.tsx
@@ -17,7 +17,7 @@ const DialogOverlay = React.forwardRef<HTMLDivElement, DialogPrimitive.Backdrop.
     ref={ref}
     data-slot="dialog-overlay"
     className={cn(
-      "fixed inset-0 z-overlay bg-foreground/50 transition-opacity duration-200 data-starting-style:opacity-0 data-ending-style:opacity-0",
+      "fixed inset-0 z-overlay bg-overlay/50 transition-opacity duration-200 data-starting-style:opacity-0 data-ending-style:opacity-0",
       className,
     )}
     {...props}

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -27,7 +27,7 @@ const SheetOverlay = React.forwardRef<HTMLDivElement, SheetPrimitive.Backdrop.Pr
       ref={ref}
       data-slot="sheet-overlay"
       className={cn(
-        "fixed inset-0 z-overlay bg-foreground/50 transition-opacity duration-300 data-starting-style:opacity-0 data-ending-style:opacity-0",
+        "fixed inset-0 z-overlay bg-overlay/50 transition-opacity duration-300 data-starting-style:opacity-0 data-ending-style:opacity-0",
         className,
       )}
       {...props}

--- a/web/src/themes/COLOR_GUIDE.md
+++ b/web/src/themes/COLOR_GUIDE.md
@@ -53,12 +53,14 @@ The color system supports both light and dark themes automatically through CSS c
 | `--card-foreground`    | Very dark   | Near white  | Text on card backgrounds    |
 | `--popover`            | Pure white  | Darker gray | Overlay backgrounds         |
 | `--popover-foreground` | Dark gray   | Light gray  | Text on overlay backgrounds |
+| `--overlay`            | Pure black  | Pure black  | Scrim behind modals         |
 
 **When to use:**
 
 - Page backgrounds (`--background`)
 - Content cards and panels (`--card`)
 - Tooltips, dropdowns, modals (`--popover`)
+- Modal scrims (`--overlay`, always with an alpha utility: `bg-overlay/50` for dialogs and sheets, `bg-overlay/20` for focus mode)
 
 ### ✏️ Text & Content Colors
 

--- a/web/src/themes/default-dark.css
+++ b/web/src/themes/default-dark.css
@@ -41,6 +41,9 @@
   --input: oklch(0.42 0.011 255);
   --ring: oklch(0.58 0.095 250);
 
+  /* Overlay - neutral scrim; alpha comes from the utility (bg-overlay/50) */
+  --overlay: oklch(0 0 0);
+
   /* Sidebar - anchored but no longer near-black */
   --sidebar: oklch(0.21 0.009 255);
   --sidebar-foreground: oklch(0.76 0.007 255);

--- a/web/src/themes/default.css
+++ b/web/src/themes/default.css
@@ -22,6 +22,10 @@
   --border: oklch(0.8847 0.0069 97.3627);
   --input: oklch(0.7621 0.0156 98.3528);
   --ring: oklch(0.45 0.08 250);
+  /* Overlay - neutral scrim base behind dialogs, sheets, and focus mode.
+     Alpha comes from the utility (bg-overlay/50, bg-overlay/20), so every
+     theme dims rather than tinting with --foreground. */
+  --overlay: oklch(0 0 0);
   --sidebar: oklch(0.9663 0.008 98.8792);
   --sidebar-foreground: oklch(0.359 0.0051 106.6524);
   --sidebar-accent: oklch(0.9245 0.0138 92.9892);
@@ -67,6 +71,7 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-overlay: var(--overlay);
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-accent: var(--sidebar-accent);

--- a/web/src/themes/paper.css
+++ b/web/src/themes/paper.css
@@ -22,6 +22,8 @@
   --border: oklch(0.85 0.025 72);
   --input: oklch(0.8 0.03 75);
   --ring: oklch(0.45 0.08 45);
+  /* Overlay - neutral scrim; alpha comes from the utility (bg-overlay/50) */
+  --overlay: oklch(0 0 0);
   --sidebar: oklch(0.9647 0.0118 83.7892);
   --sidebar-foreground: oklch(0.2941 0.0196 67.6524);
   --sidebar-accent: oklch(0.9412 0.0196 78.9456);

--- a/web/tests/column-grid-untrapped.test.tsx
+++ b/web/tests/column-grid-untrapped.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ColumnGrid, { ColumnGridUntrappedProvider, GRID_GAP, useColumnGridUntrapped } from "@/components/ColumnGrid";
+
+// Regression test for #6288: an inline editor's focus mode renders position:fixed
+// UI inside a grid tile. A tile positioned with a transform (or will-change:
+// transform) is the containing block for fixed descendants, so the focus-mode
+// surface gets trapped inside the card. The untrapped slot switches that one
+// tile to left/top for the duration.
+
+interface Item {
+  key: string;
+}
+
+const TileConsumer = ({ itemKey }: { itemKey: string }) => {
+  const { setUntrappedKey } = useColumnGridUntrapped();
+  return (
+    <button type="button" data-testid={`untrap-${itemKey}`} onClick={() => setUntrappedKey(itemKey)}>
+      untrap {itemKey}
+    </button>
+  );
+};
+
+const renderGrid = () => {
+  const items: Item[] = [{ key: "a" }, { key: "b" }];
+  render(
+    <ColumnGridUntrappedProvider>
+      <ColumnGrid
+        items={items}
+        getKey={(item) => item.key}
+        renderItem={(item) => (
+          <div data-testid={`tile-${item.key}`}>
+            <TileConsumer itemKey={item.key} />
+          </div>
+        )}
+      />
+    </ColumnGridUntrappedProvider>,
+  );
+};
+
+const tileWrapper = (key: string) => screen.getByTestId(`tile-${key}`).parentElement as HTMLElement;
+
+describe("ColumnGrid untrapped tile", () => {
+  it("positions every tile with a transform by default", () => {
+    renderGrid();
+    for (const key of ["a", "b"]) {
+      const el = tileWrapper(key);
+      expect(el.style.transform).toContain("translate3d");
+      expect(el.style.willChange).toBe("transform");
+      expect(el.className).toContain("transition-transform");
+    }
+  });
+
+  it("positions the untrapped tile with left/top so it cannot contain fixed descendants", () => {
+    renderGrid();
+    fireEvent.click(screen.getByTestId("untrap-b"));
+
+    const untrapped = tileWrapper("b");
+    expect(untrapped.style.transform).toBe("");
+    expect(untrapped.style.willChange).toBe("");
+    // jsdom reports every tile as zero-height, so the second tile's y is one gap down.
+    expect(untrapped.style.left).toBe("0px");
+    expect(untrapped.style.top).toBe(`${GRID_GAP}px`);
+    expect(untrapped.className).not.toContain("transition-transform");
+
+    const other = tileWrapper("a");
+    expect(other.style.transform).toContain("translate3d");
+    expect(other.style.willChange).toBe("transform");
+  });
+});

--- a/web/tests/column-grid-untrapped.test.tsx
+++ b/web/tests/column-grid-untrapped.test.tsx
@@ -5,19 +5,24 @@ import ColumnGrid, { ColumnGridUntrappedProvider, GRID_GAP, useColumnGridUntrapp
 // Regression test for #6288: an inline editor's focus mode renders position:fixed
 // UI inside a grid tile. A tile positioned with a transform (or will-change:
 // transform) is the containing block for fixed descendants, so the focus-mode
-// surface gets trapped inside the card. The untrapped slot switches that one
-// tile to left/top for the duration.
+// surface gets trapped inside the card. The untrapped set switches those tiles
+// to left/top for the duration.
 
 interface Item {
   key: string;
 }
 
 const TileConsumer = ({ itemKey }: { itemKey: string }) => {
-  const { setUntrappedKey } = useColumnGridUntrapped();
+  const { setUntrappedKey, clearUntrappedKey } = useColumnGridUntrapped();
   return (
-    <button type="button" data-testid={`untrap-${itemKey}`} onClick={() => setUntrappedKey(itemKey)}>
-      untrap {itemKey}
-    </button>
+    <>
+      <button type="button" data-testid={`untrap-${itemKey}`} onClick={() => setUntrappedKey(itemKey)}>
+        untrap {itemKey}
+      </button>
+      <button type="button" data-testid={`clear-${itemKey}`} onClick={() => clearUntrappedKey(itemKey)}>
+        clear {itemKey}
+      </button>
+    </>
   );
 };
 
@@ -66,5 +71,22 @@ describe("ColumnGrid untrapped tile", () => {
     const other = tileWrapper("a");
     expect(other.style.transform).toContain("translate3d");
     expect(other.style.willChange).toBe("transform");
+  });
+
+  it("keeps every focused tile untrapped when two editors claim focus mode", () => {
+    renderGrid();
+    fireEvent.click(screen.getByTestId("untrap-a"));
+    fireEvent.click(screen.getByTestId("untrap-b"));
+
+    for (const key of ["a", "b"]) {
+      const el = tileWrapper(key);
+      expect(el.style.transform).toBe("");
+      expect(el.style.willChange).toBe("");
+    }
+
+    // Releasing one claim must not retrap the other tile.
+    fireEvent.click(screen.getByTestId("clear-a"));
+    expect(tileWrapper("a").style.transform).toContain("translate3d");
+    expect(tileWrapper("b").style.transform).toBe("");
   });
 });


### PR DESCRIPTION
Closes #6288.

Two independent regressions, each with a clear source.

## 1. Focus mode capped to the card (2+ column layouts)

**Regression:** `177d65a9` ("feat(web): add max-columns memo feed layout", first shipped in v0.30.0) positions every grid tile with `transform` + `will-change: transform`. That makes the tile the containing block for `position: fixed` descendants, so the inline editor's focus-mode overlay and container resolve against the card. The composer was exempted two days later in `5329e604` (#6076) by positioning the leading tile with `left/top`; memo cards were missed.

**Fix:** generalize that exemption. `MemoView` reports its editor's focus-mode state through a small grid context, and `ColumnGrid` positions that one tile with `left/top` while it hosts a focused editor. No portal, so CodeMirror is never remounted (undo history and cursor survive the toggle), and every other tile keeps its transform animation.

Measured in a 1400x900 viewport while editing a card in a 2-column layout:

| | Overlay (`fixed inset-0`) | Container (`fixed z-50`) |
| --- | --- | --- |
| before | 420x134 (card-sized) | 356x70 |
| after | 1400x900 (viewport) | 1024x836, centered |

Regression test: `web/tests/column-grid-untrapped.test.tsx`.

Manual reproduction (2-column layout, focus mode):

| Before | After |
| --- | --- |
| <img width="1858" height="681" alt="memos-before" src="https://github.com/user-attachments/assets/24a6b2e5-b453-4020-a188-de2f726227d6" /> | <img width="1858" height="681" alt="memos-after" src="https://github.com/user-attachments/assets/36ada25b-fe07-42f6-93b5-5c72ea999e70" /> |

## 2. Dialog and sheet scrim is light in dark mode

**Regression:** `91be2f68` ("feat: variant colors", #4816) changed `bg-black/50` to `bg-foreground/50` in `dialog.tsx` and `sheet.tsx`. `--foreground` is near-white in `default-dark`, so the scrim became a light veil (computed `oklab(0.9 ... / 0.5)`).

**Fix:** add a neutral `--overlay` token (`oklch(0 0 0)` in all three themes) with a `--color-overlay` mapping, and use `bg-overlay/50` for dialogs and sheets. Focus mode keeps its existing `bg-overlay/20` + blur treatment, now sourced from the same token, so its look is unchanged. Verified in all three themes:

| Theme | `--overlay` | Dialog scrim |
| --- | --- | --- |
| Light | `oklch(0 0 0)` | `oklab(0 0 0 / 0.5)` |
| Dark | `oklch(0 0 0)` | `oklab(0 0 0 / 0.5)` |
| Paper | `oklch(0 0 0)` | `oklab(0 0 0 / 0.5)` |

`web/src/themes/COLOR_GUIDE.md` documents the token.

## Design note

The two backdrops now share the same color source but not the same effect: focus mode keeps its blur, dialogs and sheets stay flat. That difference predates both regressions (focus mode shipped with the blur as an intentional immersive treatment), so this PR does not relitigate it. Happy to unify either way, one class in `FOCUS_MODE_STYLES.backdrop` or the two `ui/` primitives, if you would rather have them identical.

## Verification

- `cd web && pnpm lint && pnpm test && pnpm build` (170 files, 1361 tests).
- Runtime before/after with a headless browser against two dev servers (unpatched and patched) sharing one backend, which is where the measurements above come from.
