### PR TITLE
fix(web): apply tag blurring to attachment previews

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -139,6 +139,13 @@ spellings remain separate only when they emit different code-point sequences.
 User configuration that selects tag values and supplies presentation or behavior metadata, such as color or content blurring. A metadata rule may match
 multiple values and does not create, own, or rename a tag.
 
+Content-blurring rules also apply to a memo's images, videos, and motion photos in the attachment library and its full-screen preview. Each preview
+can be revealed explicitly; switching to another preview does not reveal its content. A paired Live Photo is blurred if either linked memo matches a
+blur rule. Unlinked attachments do not inherit a memo's rules.
+
+While user settings or an uncached linked memo are loading, the library keeps the preview blurred. A failed memo lookup also leaves it blurred.
+Blurring is a presentation preference, not an access-control mechanism: memo visibility, file permissions, filenames, and direct file links are unchanged.
+
 ### Tag count
 
 The number of memo tag sets containing an exactly equal direct or implied tag value, not the number of textual occurrences. A memo containing only

--- a/web/src/components/AttachmentLibrary/AttachmentMediaGrid.tsx
+++ b/web/src/components/AttachmentLibrary/AttachmentMediaGrid.tsx
@@ -1,4 +1,5 @@
 import { PlayIcon } from "lucide-react";
+import BlurredMedia from "@/components/BlurredMedia";
 import MotionPhotoPreview from "@/components/MotionPhotoPreview";
 import { Badge } from "@/components/ui/badge";
 import VideoPoster from "@/components/VideoPoster";
