### PR TITLE
feat: export personal memos and attachments as a ZIP archive

### DIFF
--- a/server/router/fileserver/export.go
+++ b/server/router/fileserver/export.go
@@ -1,0 +1,300 @@
+package fileserver
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/labstack/echo/v5"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	storepb "github.com/usememos/memos/proto/gen/store"
+	"github.com/usememos/memos/store"
+)
+
+const exportReadme = `# Memos export
+
+Open index.md to browse your notes and their attached files offline.
+
+- memos/<id>-<uid>.md contains the original Markdown, unchanged.
+- attachments/<id>-<uid>/<filename> contains the original attachment bytes.
+- manifest.json (format version 1) records UTC timestamps, state, visibility,
+  pinning, tags, location, and the archive paths and original names of attachments.
+
+This is an export of your own readable memos, including archived memos and comments.
+Other users' notes, unlinked uploads, and notes you can no longer read are excluded.
+Markdown URLs are preserved as written; use index.md or the manifest to find local
+attachments. Legacy external attachments retain their URL in the manifest and
+are not downloaded. Only comment context within this export is recorded. This is
+not an instance backup or an import format. Changes made while an export is being prepared may be reflected
+in it; avoid editing during export when you need a consistent copy.
+`
+
+type memoExportManifest struct {
+	Version    int               `json:"version"`
+	ExportedAt time.Time         `json:"exportedAt"`
+	Memos      []memoExportEntry `json:"memos"`
+}
+
+type memoExportEntry struct {
+	UID         string                 `json:"uid"`
+	Path        string                 `json:"path"`
+	CreatedAt   time.Time              `json:"createdAt"`
+	UpdatedAt   time.Time              `json:"updatedAt"`
+	State       store.RowStatus        `json:"state"`
+	Visibility  store.Visibility       `json:"visibility"`
+	Comment     bool                   `json:"comment"`
+	ParentUID   string                 `json:"parentUid,omitempty"`
+	Pinned      bool                   `json:"pinned"`
+	Payload     json.RawMessage        `json:"payload"`
+	Attachments []memoExportAttachment `json:"attachments"`
+}
+
+type memoExportAttachment struct {
+	UID         string    `json:"uid"`
+	Path        string    `json:"path,omitempty"`
+	ExternalURL string    `json:"externalUrl,omitempty"`
+	Filename    string    `json:"filename"`
+	Type        string    `json:"type"`
+	Size        int64     `json:"size"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+func (s *FileServerService) serveMemoExport(c *echo.Context) error {
+	ctx := c.Request().Context()
+	c.Response().Header().Set(echo.HeaderCacheControl, privateAttachmentCacheControl)
+	setSecurityHeaders(c)
+	user, err := s.getCurrentUser(ctx, c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to authenticate export").Wrap(err)
+	}
+	if user == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
+	}
+	if !s.exportSemaphore.TryAcquire(1) {
+		c.Response().Header().Set("Retry-After", "30")
+		return echo.NewHTTPError(http.StatusTooManyRequests, "another export is in progress; try again shortly")
+	}
+	defer s.exportSemaphore.Release(1)
+
+	// Finish the ZIP before sending a successful response. A missing attachment
+	// must produce an error, not a plausible but incomplete backup. CreateTemp
+	// uses mode 0600, and every exit path removes the temporary archive.
+	archive, err := os.CreateTemp("", "memos-export-*.zip")
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to create export").Wrap(err)
+	}
+	defer func() {
+		archive.Close()
+		os.Remove(archive.Name())
+	}()
+	now := time.Now().UTC()
+	if err := s.writeMemoExport(ctx, archive, user.ID, now); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "could not export all memos and attachments; please try again").Wrap(err)
+	}
+	if _, err := archive.Seek(0, io.SeekStart); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to read export").Wrap(err)
+	}
+	info, err := archive.Stat()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to read export").Wrap(err)
+	}
+	c.Response().Header().Set(echo.HeaderContentDisposition, `attachment; filename="memos-export-`+now.Format("2006-01-02")+`.zip"`)
+	c.Response().Header().Set(echo.HeaderContentLength, fmt.Sprint(info.Size()))
+	return c.Stream(http.StatusOK, "application/zip", archive)
+}
+
+func (s *FileServerService) writeMemoExport(ctx context.Context, dst io.Writer, userID int32, now time.Time) error {
+	scope := &store.MemoAccessScope{UserID: &userID, AllowPublic: true, AllowProtected: true}
+	// Capture the IDs without loading every note's content or applying API page
+	// limits. Reload each memo with current access before exporting its content.
+	memos, err := s.Store.ListMemos(ctx, &store.FindMemo{CreatorID: &userID, Access: scope, ExcludeContent: true})
+	if err != nil {
+		return errors.Wrap(err, "list export memos")
+	}
+	exportedUIDs := make(map[string]bool, len(memos))
+	for _, memo := range memos {
+		exportedUIDs[memo.UID] = true
+	}
+	slices.SortFunc(memos, func(a, b *store.Memo) int { return strings.Compare(a.UID, b.UID) })
+	manifest := memoExportManifest{Version: 1, ExportedAt: now, Memos: make([]memoExportEntry, 0, len(memos))}
+	archive := zip.NewWriter(dst)
+	defer archive.Close()
+	var index strings.Builder
+	index.WriteString("# Exported memos\n\n")
+	for _, snapshot := range memos {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		memo, err := s.Store.GetMemo(ctx, &store.FindMemo{ID: &snapshot.ID, UID: &snapshot.UID, CreatorID: &userID, Access: scope})
+		if err != nil {
+			return errors.Wrap(err, "load export memo")
+		}
+		if memo == nil {
+			return errors.New("memo removed or access changed during export")
+		}
+		entry, err := s.exportMemo(ctx, archive, memo, scope)
+		if err != nil {
+			return err
+		}
+		entry.Comment = memo.ParentUID != nil
+		if memo.ParentUID != nil && exportedUIDs[*memo.ParentUID] {
+			entry.ParentUID = *memo.ParentUID
+		}
+		manifest.Memos = append(manifest.Memos, *entry)
+		fmt.Fprintf(&index, "## [%s](%s)\n\n%s · %s\n\n", entry.UID, entry.Path, entry.CreatedAt.Format(time.RFC3339), entry.State)
+		for _, attachment := range entry.Attachments {
+			if attachment.ExternalURL != "" {
+				fmt.Fprintf(&index, "- Attachment %s (external URL in manifest.json)\n", attachment.UID)
+				continue
+			}
+			// Display stable UIDs so user-provided filenames cannot inject Markdown.
+			fmt.Fprintf(&index, "- [Attachment %s](%s)\n", attachment.UID, (&url.URL{Path: attachment.Path}).EscapedPath())
+		}
+		index.WriteString("\n")
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return errors.Wrap(err, "encode export manifest")
+	}
+	for _, file := range []struct{ name, content string }{
+		{"README.md", exportReadme}, {"index.md", index.String()}, {"manifest.json", string(data) + "\n"},
+	} {
+		if err := writeExportFile(archive, file.name, now, strings.NewReader(file.content)); err != nil {
+			return err
+		}
+	}
+	return errors.Wrap(archive.Close(), "finish export archive")
+}
+
+func (s *FileServerService) exportMemo(ctx context.Context, archive *zip.Writer, memo *store.Memo, scope *store.MemoAccessScope) (*memoExportEntry, error) {
+	entry := &memoExportEntry{
+		UID: memo.UID, Path: fmt.Sprintf("memos/%d-%s.md", memo.ID, memo.UID),
+		CreatedAt: time.Unix(memo.CreatedTs, 0).UTC(), UpdatedAt: time.Unix(memo.UpdatedTs, 0).UTC(),
+		State: memo.RowStatus, Visibility: memo.Visibility, Pinned: memo.Pinned,
+		Payload: json.RawMessage("{}"), Attachments: []memoExportAttachment{},
+	}
+	if memo.Payload != nil {
+		payload, err := protojson.Marshal(memo.Payload)
+		if err != nil {
+			return nil, errors.Wrap(err, "encode memo metadata")
+		}
+		entry.Payload = payload
+	}
+	if err := writeExportFile(archive, entry.Path, entry.UpdatedAt, strings.NewReader(memo.Content)); err != nil {
+		return nil, err
+	}
+	attachments, err := s.Store.ListAttachments(ctx, &store.FindAttachment{MemoID: &memo.ID, Access: scope})
+	if err != nil {
+		return nil, errors.Wrap(err, "list export attachments")
+	}
+	slices.SortFunc(attachments, func(a, b *store.Attachment) int { return strings.Compare(a.UID, b.UID) })
+	for _, attachment := range attachments {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		// Load at most one database blob at a time, and recheck the binding and
+		// audience in case an attachment moved while the archive was being built.
+		attachment, err = s.Store.GetAttachment(ctx, &store.FindAttachment{
+			ID: &attachment.ID, MemoID: &memo.ID, Access: scope, GetBlob: true,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "load export attachment")
+		}
+		if attachment == nil {
+			return nil, errors.New("attachment removed or access changed during export")
+		}
+		attachmentEntry := memoExportAttachment{
+			UID: attachment.UID, Filename: attachment.Filename, Type: attachment.Type, Size: attachment.Size,
+			CreatedAt: time.Unix(attachment.CreatedTs, 0).UTC(), UpdatedAt: time.Unix(attachment.UpdatedTs, 0).UTC(),
+		}
+		if attachment.StorageType == storepb.AttachmentStorageType_EXTERNAL {
+			if attachment.Reference == "" {
+				return nil, errors.New("external attachment URL is missing")
+			}
+			attachmentEntry.ExternalURL = attachment.Reference
+		} else {
+			attachmentEntry.Path = fmt.Sprintf("attachments/%d-%s/%s", attachment.ID, attachment.UID, exportFilename(attachment.Filename))
+			if err := s.exportAttachment(ctx, archive, attachment, attachmentEntry.Path); err != nil {
+				return nil, err
+			}
+		}
+		entry.Attachments = append(entry.Attachments, attachmentEntry)
+	}
+	return entry, nil
+}
+
+func (s *FileServerService) exportAttachment(ctx context.Context, archive *zip.Writer, attachment *store.Attachment, path string) error {
+	reader, err := s.getAttachmentReader(ctx, attachment)
+	if err != nil {
+		return errors.Wrap(err, "open export attachment")
+	}
+	defer reader.Close()
+	if attachment.Size < 0 {
+		return errors.New("invalid attachment size")
+	}
+	counted := &exportReader{ctx: ctx, reader: reader}
+	if err := writeExportFile(archive, path, time.Unix(attachment.UpdatedTs, 0).UTC(), counted); err != nil {
+		return err
+	}
+	if counted.bytesRead != attachment.Size {
+		return errors.New("attachment size changed during export")
+	}
+	return nil
+}
+
+func writeExportFile(archive *zip.Writer, name string, modified time.Time, reader io.Reader) error {
+	header := &zip.FileHeader{Name: name, Method: zip.Deflate, Modified: modified}
+	header.SetMode(0o600)
+	writer, err := archive.CreateHeader(header)
+	if err != nil {
+		return errors.Wrap(err, "create export entry")
+	}
+	_, err = io.Copy(writer, reader)
+	return errors.Wrap(err, "write export entry")
+}
+
+// exportFilename produces a single portable path segment. Prefixing also avoids
+// Windows device names; the original filename is preserved in the manifest.
+func exportFilename(filename string) string {
+	name := strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || strings.ContainsRune("._-", r) {
+			return r
+		}
+		return '_'
+	}, filename)
+	if len(name) > 200 {
+		name = name[len(name)-200:]
+		for !utf8.RuneStart(name[0]) {
+			name = name[1:]
+		}
+	}
+	return "file-" + strings.TrimRight(name, ".")
+}
+
+type exportReader struct {
+	ctx       context.Context
+	reader    io.Reader
+	bytesRead int64
+}
+
+func (r *exportReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	n, err := r.reader.Read(p)
+	r.bytesRead += int64(n)
+	return n, err
+}

--- a/server/router/fileserver/export_test.go
+++ b/server/router/fileserver/export_test.go
@@ -1,0 +1,341 @@
+package fileserver
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/usememos/memos/internal/testutil/fakes3"
+	v1pb "github.com/usememos/memos/proto/gen/api/v1"
+	storepb "github.com/usememos/memos/proto/gen/store"
+	"github.com/usememos/memos/server/auth"
+	"github.com/usememos/memos/store"
+)
+
+func TestMemoExportArchive(t *testing.T) {
+	ctx := context.Background()
+	_, fs, stores, cleanup := newShareAttachmentTestServices(ctx, t)
+	defer cleanup()
+	user, err := stores.CreateUser(ctx, &store.User{Username: "exporter", Role: store.RoleUser})
+	require.NoError(t, err)
+	other, err := stores.CreateUser(ctx, &store.User{Username: "other", Role: store.RoleAdmin})
+	require.NoError(t, err)
+	created := time.Date(2020, 2, 3, 4, 5, 6, 0, time.UTC)
+	content := "# Original\r\n\r\n#旅行/nested\n![inline](/file/attachments/photo/image.png)\n```\nunchanged\n```"
+	memo, err := stores.CreateMemo(ctx, &store.Memo{
+		UID: "my-note", CreatorID: user.ID, Content: content, Visibility: store.Private,
+		CreatedTs: created.Unix(), UpdatedTs: created.Add(time.Hour).Unix(),
+		Payload: &storepb.MemoPayload{Tags: []string{"旅行/nested"}, Location: &storepb.MemoPayload_Location{
+			Placeholder: "Vienna", Latitude: 48.2, Longitude: 16.3,
+		}},
+	})
+	require.NoError(t, err)
+	archived := store.Archived
+	pinned := true
+	err = stores.UpdateMemo(ctx, &store.UpdateMemo{ID: memo.ID, RowStatus: &archived, Pinned: &pinned})
+	require.NoError(t, err)
+	for _, visibility := range []store.Visibility{store.Private, store.Public, store.Protected} {
+		_, err := stores.CreateMemo(ctx, &store.Memo{UID: "other-" + strings.ToLower(string(visibility)), CreatorID: other.ID, Content: "other-user-secret", Visibility: visibility})
+		require.NoError(t, err)
+	}
+	// More than the default attachment and API memo page sizes must survive.
+	for i := range 105 {
+		_, err := stores.CreateMemo(ctx, &store.Memo{UID: fmt.Sprintf("memo-%03d", i), CreatorID: user.ID, Content: fmt.Sprint(i), Visibility: store.Private})
+		require.NoError(t, err)
+	}
+	for i := range 12 {
+		_, err := stores.CreateAttachment(ctx, &store.Attachment{
+			UID: fmt.Sprintf("attachment-%02d", i), CreatorID: user.ID, MemoID: &memo.ID,
+			Filename: "../CON/照片 [same].txt", Type: "text/plain", Blob: []byte("database bytes"), Size: 14,
+			StorageType: storepb.AttachmentStorageType_ATTACHMENT_STORAGE_TYPE_UNSPECIFIED,
+		})
+		require.NoError(t, err)
+	}
+	_, err = stores.CreateAttachment(ctx, &store.Attachment{UID: "unlinked", CreatorID: user.ID, Filename: "unlinked-secret", Blob: []byte("unlinked bytes"), Size: 14})
+	require.NoError(t, err)
+
+	rec := requestMemoExport(t, fs, user)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.Equal(t, "private, no-store", rec.Header().Get("Cache-Control"))
+	require.Equal(t, "application/zip", rec.Header().Get("Content-Type"))
+	require.Contains(t, rec.Header().Get("Content-Disposition"), "attachment; filename=\"memos-export-")
+	require.Equal(t, fmt.Sprint(rec.Body.Len()), rec.Header().Get("Content-Length"))
+	files, manifest := readMemoExport(t, rec.Body.Bytes())
+	require.Len(t, manifest.Memos, 106)
+	require.Equal(t, content, files[fmt.Sprintf("memos/%d-my-note.md", memo.ID)])
+	var exported memoExportEntry
+	for _, item := range manifest.Memos {
+		if item.UID == memo.UID {
+			exported = item
+		}
+	}
+	require.Equal(t, created, exported.CreatedAt)
+	require.Equal(t, created.Add(time.Hour), exported.UpdatedAt)
+	require.Equal(t, store.Archived, exported.State)
+	require.Equal(t, store.Private, exported.Visibility)
+	require.True(t, exported.Pinned)
+	require.JSONEq(t, `{"tags":["旅行/nested"],"location":{"placeholder":"Vienna","latitude":48.2,"longitude":16.3}}`, string(exported.Payload))
+	require.Len(t, exported.Attachments, 12)
+	for _, attachment := range exported.Attachments {
+		require.Equal(t, "database bytes", files[attachment.Path])
+		require.Equal(t, "../CON/照片 [same].txt", attachment.Filename)
+		require.Contains(t, files["index.md"], attachment.UID)
+	}
+	for name, data := range files {
+		require.NotContains(t, name, "unlinked")
+		require.NotContains(t, data, "other-user-secret")
+		require.NotContains(t, data, "unlinked bytes")
+	}
+}
+
+func TestMemoExportLocalAndS3Attachments(t *testing.T) {
+	ctx := context.Background()
+	svc, fs, stores, cleanup := newShareAttachmentTestServices(ctx, t)
+	defer cleanup()
+	user, err := stores.CreateUser(ctx, &store.User{Username: "storage-exporter", Role: store.RoleUser})
+	require.NoError(t, err)
+	memo, err := stores.CreateMemo(ctx, &store.Memo{UID: "storage-note", CreatorID: user.ID, Content: "storage", Visibility: store.Private})
+	require.NoError(t, err)
+	binary := []byte{0, 255, 1, 254, 0, 128}
+	require.NoError(t, os.WriteFile(filepath.Join(fs.Profile.Data, "local.bin"), binary, 0o600))
+	_, err = stores.CreateAttachment(ctx, &store.Attachment{
+		UID: "local", CreatorID: user.ID, MemoID: &memo.ID, Filename: "same.bin", Type: "application/octet-stream",
+		Size: int64(len(binary)), StorageType: storepb.AttachmentStorageType_LOCAL, Reference: "local.bin",
+	})
+	require.NoError(t, err)
+	fake := fakes3.New(t, "export-attachments")
+	_, err = stores.UpsertInstanceSetting(ctx, &storepb.InstanceSetting{
+		Key: storepb.InstanceSettingKey_STORAGE,
+		Value: &storepb.InstanceSetting_StorageSetting{StorageSetting: &storepb.InstanceStorageSetting{
+			FilepathTemplate: "files/{uuid}_{filename}", UploadSizeLimitMb: 30,
+			Storages: []*storepb.Storage{{Id: "export-s3", Name: "Export S3", Type: storepb.StorageType_STORAGE_TYPE_S3,
+				Config: &storepb.Storage_S3Config{S3Config: fake.Config("export-attachments")}}},
+			DefaultStorageId: "export-s3",
+		}},
+	})
+	require.NoError(t, err)
+	creatorCtx := context.WithValue(ctx, auth.UserIDContextKey, user.ID)
+	_, err = svc.CreateAttachment(creatorCtx, &v1pb.CreateAttachmentRequest{Attachment: &v1pb.Attachment{
+		Filename: "same.bin", Type: "application/octet-stream", Content: binary, Memo: ptr("memos/" + memo.UID),
+	}})
+	require.NoError(t, err)
+	rec := requestMemoExport(t, fs, user)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	files, manifest := readMemoExport(t, rec.Body.Bytes())
+	require.Len(t, manifest.Memos[0].Attachments, 2)
+	for _, attachment := range manifest.Memos[0].Attachments {
+		require.Equal(t, binary, []byte(files[attachment.Path]))
+	}
+	require.NotContains(t, files["manifest.json"], "s3Config")
+	require.NotContains(t, files["manifest.json"], "accessKey")
+}
+
+func TestMemoExportCommentsExternalLinksAndCaseCollisions(t *testing.T) {
+	ctx := context.Background()
+	_, fs, stores, cleanup := newShareAttachmentTestServices(ctx, t)
+	defer cleanup()
+	user, err := stores.CreateUser(ctx, &store.User{Username: "export-comments", Role: store.RoleAdmin})
+	require.NoError(t, err)
+	other, err := stores.CreateUser(ctx, &store.User{Username: "other-comments", Role: store.RoleUser})
+	require.NoError(t, err)
+	parent, err := stores.CreateMemo(ctx, &store.Memo{UID: "Parent", CreatorID: user.ID, Content: "parent", Visibility: store.Private})
+	require.NoError(t, err)
+	_, err = stores.CreateMemo(ctx, &store.Memo{UID: "parent", CreatorID: user.ID, Content: "case-sensitive UID", Visibility: store.Private})
+	require.NoError(t, err)
+	foreign, err := stores.CreateMemo(ctx, &store.Memo{UID: "foreign-parent", CreatorID: other.ID, Content: "public context", Visibility: store.Public})
+	require.NoError(t, err)
+	for _, contextMemo := range []*store.Memo{parent, foreign} {
+		_, err = stores.CreateMemoComment(ctx, &store.Memo{UID: "reply-" + contextMemo.UID, CreatorID: user.ID, Content: "own comment", Visibility: store.Private}, contextMemo.ID, user.ID)
+		require.NoError(t, err)
+	}
+	_, err = stores.CreateAttachment(ctx, &store.Attachment{UID: "external-link", CreatorID: user.ID, MemoID: &parent.ID, Filename: "remote.pdf", Type: "application/pdf", StorageType: storepb.AttachmentStorageType_EXTERNAL, Reference: "https://example.invalid/original.pdf"})
+	require.NoError(t, err)
+	rec := requestMemoExport(t, fs, user)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	files, manifest := readMemoExport(t, rec.Body.Bytes())
+	require.Len(t, manifest.Memos, 4)
+	byUID := map[string]memoExportEntry{}
+	for _, memo := range manifest.Memos {
+		byUID[memo.UID] = memo
+	}
+	require.True(t, byUID["reply-Parent"].Comment)
+	require.Equal(t, "Parent", byUID["reply-Parent"].ParentUID)
+	require.True(t, byUID["reply-foreign-parent"].Comment)
+	require.Empty(t, byUID["reply-foreign-parent"].ParentUID, "only exported parents may be identified")
+	require.NotContains(t, byUID, "foreign-parent", "instance admin must not export other authors' memos")
+	attachment := byUID["Parent"].Attachments[0]
+	require.Equal(t, "https://example.invalid/original.pdf", attachment.ExternalURL)
+	require.Empty(t, attachment.Path, "external URLs must not become empty local files")
+	require.NotContains(t, files, "attachments/external-link/remote.pdf")
+	lowerPaths := map[string]bool{}
+	for name := range files {
+		require.False(t, lowerPaths[strings.ToLower(name)], "paths must also be unique on case-insensitive filesystems")
+		lowerPaths[strings.ToLower(name)] = true
+	}
+}
+
+func TestMemoExportAuthentication(t *testing.T) {
+	ctx := context.Background()
+	_, fs, stores, cleanup := newShareAttachmentTestServices(ctx, t)
+	defer cleanup()
+	user, err := stores.CreateUser(ctx, &store.User{Username: "export-auth", Role: store.RoleUser})
+	require.NoError(t, err)
+	e := echo.New()
+	fs.RegisterRoutes(e)
+	for _, header := range []string{"", "Bearer invalid"} {
+		req := httptest.NewRequest(http.MethodGet, "/file/memos/export?user_id=1&share_token=anything", nil)
+		req.Header.Set("Authorization", header)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
+		require.Equal(t, "private, no-store", rec.Header().Get("Cache-Control"))
+	}
+	// A valid browser refresh cookie is sufficient; no token belongs in the URL.
+	tokenID := "export-refresh"
+	token, expires, err := auth.GenerateRefreshToken(user.ID, tokenID, []byte("test-secret"))
+	require.NoError(t, err)
+	require.NoError(t, stores.AddUserRefreshToken(ctx, user.ID, &storepb.RefreshTokensUserSetting_RefreshToken{TokenId: tokenID, ExpiresAt: timestamppb.New(expires)}))
+	req := httptest.NewRequest(http.MethodGet, "/file/memos/export", nil)
+	req.AddCookie(&http.Cookie{Name: auth.RefreshTokenCookieName, Value: token})
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	_, manifest := readMemoExport(t, rec.Body.Bytes())
+	require.Empty(t, manifest.Memos)
+}
+
+func TestMemoExportFailureAndConcurrency(t *testing.T) {
+	ctx := context.Background()
+	_, fs, stores, cleanup := newShareAttachmentTestServices(ctx, t)
+	defer cleanup()
+	user, err := stores.CreateUser(ctx, &store.User{Username: "export-errors", Role: store.RoleUser})
+	require.NoError(t, err)
+	memo, err := stores.CreateMemo(ctx, &store.Memo{UID: "missing-file", CreatorID: user.ID, Content: "note", Visibility: store.Private})
+	require.NoError(t, err)
+	_, err = stores.CreateAttachment(ctx, &store.Attachment{UID: "missing", CreatorID: user.ID, MemoID: &memo.ID, Filename: "missing", Reference: "does-not-exist", StorageType: storepb.AttachmentStorageType_LOCAL})
+	require.NoError(t, err)
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+	rec := requestMemoExport(t, fs, user)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.NotContains(t, rec.Header().Get("Content-Type"), "zip")
+	require.Empty(t, rec.Header().Get("Content-Disposition"))
+	entries, err := os.ReadDir(tmp)
+	require.NoError(t, err)
+	require.Empty(t, entries, "failed exports must remove temporary archives")
+	// A readable but truncated file is also an incomplete export, not success.
+	require.NoError(t, os.WriteFile(filepath.Join(fs.Profile.Data, "does-not-exist"), []byte("unexpected bytes"), 0o600))
+	rec = requestMemoExport(t, fs, user)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	// Repairing the attachment must allow the next attempt to complete.
+	require.NoError(t, os.WriteFile(filepath.Join(fs.Profile.Data, "does-not-exist"), nil, 0o600))
+	rec = requestMemoExport(t, fs, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	entries, err = os.ReadDir(tmp)
+	require.NoError(t, err)
+	require.Empty(t, entries, "successful exports must also remove temporary archives")
+	require.True(t, fs.exportSemaphore.TryAcquire(1), "failure must release the export slot")
+	rec = requestMemoExport(t, fs, user)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Equal(t, "30", rec.Header().Get("Retry-After"))
+	fs.exportSemaphore.Release(1)
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	require.Error(t, fs.writeMemoExport(canceled, io.Discard, user.ID, time.Now()))
+	reader := &exportReader{ctx: canceled, reader: strings.NewReader("bytes")}
+	_, err = reader.Read(make([]byte, 5))
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestMemoExportSpaceMembership(t *testing.T) {
+	ctx := context.Background()
+	_, fs, stores, cleanup := newShareAttachmentTestServices(ctx, t)
+	defer cleanup()
+	user, err := stores.CreateUser(ctx, &store.User{Username: "export-member", Role: store.RoleUser})
+	require.NoError(t, err)
+	admin, err := stores.CreateUser(ctx, &store.User{Username: "space-admin", Role: store.RoleUser})
+	require.NoError(t, err)
+	space, err := stores.CreateSpace(ctx, &store.Space{UID: "export-space", Title: "Space"}, admin.ID)
+	require.NoError(t, err)
+	_, err = stores.CreateSpaceInvitation(ctx, &store.SpaceInvitation{SpaceID: space.ID, UserID: user.ID, Role: store.SpaceMemberRoleUser}, admin.ID)
+	require.NoError(t, err)
+	_, err = stores.AcceptSpaceInvitation(ctx, &store.AcceptSpaceInvitation{SpaceID: space.ID, UserID: user.ID}, user.ID)
+	require.NoError(t, err)
+	_, err = stores.CreateMemo(ctx, &store.Memo{UID: "space-note", CreatorID: user.ID, Content: "space secret", Visibility: store.SpaceAudience, SpaceID: &space.ID})
+	require.NoError(t, err)
+	rec := requestMemoExport(t, fs, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	_, manifest := readMemoExport(t, rec.Body.Bytes())
+	require.Len(t, manifest.Memos, 1)
+	require.NoError(t, stores.DeleteSpaceMember(ctx, &store.DeleteSpaceMember{SpaceID: space.ID, UserID: user.ID}, admin.ID))
+	rec = requestMemoExport(t, fs, user)
+	require.Equal(t, http.StatusOK, rec.Code)
+	files, manifest := readMemoExport(t, rec.Body.Bytes())
+	require.Empty(t, manifest.Memos)
+	require.Len(t, files, 3)
+}
+
+func TestExportFilename(t *testing.T) {
+	for _, filename := range []string{"", ".", "..", "../../escape", `C:\\..\\escape`, "CON", "NUL.txt", "photo.png.", "名字.jpg", "bad\x00\r\nname", strings.Repeat("z", 500), strings.Repeat("名", 150)} {
+		name := exportFilename(filename)
+		require.Equal(t, path.Base(name), name)
+		require.NotContains(t, name, `\`)
+		require.NotContains(t, name, "\x00")
+		require.False(t, strings.HasSuffix(name, "."))
+		require.LessOrEqual(t, len(name), 205)
+		require.True(t, strings.HasPrefix(name, "file-"))
+	}
+}
+
+func requestMemoExport(t *testing.T, fs *FileServerService, user *store.User) *httptest.ResponseRecorder {
+	t.Helper()
+	token, _, err := auth.GenerateAccessTokenV2(user.ID, user.Username, string(user.Role), string(user.RowStatus), []byte("test-secret"))
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodGet, "/file/memos/export", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	e := echo.New()
+	fs.RegisterRoutes(e)
+	e.ServeHTTP(rec, req)
+	return rec
+}
+
+func readMemoExport(t *testing.T, data []byte) (map[string]string, memoExportManifest) {
+	t.Helper()
+	archive, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	files := map[string]string{}
+	for _, file := range archive.File {
+		require.True(t, filepath.IsLocal(file.Name), file.Name)
+		require.Equal(t, path.Clean(file.Name), file.Name)
+		require.Equal(t, os.FileMode(0o600), file.Mode().Perm())
+		require.NotContains(t, files, file.Name, "duplicate archive entry")
+		reader, err := file.Open()
+		require.NoError(t, err)
+		content, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		require.NoError(t, reader.Close())
+		files[file.Name] = string(content)
+	}
+	var manifest memoExportManifest
+	require.NoError(t, json.Unmarshal([]byte(files["manifest.json"]), &manifest))
+	require.Equal(t, 1, manifest.Version)
+	return files, manifest
+}
+
+func ptr[T any](value T) *T { return &value }

--- a/server/router/fileserver/fileserver.go
+++ b/server/router/fileserver/fileserver.go
@@ -100,6 +100,8 @@ type FileServerService struct {
 
 	// thumbnailSemaphore limits concurrent thumbnail generation.
 	thumbnailSemaphore *semaphore.Weighted
+	// exportSemaphore bounds temporary disk usage to one archive at a time.
+	exportSemaphore *semaphore.Weighted
 }
 
 // NewFileServerService creates a new file server service.
@@ -109,6 +111,7 @@ func NewFileServerService(profile *profile.Profile, store *store.Store, secret s
 		Store:              store,
 		authenticator:      auth.NewAuthenticator(store, secret),
 		thumbnailSemaphore: semaphore.NewWeighted(maxConcurrentThumbnails),
+		exportSemaphore:    semaphore.NewWeighted(1),
 	}
 }
 
@@ -118,6 +121,7 @@ func (s *FileServerService) RegisterRoutes(echoServer *echo.Echo) {
 	fileGroup.GET("/attachments/:uid", s.serveAttachmentFile)
 	fileGroup.GET("/attachments/:uid/:filename", s.serveAttachmentFile)
 	fileGroup.GET("/users/:identifier/avatar", s.serveUserAvatar)
+	fileGroup.GET("/memos/export", s.serveMemoExport)
 }
 
 // =============================================================================

--- a/web/src/components/Settings/ExportMemosSection.tsx
+++ b/web/src/components/Settings/ExportMemosSection.tsx
@@ -1,0 +1,68 @@
+import { DownloadIcon, LoaderIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import { Button } from "@/components/ui/button";
+import { getRequestToken } from "@/connect";
+import { useTranslate } from "@/utils/i18n";
+import SettingGroup from "./SettingGroup";
+
+const ExportMemosSection = () => {
+  const t = useTranslate();
+  const [exporting, setExporting] = useState(false);
+  const pending = useRef<AbortController | null>(null);
+
+  useEffect(() => () => pending.current?.abort(), []);
+
+  const exportMemos = async () => {
+    if (pending.current) return;
+    const controller = new AbortController();
+    pending.current = controller;
+    setExporting(true);
+    try {
+      const token = await getRequestToken();
+      if (controller.signal.aborted) return;
+      const response = await fetch("/file/memos/export", {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+        credentials: "same-origin",
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(t(response.status === 429 ? "setting.account.export-busy" : "setting.account.export-failed"));
+      }
+      const blob = await response.blob();
+      if (controller.signal.aborted) return;
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `memos-export-${new Date().toISOString().slice(0, 10)}.zip`;
+      try {
+        document.body.appendChild(link);
+        link.click();
+      } finally {
+        link.remove();
+        // Give the browser time to start consuming the download before revoking it.
+        window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
+      }
+    } catch (error) {
+      if (!controller.signal.aborted) {
+        toast.error(error instanceof Error ? error.message : t("setting.account.export-failed"));
+      }
+    } finally {
+      pending.current = null;
+      if (!controller.signal.aborted) setExporting(false);
+    }
+  };
+
+  return (
+    <SettingGroup showSeparator title={t("setting.account.export-memos")} description={t("setting.account.export-description")}>
+      <div>
+        <Button variant="outline" size="sm" disabled={exporting} onClick={exportMemos}>
+          {exporting ? <LoaderIcon className="w-4 h-4 mr-1.5 animate-spin" /> : <DownloadIcon className="w-4 h-4 mr-1.5" />}
+          {t(exporting ? "setting.account.export-preparing" : "setting.account.export-download")}
+        </Button>
+      </div>
+    </SettingGroup>
+  );
+};
+
+export default ExportMemosSection;

--- a/web/src/components/Settings/MyAccountSection.tsx
+++ b/web/src/components/Settings/MyAccountSection.tsx
@@ -14,6 +14,7 @@ import { useTranslate } from "@/utils/i18n";
 import ChangeMemberPasswordDialog from "../ChangeMemberPasswordDialog";
 import UpdateAccountDialog from "../UpdateAccountDialog";
 import UserAvatar from "../UserAvatar";
+import ExportMemosSection from "./ExportMemosSection";
 import LinkedIdentitySection from "./LinkedIdentitySection";
 import SettingGroup from "./SettingGroup";
 import SettingSection from "./SettingSection";
@@ -68,6 +69,8 @@ const MyAccountSection = () => {
       </SettingGroup>
 
       <LinkedIdentitySection />
+
+      <ExportMemosSection />
 
       <SettingGroup showSeparator title={t("setting.account.danger-area")} description={t("setting.account.danger-area-description")}>
         <div className="flex flex-col gap-3 rounded-xl border border-destructive/30 bg-destructive/5 p-4">

--- a/web/src/locales/az.json
+++ b/web/src/locales/az.json
@@ -614,6 +614,11 @@
       "web-clipper-title": "Memos Web Clipper ilə tokendən istifadə"
     },
     "account": {
+      "export-description": "Arxivləşdirilmiş qeydlər və şərhlər daxil olmaqla, oxuya bildiyiniz memolarınızı orijinal Markdown, metadata və əlavə edilmiş fayllarla birlikdə ZIP arxivi kimi yükləyin. Heç bir memoya bağlı olmayan fayllar və digər istifadəçilərin memoları daxil edilmir.",
+      "export-download": "ZIP yüklə",
+      "export-preparing": "İxrac hazırlanır…",
+      "export-busy": "Başqa bir ixrac davam edir. Bir az sonra yenidən cəhd edin.",
+      "export-failed": "Bütün memoları və əlavələri ixrac etmək mümkün olmadı. Yenidən cəhd edin.",
       "change-password": "Parolu dəyiş",
       "danger-area": "Təhlükəli sahə",
       "danger-area-description": "Geri qaytarıla bilməyən hesab əməliyyatları buradadır. Davam etməzdən əvvəl onları diqqətlə nəzərdən keçirin.",

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -614,6 +614,11 @@
       "web-clipper-title": "Use a token with Memos Web Clipper"
     },
     "account": {
+      "export-description": "Download a ZIP of your readable memos, including archived notes and comments, with original Markdown, metadata, and attached files. Unlinked uploads and other users' memos are excluded.",
+      "export-download": "Download ZIP",
+      "export-preparing": "Preparing export…",
+      "export-busy": "Another export is in progress. Please try again shortly.",
+      "export-failed": "Could not export all memos and attachments. Please try again.",
       "change-password": "Change password",
       "danger-area": "Danger area",
       "danger-area-description": "Irreversible account actions live here. Review them carefully before continuing.",

--- a/web/tests/export-memos-section.test.tsx
+++ b/web/tests/export-memos-section.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ExportMemosSection from "@/components/Settings/ExportMemosSection";
+
+const mocks = vi.hoisted(() => ({ getRequestToken: vi.fn(), toastError: vi.fn() }));
+vi.mock("@/connect", () => ({ getRequestToken: mocks.getRequestToken }));
+vi.mock("react-hot-toast", () => ({ default: { error: mocks.toastError } }));
+vi.mock("@/utils/i18n", () => ({ useTranslate: () => (key: string) => key }));
+
+const fetchMock = vi.fn();
+const createObjectURL = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getRequestToken.mockResolvedValue("fresh-token");
+  vi.stubGlobal("fetch", fetchMock);
+  Object.defineProperty(URL, "createObjectURL", { configurable: true, value: createObjectURL });
+  Object.defineProperty(URL, "revokeObjectURL", { configurable: true, value: vi.fn() });
+  createObjectURL.mockReturnValue("blob:export");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("memo export", () => {
+  it("downloads the complete ZIP using refreshed credentials and blocks duplicate requests", async () => {
+    let complete!: (response: Response) => void;
+    fetchMock.mockReturnValue(
+      new Promise<Response>((resolve) => {
+        complete = resolve;
+      }),
+    );
+    const downloaded: HTMLAnchorElement[] = [];
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (this: HTMLAnchorElement) {
+      downloaded.push(this);
+    });
+    const { unmount } = render(<ExportMemosSection />);
+    fireEvent.click(screen.getByRole("button", { name: "setting.account.export-download" }));
+    expect(screen.getByRole("button", { name: "setting.account.export-preparing" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    expect(fetchMock.mock.calls[0][0]).toBe("/file/memos/export");
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ headers: { Authorization: "Bearer fresh-token" }, credentials: "same-origin" });
+    expect(createObjectURL).not.toHaveBeenCalled();
+    const blob = new Blob(["zip bytes"], { type: "application/zip" });
+    complete({ ok: true, blob: async () => blob } as Response);
+    await waitFor(() => expect(downloaded).toHaveLength(1));
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+    expect(downloaded[0].download).toMatch(/^memos-export-\d{4}-\d{2}-\d{2}\.zip$/);
+    expect(downloaded[0].isConnected).toBe(false);
+    expect(screen.getByRole("button")).toBeEnabled();
+    unmount();
+  });
+
+  it.each([500, 401, 429])("shows an error instead of downloading an HTTP %s response", async (status) => {
+    fetchMock.mockResolvedValue({ ok: false, status });
+    render(<ExportMemosSection />);
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(status === 429 ? "setting.account.export-busy" : "setting.account.export-failed"),
+    );
+    expect(createObjectURL).not.toHaveBeenCalled();
+    expect(screen.getByRole("button")).toBeEnabled();
+  });
+
+  it("aborts work when leaving account settings", async () => {
+    fetchMock.mockImplementation(
+      (_url, options: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          options.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+        }),
+    );
+    const { unmount } = render(<ExportMemosSection />);
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    unmount();
+    expect(fetchMock.mock.calls[0][1].signal.aborted).toBe(true);
+    expect(createObjectURL).not.toHaveBeenCalled();
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds **My Account → Export Memos → Download ZIP**, so a user can keep a local copy of their notes and attached files without querying each API page or copying server storage.

The archive contains original, unchanged Markdown, a versioned JSON manifest with timestamps/state/visibility/pinning/tags/location and attachment metadata, and an offline Markdown index linking to the exported files. It includes the caller's readable archived notes and comments. Database, local-file, and S3 attachment bytes are included; legacy external attachments retain their URLs in the manifest.

This follows the one-shot export direction discussed with @clnhlzmn in #5998. Refs #6309 for the bulk-export portion; import and single-memo export remain separate work.

### Implementation

- An authenticated native HTTP download route reuses the existing file-server authenticator and S3 resolution. Creator filtering and the store's memo access predicate apply together, including current Space membership. Share tokens and administrator status do not expand the export.
- The server finishes a private temporary ZIP before responding. Missing, unreadable, or size-mismatched attachments fail the request. Cancellation and all exit paths clean up the temporary file; one concurrent export is allowed per server process.
- Note content and attachment blobs are loaded one at a time. Archive paths handle traversal characters, Windows device names, long Unicode filenames, and case-insensitive filesystem collisions; original names remain in the manifest.
- The UI refreshes credentials, disables duplicate submissions, reports failures, and aborts the request when leaving settings.

### Scope

Markdown URLs are preserved verbatim. The offline index and manifest locate exported attachments; external URLs are not fetched. Other users' notes and unlinked uploads are excluded, and comment parent IDs are recorded only when the parent is also exported. This is a user export, not a transactional instance backup or an import format. Server temporary storage and the browser's completed download must accommodate the archive.

### Validation

- `pnpm lint`, `pnpm test`: **1,373 tests passed**, and `pnpm build` passed.
- `golangci-lint v2.13.1 run` passed; `go mod tidy -go=1.27.0` leaves both module files unchanged.
- `go test -v -race ./server/...` found one pre-existing failure: `TestDetectAttachmentMimeType/unknown_extension_falls_back_to_content_sniffing` expects `.xyz` to be unknown, but this macOS installation resolves it to `chemical/x-xyz`. The same test fails identically in an untouched worktree at `7330627`.
- The full server race suite passes with only that subtest excluded using `-skip '^TestDetectAttachmentMimeType$/^unknown_extension_falls_back_to_content_sniffing$'`. The two optional MinIO container tests are skipped by the local environment; the fake-S3 HTTP integration tests run.
- New tests cover archive content and metadata, more than a page of notes/attachments, ownership and Space access, browser-cookie and bearer authentication, comments, external URLs, filename collisions, failed exports, cleanup, cancellation, and concurrent requests. UI tests cover downloads, duplicate clicks, HTTP errors, and aborting on unmount.
- Inspected account settings in the browser. A live local server export was downloaded over HTTP and checked for note content, attachment bytes, manifest, and ZIP CRCs.