@@ -22,38 +23,42 @@ const AttachmentMediaCard = ({ item, onPreview }: { item: AttachmentLibraryMedia
     <article className="overflow-hidden rounded-[20px] border border-border/60 bg-background/90 shadow-sm shadow-black/[0.03]">
       <div className="relative block w-full cursor-pointer text-left" onClick={onPreview}>
         <div className="relative aspect-[5/4] overflow-hidden bg-muted/40">
-          {item.kind === "video" ? (
-            <>
-              <VideoPoster
-                sourceUrl={item.sourceUrl}
-                posterUrl={item.posterUrl}
-                alt={item.filename}
-                className="h-full w-full object-cover"
-              />
-              <div className="absolute inset-0 bg-linear-to-t from-black/35 via-black/5 to-transparent" />
-              <span
-                className={cn(
-                  "absolute bottom-2.5 right-2.5 inline-flex h-8 items-center justify-center rounded-full bg-background/85 text-foreground shadow-sm backdrop-blur-sm",
-                  videoDuration === undefined ? "w-8" : "gap-1.5 px-2.5 text-[11px] font-medium tabular-nums",
-                )}
-              >
-                <PlayIcon className="h-3.5 w-3.5 fill-current" />
-                {videoDuration !== undefined && <span>{formatMediaDuration(videoDuration)}</span>}
-              </span>
-            </>
-          ) : item.kind === "motion" ? (
-            <MotionPhotoPreview
-              posterUrl={item.posterUrl}
-              motionUrl={item.previewItem.kind === "motion" ? item.previewItem.motionUrl : item.sourceUrl}
-              alt={item.filename}
-              presentationTimestampUs={item.previewItem.kind === "motion" ? item.previewItem.presentationTimestampUs : undefined}
-              containerClassName="h-full w-full"
-              mediaClassName="h-full w-full object-cover"
-              badgeClassName="left-3 top-3"
-            />
-          ) : (
-            <img src={item.posterUrl} alt={item.filename} className="h-full w-full object-cover" loading="lazy" decoding="async" />
-          )}
+          <BlurredMedia key={item.memoName} blurred={item.blurred} className="size-full" contentClassName="size-full">
+            {(concealed) =>
+              item.kind === "video" ? (
+                <>
+                  <VideoPoster
+                    sourceUrl={item.sourceUrl}
+                    posterUrl={item.posterUrl}
+                    alt={item.filename}
+                    className="h-full w-full object-cover"
+                  />
+                  <div className="absolute inset-0 bg-linear-to-t from-black/35 via-black/5 to-transparent" />
+                  <span
+                    className={cn(
+                      "absolute bottom-2.5 right-2.5 inline-flex h-8 items-center justify-center rounded-full bg-background/85 text-foreground shadow-sm backdrop-blur-sm",
+                      videoDuration === undefined ? "w-8" : "gap-1.5 px-2.5 text-[11px] font-medium tabular-nums",
+                    )}
+                  >
+                    <PlayIcon className="h-3.5 w-3.5 fill-current" />
+                    {videoDuration !== undefined && <span>{formatMediaDuration(videoDuration)}</span>}
+                  </span>
+                </>
+              ) : item.kind === "motion" && !concealed ? (
+                <MotionPhotoPreview
+                  posterUrl={item.posterUrl}
+                  motionUrl={item.previewItem.kind === "motion" ? item.previewItem.motionUrl : item.sourceUrl}
+                  alt={item.filename}
+                  presentationTimestampUs={item.previewItem.kind === "motion" ? item.previewItem.presentationTimestampUs : undefined}
+                  containerClassName="h-full w-full"
+                  mediaClassName="h-full w-full object-cover"
+                  badgeClassName="left-3 top-3"
+                />
+              ) : (
+                <img src={item.posterUrl} alt={item.filename} className="h-full w-full object-cover" loading="lazy" decoding="async" />
+              )
+            }
+          </BlurredMedia>
         </div>
       </div>
 

--- a/web/src/components/BlurredMedia.tsx
+++ b/web/src/components/BlurredMedia.tsx
@@ -1,0 +1,45 @@
+import { EyeIcon } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useTranslate } from "@/utils/i18n";
+
+interface Props {
+  blurred?: boolean;
+  className?: string;
+  contentClassName?: string;
+  children: (concealed: boolean) => ReactNode;
+}
+
+const ConcealedMedia = ({ className, contentClassName, children }: Props) => {
+  const t = useTranslate();
+  const [revealed, setRevealed] = useState(false);
+  return (
+    <div className={cn("relative", className)}>
+      <div className={cn(contentClassName, !revealed && "pointer-events-none select-none blur-lg")}>{children(!revealed)}</div>
+      {!revealed && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center p-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-auto min-h-8 whitespace-normal bg-card py-1.5 text-xs text-foreground shadow-sm"
+            onClick={(event) => {
+              event.stopPropagation();
+              setRevealed(true);
+            }}
+          >
+            <EyeIcon className="size-3.5 shrink-0" />
+            {t("memo.click-to-show-sensitive-content")}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// Leaving the blurred state unmounts the reveal state, so enabling the rule
+// again does not reuse a previous reveal. Callers key this boundary by media.
+const BlurredMedia = (props: Props) => (props.blurred ? <ConcealedMedia {...props} /> : props.children(false));
+
+export default BlurredMedia;

--- a/web/src/components/BlurredMedia.tsx
+++ b/web/src/components/BlurredMedia.tsx
@@ -23,14 +23,14 @@ const ConcealedMedia = ({ className, contentClassName, children }: Props) => {
             type="button"
             variant="outline"
             size="sm"
-            className="h-auto min-h-8 whitespace-normal bg-card py-1.5 text-xs text-foreground shadow-sm"
+            className="h-auto min-h-8 max-w-full whitespace-normal bg-card py-1.5 text-xs text-foreground shadow-sm"
             onClick={(event) => {
               event.stopPropagation();
               setRevealed(true);
             }}
           >
             <EyeIcon className="size-3.5 shrink-0" />
-            {t("memo.click-to-show-sensitive-content")}
+            <span className="min-w-0 wrap-break-word">{t("memo.click-to-show-sensitive-content")}</span>
           </Button>
         </div>
       )}

--- a/web/src/components/PreviewImageDialog.tsx
+++ b/web/src/components/PreviewImageDialog.tsx
@@ -1,10 +1,12 @@
 import { ChevronLeft, ChevronRight, InfoIcon, RotateCcw, X, ZoomIn, ZoomOut } from "lucide-react";
 import React, { useEffect, useMemo, useState } from "react";
+import BlurredMedia from "@/components/BlurredMedia";
 import MediaMetadataDetails from "@/components/MediaMetadataDetails";
 import MotionPhotoPreview from "@/components/MotionPhotoPreview";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { VisuallyHidden } from "@/components/ui/visually-hidden";
+import VideoPoster from "@/components/VideoPoster";
 import useMediaQuery from "@/hooks/useMediaQuery";
 import { cn } from "@/lib/utils";
 import { useTranslate } from "@/utils/i18n";
@@ -31,7 +33,7 @@ function PreviewImageDialog({ open, onOpenChange, imgUrls = [], items, initialIn
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
   const [zoomScale, setZoomScale] = useState(MIN_ZOOM);
   const [showDetails, setShowDetails] = useState(false);
-  const previewItems = useMemo(
+  const previewItems = useMemo<PreviewMediaItem[]>(
     () => items ?? imgUrls.map((url) => ({ id: url, kind: "image" as const, sourceUrl: url, posterUrl: url, filename: "Image" })),
     [imgUrls, items],
   );
@@ -189,51 +191,67 @@ function PreviewImageDialog({ open, onOpenChange, imgUrls = [], items, initialIn
           }}
         >
           <div className="flex max-h-full max-w-full items-center justify-center" onClick={(event) => event.stopPropagation()}>
-            {currentItem.kind === "video" ? (
-              <video
-                key={currentItem.id}
-                src={currentItem.sourceUrl}
-                poster={currentItem.posterUrl}
-                className={cn(
-                  "max-h-[calc(100vh-8rem)] max-w-[calc(100vw-1.5rem)] rounded-md object-contain sm:max-h-[calc(100vh-7rem)] sm:max-w-[calc(100vw-8rem)]",
-                  showDetails && "lg:max-w-[calc(100vw-30rem)]",
-                )}
-                controls
-                autoPlay
-                playsInline
-              />
-            ) : currentItem.kind === "motion" ? (
-              <MotionPhotoPreview
-                key={currentItem.id}
-                posterUrl={currentItem.posterUrl}
-                motionUrl={currentItem.motionUrl}
-                alt={`Preview live photo ${safeIndex + 1} of ${itemCount}`}
-                presentationTimestampUs={currentItem.presentationTimestampUs}
-                badgeClassName="left-3 top-3 sm:left-4 sm:top-4"
-                mediaClassName={cn(
-                  "max-h-[calc(100vh-8rem)] max-w-[calc(100vw-1.5rem)] rounded-md object-contain sm:max-h-[calc(100vh-7rem)] sm:max-w-[calc(100vw-8rem)]",
-                  showDetails && "lg:max-w-[calc(100vw-30rem)]",
-                )}
-              />
-            ) : (
-              <img
-                src={currentItem.sourceUrl}
-                alt={`Preview image ${safeIndex + 1} of ${itemCount}`}
-                className={cn(
-                  "max-h-[calc(100vh-8rem)] max-w-[calc(100vw-1.5rem)] rounded-md object-contain select-none sm:max-h-[calc(100vh-7rem)] sm:max-w-[calc(100vw-8rem)]",
-                  showDetails && "lg:max-w-[calc(100vw-30rem)]",
-                )}
-                style={{
-                  transform: `translate3d(0px, 0px, 0) scale(${zoomScale})`,
-                  transition: "transform 120ms ease-out",
-                  transformOrigin: "center center",
-                }}
-                onDoubleClick={handleDoubleClick}
-                draggable={false}
-                loading="eager"
-                decoding="async"
-              />
-            )}
+            <BlurredMedia
+              key={`${currentItem.id}:${open}`}
+              blurred={currentItem.blurred}
+              className="max-h-full max-w-full"
+              contentClassName="max-h-full max-w-full"
+            >
+              {(concealed) =>
+                currentItem.kind === "video" && concealed ? (
+                  <VideoPoster
+                    sourceUrl={currentItem.sourceUrl}
+                    posterUrl={currentItem.posterUrl}
+                    alt={`Preview video ${safeIndex + 1} of ${itemCount}`}
+                    className="max-h-[calc(100vh-8rem)] max-w-[calc(100vw-1.5rem)] rounded-md object-contain sm:max-w-[calc(100vw-8rem)]"
+                  />
+                ) : currentItem.kind === "video" ? (
+                  <video
+                    key={currentItem.id}
+                    src={currentItem.sourceUrl}
+                    poster={currentItem.posterUrl}
+                    className={cn(
+                      "max-h-[calc(100vh-8rem)] max-w-[calc(100vw-1.5rem)] rounded-md object-contain sm:max-h-[calc(100vh-7rem)] sm:max-w-[calc(100vw-8rem)]",
+                      showDetails && "lg:max-w-[calc(100vw-30rem)]",
+                    )}
+                    controls
+                    autoPlay
+                    playsInline
+                  />
+                ) : currentItem.kind === "motion" && !concealed ? (
+                  <MotionPhotoPreview
+                    key={currentItem.id}
+                    posterUrl={currentItem.posterUrl}
+                    motionUrl={currentItem.motionUrl}
+                    alt={`Preview live photo ${safeIndex + 1} of ${itemCount}`}
+                    presentationTimestampUs={currentItem.presentationTimestampUs}
+                    badgeClassName="left-3 top-3 sm:left-4 sm:top-4"
+                    mediaClassName={cn(
+                      "max-h-[calc(100vh-8rem)] max-w-[calc(100vw-1.5rem)] rounded-md object-contain sm:max-h-[calc(100vh-7rem)] sm:max-w-[calc(100vw-8rem)]",
+                      showDetails && "lg:max-w-[calc(100vw-30rem)]",
+                    )}
+                  />
+                ) : (
+                  <img
+                    src={currentItem.kind === "motion" ? currentItem.posterUrl : currentItem.sourceUrl}
+                    alt={`Preview image ${safeIndex + 1} of ${itemCount}`}
+                    className={cn(
+                      "max-h-[calc(100vh-8rem)] max-w-[calc(100vw-1.5rem)] rounded-md object-contain select-none sm:max-h-[calc(100vh-7rem)] sm:max-w-[calc(100vw-8rem)]",
+                      showDetails && "lg:max-w-[calc(100vw-30rem)]",
+                    )}
+                    style={{
+                      transform: `translate3d(0px, 0px, 0) scale(${zoomScale})`,
+                      transition: "transform 120ms ease-out",
+                      transformOrigin: "center center",
+                    }}
+                    onDoubleClick={handleDoubleClick}
+                    draggable={false}
+                    loading="eager"
+                    decoding="async"
+                  />
+                )
+              }
+            </BlurredMedia>
           </div>
         </div>
 

--- a/web/src/hooks/useAttachmentLibrary.ts
+++ b/web/src/hooks/useAttachmentLibrary.ts
@@ -8,6 +8,7 @@ import {
   isVideoAttachment,
 } from "@/components/MemoMetadata/Attachment/attachmentHelpers";
 import { useInfiniteAttachments } from "@/hooks/useAttachmentQueries";
+import { useBlurredAttachmentItems } from "@/hooks/useBlurredAttachmentItems";
 import { combineCELFilters } from "@/lib/cel-filter";
 import type { Attachment, ListAttachmentsRequest } from "@/types/proto/api/v1/attachment_service_pb";
 import { isMotionAttachment } from "@/utils/attachment";
@@ -34,6 +35,7 @@ export interface AttachmentLibraryListItem {
 }
 
 export interface AttachmentLibraryMediaItem extends AttachmentVisualItem {
+  blurred?: boolean;
   primaryAttachment: Attachment;
   createdAt?: Date;
   createdLabel: string;
@@ -187,13 +189,15 @@ export function useAttachmentLibrary(locale: string, filter?: string) {
     [attachments],
   );
 
-  const mediaItems = useMemo(
+  const visualItems = useMemo(
     () =>
       buildAttachmentVisualItems(linkedAttachments.filter(isVisualAttachment))
         .map((item) => toLibraryMediaItem(item, locale, t("attachment-library.labels.live-photo")))
         .sort((a, b) => sortByNewest(a.createdAt, b.createdAt)),
     [linkedAttachments, locale, t],
   );
+  const blurredItemIds = useBlurredAttachmentItems(visualItems);
+  const mediaItems = visualItems.map((item) => ({ ...item, blurred: blurredItemIds.has(item.id) }));
 
   const documentItems = useMemo(
     () =>
@@ -217,7 +221,7 @@ export function useAttachmentLibrary(locale: string, filter?: string) {
     () => groupMediaByMonth(mediaItems, locale, t("attachment-library.labels.unknown-date")),
     [locale, mediaItems, t],
   );
-  const mediaPreviewItems = useMemo(() => mediaItems.map((item) => item.previewItem), [mediaItems]);
+  const mediaPreviewItems = useMemo(() => mediaItems.map((item) => ({ ...item.previewItem, blurred: item.blurred })), [mediaItems]);
 
   const stats = useMemo<AttachmentLibraryStats>(
     () => ({

--- a/web/src/hooks/useBlurredAttachmentItems.ts
+++ b/web/src/hooks/useBlurredAttachmentItems.ts
@@ -1,0 +1,37 @@
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { memoDetailQueryOptions } from "@/hooks/useMemoQueries";
+import { isMemoBlurred } from "@/lib/tag";
+import type { AttachmentVisualItem } from "@/utils/media-item";
+
+export const useBlurredAttachmentItems = (items: AttachmentVisualItem[]): Set<string> => {
+  const { isUserSettingsInitialized, userTagsSetting } = useAuth();
+  const hasBlurRules = Object.values(userTagsSetting?.tags ?? {}).some((metadata) => metadata.blurContent);
+  const memoNames = useMemo(
+    () => [...new Set(items.flatMap((item) => item.attachments.flatMap((attachment) => (attachment.memo ? [attachment.memo] : []))))],
+    [items],
+  );
+  // Reuse memo detail caching and unavailable-memo handling. Multiple files
+  // from one memo need only one lookup; users without blur rules need none.
+  const queries = useQueries({
+    queries: isUserSettingsInitialized && hasBlurRules ? memoNames.map(memoDetailQueryOptions) : [],
+  });
+  const blurredMemos = new Set<string>();
+  if (hasBlurRules) {
+    memoNames.forEach((name, index) => {
+      const query = queries[index];
+      if (!query?.data || query.isError || isMemoBlurred(query.data, userTagsSetting)) {
+        blurredMemos.add(name);
+      }
+    });
+  }
+
+  return new Set(
+    items
+      .filter((item) =>
+        item.attachments.some((attachment) => attachment.memo && (!isUserSettingsInitialized || blurredMemos.has(attachment.memo))),
+      )
+      .map((item) => item.id),
+  );
+};

--- a/web/src/utils/media-item.ts
+++ b/web/src/utils/media-item.ts
@@ -15,6 +15,7 @@ interface PreviewMediaItemBase {
   id: string;
   filename: string;
   attachments?: Attachment[];
+  blurred?: boolean;
 }
 
 export interface ImagePreviewMediaItem extends PreviewMediaItemBase {

--- a/web/tests/attachment-library-blur.test.tsx
+++ b/web/tests/attachment-library-blur.test.tsx
@@ -1,0 +1,278 @@
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { useEffect } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppSidebarProvider } from "@/contexts/AppSidebarContext";
+import { AuthProvider, useAuth } from "@/contexts/AuthContext";
+import { SpaceProvider } from "@/contexts/SpaceContext";
+import { memoKeys } from "@/hooks/useMemoQueries";
+import Attachments from "@/pages/Attachments";
+import { AttachmentSchema, MotionMediaFamily, MotionMediaRole } from "@/types/proto/api/v1/attachment_service_pb";
+import { type Memo, MemoSchema } from "@/types/proto/api/v1/memo_service_pb";
+import { UserSchema, UserSetting_TagsSettingSchema, UserSettingSchema } from "@/types/proto/api/v1/user_service_pb";
+
+const clients = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  listUserSettings: vi.fn(),
+  listAttachments: vi.fn(),
+  getMemo: vi.fn(),
+  listSpaces: vi.fn(),
+}));
+
+// Keep the real page, providers, query hooks and media components. Only the
+// RPC boundary, stored credential and presentation-only translations are replaced.
+vi.mock("@/auth-state", () => ({ getAccessToken: () => "fixture-token", clearAccessToken: vi.fn() }));
+vi.mock("@/connect", () => ({
+  authServiceClient: { getCurrentUser: clients.getCurrentUser, signOut: vi.fn() },
+  userServiceClient: { listUserSettings: clients.listUserSettings },
+  attachmentServiceClient: { listAttachments: clients.listAttachments, batchDeleteAttachments: vi.fn() },
+  memoServiceClient: { getMemo: clients.getMemo },
+  spaceServiceClient: { listSpaces: clients.listSpaces },
+  refreshAccessToken: vi.fn(),
+}));
+vi.mock("@/utils/i18n", () => ({ useTranslate: () => (key: string) => key }));
+vi.mock("@/i18n", () => ({ default: { language: "en" } }));
+vi.mock("@/hooks/useMediaQuery", () => ({ default: () => true }));
+
+const attachment = (name: string, memo: string) =>
+  create(AttachmentSchema, { name: `attachments/${name}`, filename: `${name}.png`, type: "image/png", memo });
+
+const settings = (tags: Record<string, { blurContent: boolean }> = { "private.*": { blurContent: true } }) => ({
+  settings: [
+    create(UserSettingSchema, {
+      name: "users/fixture/settings/TAGS",
+      value: { case: "tagsSetting", value: create(UserSetting_TagsSettingSchema, { tags }) },
+    }),
+  ],
+});
+
+const Initialize = () => {
+  const { initialize, isUserSettingsInitialized, refetchSettings } = useAuth();
+  useEffect(() => void initialize(), [initialize]);
+  return (
+    <>
+      <output data-testid="settings-ready">{String(isUserSettingsInitialized)}</output>
+      <button type="button" onClick={() => void refetchSettings()}>
+        refresh rules
+      </button>
+    </>
+  );
+};
+
+const renderLibrary = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, retryDelay: 0 } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <MemoryRouter initialEntries={["/attachments"]}>
+          <SpaceProvider>
+            <AppSidebarProvider>
+              <Initialize />
+              <Attachments />
+            </AppSidebarProvider>
+          </SpaceProvider>
+        </MemoryRouter>
+      </AuthProvider>
+    </QueryClientProvider>,
+  );
+  return queryClient;
+};
+
+const isBlurred = (image: HTMLElement) => image.closest(".blur-lg") !== null;
+
+describe("attachment library tag-based blurring", () => {
+  beforeEach(() => {
+    clients.getCurrentUser.mockResolvedValue({ user: create(UserSchema, { name: "users/fixture", username: "fixture" }) });
+    clients.listUserSettings.mockResolvedValue(settings());
+    clients.listSpaces.mockResolvedValue({ spaces: [], nextPageToken: "" });
+    clients.listAttachments.mockResolvedValue({
+      attachments: [attachment("normal", "memos/normal"), attachment("private", "memos/private")],
+      nextPageToken: "",
+    });
+    clients.getMemo.mockImplementation(async ({ name }: { name: string }) =>
+      create(MemoSchema, { name, tags: name === "memos/private" ? ["private"] : [] }),
+    );
+  });
+
+  it("applies memo rules to the real gallery and deduplicates lookups for attachments from the same memo", async () => {
+    clients.listAttachments.mockResolvedValue({
+      attachments: [attachment("normal", "memos/normal"), attachment("private", "memos/private"), attachment("second", "memos/private")],
+      nextPageToken: "",
+    });
+    renderLibrary();
+    const privateImage = await screen.findByAltText("private.png");
+    await waitFor(() => expect(clients.getMemo).toHaveBeenCalledTimes(2));
+    expect(isBlurred(privateImage)).toBe(true);
+    expect(isBlurred(screen.getByAltText("second.png"))).toBe(true);
+    await waitFor(() => expect(isBlurred(screen.getByAltText("normal.png"))).toBe(false));
+
+    const card = privateImage.closest("article")!;
+    fireEvent.click(within(card).getByRole("button", { name: "memo.click-to-show-sensitive-content" }));
+    expect(isBlurred(privateImage)).toBe(false);
+    expect(isBlurred(screen.getByAltText("second.png"))).toBe(true);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("does not request memo details when no tag rule enables blurring", async () => {
+    clients.listUserSettings.mockResolvedValue(settings({ private: { blurContent: false } }));
+    renderLibrary();
+    await screen.findByAltText("private.png");
+    await waitFor(() => expect(screen.getByTestId("settings-ready")).toHaveTextContent("true"));
+    expect(isBlurred(screen.getByAltText("private.png"))).toBe(false);
+    expect(clients.getMemo).not.toHaveBeenCalled();
+  });
+
+  it("conceals previews while user tag settings are still loading", async () => {
+    let resolveSettings!: (value: ReturnType<typeof settings>) => void;
+    clients.listUserSettings.mockImplementation(() => new Promise((resolve) => (resolveSettings = resolve)));
+    renderLibrary();
+    const image = await screen.findByAltText("private.png");
+    try {
+      expect(screen.getByTestId("settings-ready")).toHaveTextContent("false");
+      expect(isBlurred(image)).toBe(true);
+      expect(clients.getMemo).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => resolveSettings(settings()));
+    }
+  });
+
+  it("conceals pending memo details, then evaluates the returned tags", async () => {
+    let resolveMemo!: (value: Memo) => void;
+    clients.getMemo.mockImplementation(() => new Promise((resolve) => (resolveMemo = resolve)));
+    clients.listAttachments.mockResolvedValue({ attachments: [attachment("normal", "memos/normal")], nextPageToken: "" });
+    renderLibrary();
+    const image = await screen.findByAltText("normal.png");
+    await waitFor(() => expect(clients.getMemo).toHaveBeenCalledTimes(1));
+    expect(isBlurred(image)).toBe(true);
+    await act(async () => resolveMemo(create(MemoSchema, { name: "memos/normal", tags: [] })));
+    await waitFor(() => expect(isBlurred(screen.getByAltText("normal.png"))).toBe(false));
+  });
+
+  it.each([
+    Code.PermissionDenied,
+    Code.NotFound,
+    Code.Unavailable,
+  ])("does not expose previews when memo lookup fails with code %s", async (code) => {
+    clients.getMemo.mockRejectedValue(new ConnectError("not readable", code));
+    const queryClient = renderLibrary();
+    await screen.findByAltText("private.png");
+    await waitFor(() => {
+      const state = queryClient.getQueryState(memoKeys.detail("memos/private"));
+      expect(state?.fetchStatus).toBe("idle");
+      expect(state?.data === null || state?.status === "error").toBe(true);
+    });
+    expect(isBlurred(screen.getByAltText("private.png"))).toBe(true);
+  });
+
+  it("conceals stale cached metadata after its refresh fails", async () => {
+    clients.listAttachments.mockResolvedValue({ attachments: [attachment("normal", "memos/normal")], nextPageToken: "" });
+    clients.getMemo.mockRejectedValue(new ConnectError("offline", Code.Unavailable));
+    const queryClient = renderLibrary();
+    queryClient.setQueryData(memoKeys.detail("memos/normal"), create(MemoSchema, { name: "memos/normal", tags: [] }), {
+      updatedAt: Date.now() - 30_000,
+    });
+    await screen.findByAltText("normal.png");
+    await waitFor(() => expect(queryClient.getQueryState(memoKeys.detail("memos/normal"))?.status).toBe("error"));
+    expect(isBlurred(screen.getByAltText("normal.png"))).toBe(true);
+  });
+
+  it("uses the same exact-key precedence and anchored patterns as memo blurring", async () => {
+    clients.listUserSettings.mockResolvedValue(settings({ private: { blurContent: false }, "private.*": { blurContent: true } }));
+    clients.getMemo.mockImplementation(async ({ name }: { name: string }) =>
+      create(MemoSchema, { name, tags: name === "memos/private" ? ["private"] : ["private/child"] }),
+    );
+    renderLibrary();
+    await screen.findByAltText("private.png");
+    await waitFor(() => expect(clients.getMemo).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(isBlurred(screen.getByAltText("private.png"))).toBe(false));
+    expect(isBlurred(screen.getByAltText("normal.png"))).toBe(true);
+  });
+
+  it("keeps a blurred item concealed when navigating to it from an ordinary full-screen preview", async () => {
+    renderLibrary();
+    await screen.findByAltText("normal.png");
+    await waitFor(() => expect(clients.getMemo).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(isBlurred(screen.getByAltText("normal.png"))).toBe(false));
+    fireEvent.click(screen.getByAltText("normal.png"));
+    const dialog = await screen.findByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Next item" }));
+    const image = within(dialog).getByAltText("Preview image 2 of 2");
+    expect(isBlurred(image)).toBe(true);
+    fireEvent.click(within(dialog).getByRole("button", { name: "memo.click-to-show-sensitive-content" }));
+    expect(isBlurred(image)).toBe(false);
+    fireEvent.click(within(dialog).getByRole("button", { name: "Previous item" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "Next item" }));
+    expect(isBlurred(within(dialog).getByAltText("Preview image 2 of 2"))).toBe(true);
+  });
+
+  it("requires a new reveal after a blur rule is disabled and enabled again", async () => {
+    renderLibrary();
+    await screen.findByAltText("private.png");
+    await waitFor(() => expect(clients.getMemo).toHaveBeenCalledTimes(2));
+    const card = screen.getByAltText("private.png").closest("article")!;
+    fireEvent.click(within(card).getByRole("button", { name: "memo.click-to-show-sensitive-content" }));
+    expect(isBlurred(screen.getByAltText("private.png"))).toBe(false);
+
+    clients.listUserSettings.mockResolvedValue(settings({}));
+    fireEvent.click(screen.getByRole("button", { name: "refresh rules" }));
+    await waitFor(() => expect(screen.queryByRole("button", { name: "memo.click-to-show-sensitive-content" })).not.toBeInTheDocument());
+    clients.listUserSettings.mockResolvedValue(settings());
+    fireEvent.click(screen.getByRole("button", { name: "refresh rules" }));
+    await waitFor(() => expect(isBlurred(screen.getByAltText("private.png"))).toBe(true));
+  });
+
+  it("does not mount a playable full-screen video before explicit reveal", async () => {
+    clients.listAttachments.mockResolvedValue({
+      attachments: [create(AttachmentSchema, { name: "attachments/clip", filename: "clip.mp4", type: "video/mp4", memo: "memos/private" })],
+      nextPageToken: "",
+    });
+    renderLibrary();
+    await screen.findByRole("img", { name: "clip.mp4" });
+    await waitFor(() => expect(clients.getMemo).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole("button", { name: "memo.click-to-show-sensitive-content" }));
+    fireEvent.click(screen.getByRole("img", { name: "clip.mp4" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.querySelector("video[controls], video[autoplay]")).toBeNull();
+    fireEvent.click(within(dialog).getByRole("button", { name: "memo.click-to-show-sensitive-content" }));
+    expect(dialog.querySelector("video[controls][autoplay]")).not.toBeNull();
+  });
+
+  it("considers both memos of a paired live photo and keeps its playback control concealed", async () => {
+    vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(() => {});
+    clients.listAttachments.mockResolvedValue({
+      attachments: [
+        create(AttachmentSchema, {
+          name: "attachments/live-still",
+          filename: "live.jpg",
+          type: "image/jpeg",
+          memo: "memos/normal",
+          motionMedia: { family: MotionMediaFamily.APPLE_LIVE_PHOTO, role: MotionMediaRole.STILL, groupId: "live" },
+        }),
+        create(AttachmentSchema, {
+          name: "attachments/live-video",
+          filename: "live.mov",
+          type: "video/quicktime",
+          memo: "memos/private",
+          motionMedia: { family: MotionMediaFamily.APPLE_LIVE_PHOTO, role: MotionMediaRole.VIDEO, groupId: "live" },
+        }),
+      ],
+      nextPageToken: "",
+    });
+    renderLibrary();
+    await screen.findByAltText("live.jpg");
+    await waitFor(() => expect(clients.getMemo).toHaveBeenCalledTimes(2));
+    expect(isBlurred(screen.getByAltText("live.jpg"))).toBe(true);
+    expect(screen.queryByRole("button", { name: "Hover or press to play live photo" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "memo.click-to-show-sensitive-content" }));
+    expect(screen.getByRole("button", { name: "Hover or press to play live photo" })).toBeInTheDocument();
+    fireEvent.click(screen.getByAltText("live.jpg"));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).queryByRole("button", { name: "Hover or press to play live photo" })).not.toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole("button", { name: "memo.click-to-show-sensitive-content" }));
+    expect(within(dialog).getByRole("button", { name: "Hover or press to play live photo" })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #6127
Closes #6189

Memo details already apply tag-based content blurring, but the attachment library renders the same images without it.

This applies the existing tag rules to library thumbnails and full-screen previews. Linked memo lookups share the existing query cache and are deduplicated by memo; no extra memo requests are made when no blur rule is enabled. Pending or unavailable memo data stays concealed.

Each item has an explicit reveal button. Opening another full-screen item keeps that item's blur state, and closing the preview resets its reveal. Videos do not autoplay behind the blur, and motion-photo playback controls appear only after reveal. Paired Live Photos check both linked memos rather than only the still image's memo.

The change is limited to presentation. It does not change memo visibility, authentication, file permissions, filenames or direct file links, and adds no dependencies.

Validation:
- `pnpm lint`
- `pnpm test --maxWorkers=2`: 1,376 tests passed, including 13 new tests through the actual attachments page, providers, query hooks and preview components. RPC boundaries are mocked in these tests; the original implementation fails 12 of the 13 cases.
- `pnpm build` and `pnpm release`
- Browser checks against a real SQLite instance: desktop/mobile Chrome and Firefox; delayed settings and memo lookups; lookup failure; disabled rules; archived memos; image reveal/navigation; actual MP4, Apple Live Photo and Android motion-photo playback.
- Real pagination from 49 to 51 displayed media items retained the six blurred previews and made only three memo-detail requests.

To check manually, add a blur rule to a tag, attach an image to a matching memo, then open Attachments. The thumbnail should stay blurred until revealed. Also open a normal image and navigate to a tagged item's full-screen preview; that item should still require its own reveal.

Narrow-screen follow-up: the reveal label wraps within the thumbnail instead of being clipped. The production mobile check now verifies both button bounds and text overflow, in addition to the reveal/navigation behavior.
